### PR TITLE
Introduce `guard` syntax

### DIFF
--- a/src/napkin_diagnostics.ml
+++ b/src/napkin_diagnostics.ml
@@ -95,6 +95,8 @@ let explain t =
         begin match breadcrumbs, t with
         | (ExprBlock, _) :: _, Rbrace ->
           "It seems that this expression block is empty"
+        | (ExprBlock, _) :: _, Eof ->
+          "It seems that this expression block is incomplete"
         | (ExprBlock, _) :: _, Bar -> (* Pattern matching *)
           "Looks like there might be an expression missing here"
         | (ExprSetField, _) :: _, _ ->

--- a/src/napkin_grammar.ml
+++ b/src/napkin_grammar.ml
@@ -17,6 +17,7 @@ type t =
   | ExprArrayAccess
   | ExprArrayMutation
   | ExprIf
+  | ExprGuard
   | IfCondition | IfBranch | ElseBranch
   | TypeExpression
   | External
@@ -69,6 +70,7 @@ let toString = function
   | ExprUnary -> "a unary expression"
   | ExprBinaryAfterOp op -> "an expression after the operator \"" ^ Token.toString op  ^ "\""
   | ExprIf -> "an if expression"
+  | ExprGuard -> "a guard expression"
   | IfCondition -> "the condition of an if expression"
   | IfBranch -> "the true-branch of an if expression"
   | ElseBranch -> "the else-branch of an if expression"
@@ -169,7 +171,7 @@ let isExprStart = function
   | LessThan
   | Minus | MinusDot | Plus | PlusDot | Bang
   | Percent | At
-  | If | Switch | While | For | Assert | Lazy | Try -> true
+  | If | Guard | Switch | While | For | Assert | Lazy | Try -> true
   | _ -> false
 
 let isJsxAttributeStart = function
@@ -300,7 +302,7 @@ let isBlockExprStart = function
   | Token.At | Hash | Percent | Minus | MinusDot | Plus | PlusDot | Bang
   | True | False | Float _ | Int _ | String _ | Character _ | Lident _ | Uident _
   | Lparen | List | Lbracket | Lbrace | Forwardslash | Assert
-  | Lazy | If | For | While | Switch | Open | Module | Exception | Let
+  | Lazy | If | Guard | For | While | Switch | Open | Module | Exception | Let
   | LessThan | Backtick | Try | Underscore -> true
   | _ -> false
 

--- a/src/napkin_parsetree_viewer.ml
+++ b/src/napkin_parsetree_viewer.ml
@@ -153,7 +153,7 @@ let processBracesAttr expr =
 let filterParsingAttrs attrs =
   List.filter (fun attr ->
     match attr with
-    | ({Location.txt = ("ns.ternary" | "ns.braces" | "bs" | "ns.iflet" | "ns.namedArgLoc")}, _) -> false
+    | ({Location.txt = ("ns.ternary" | "ns.braces" | "bs" | "ns.iflet" | "ns.guard" | "ns.namedArgLoc")}, _) -> false
     | _ -> true
   ) attrs
 
@@ -268,9 +268,22 @@ let isIfLetExpr expr = match expr with
     } when hasIfLetAttribute attrs -> true
   | _ -> false
 
+let rec hasGuardAttribute attrs =
+  match attrs with
+  | [] -> false
+  | ({Location.txt="ns.guard"},_)::_ -> true
+  | _::attrs -> hasGuardAttribute attrs
+
+let isGuardExpr expr = match expr with
+  | {
+      pexp_attributes = attrs;
+      pexp_desc = Pexp_match _ | Pexp_ifthenelse _
+    } when hasGuardAttribute attrs -> true
+  | _ -> false
+
 let hasAttributes attrs =
   List.exists (fun attr -> match attr with
-    | ({Location.txt = "bs" | "ns.ternary" | "ns.braces" | "ns.iflet"}, _) -> false
+    | ({Location.txt = "bs" | "ns.ternary" | "ns.braces" | "ns.iflet" | "ns.guard"}, _) -> false
     (* Remove the fragile pattern warning for iflet expressions *)
     | ({Location.txt="warning"}, PStr [{
       pstr_desc = Pstr_eval ({
@@ -426,13 +439,13 @@ let shouldInlineRhsBinaryExpr rhs = match rhs.pexp_desc with
 
 let filterPrinteableAttributes attrs =
   List.filter (fun attr -> match attr with
-    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet"}, _) -> false
+    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet" | "ns.guard"}, _) -> false
     | _ -> true
   ) attrs
 
 let partitionPrinteableAttributes attrs =
   List.partition (fun attr -> match attr with
-    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet"}, _) -> false
+    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet" | "ns.guard"}, _) -> false
     | _ -> true
   ) attrs
 

--- a/src/napkin_parsetree_viewer.mli
+++ b/src/napkin_parsetree_viewer.mli
@@ -67,6 +67,7 @@ val hasAttributes: Parsetree.attributes -> bool
 val isArrayAccess: Parsetree.expression -> bool
 val isTernaryExpr: Parsetree.expression -> bool
 val isIfLetExpr: Parsetree.expression -> bool
+val isGuardExpr: Parsetree.expression -> bool
 
 val collectTernaryParts: Parsetree.expression -> ((Parsetree.expression * Parsetree.expression) list * Parsetree.expression)
 

--- a/src/napkin_token.ml
+++ b/src/napkin_token.ml
@@ -46,7 +46,7 @@ type t =
   | Lazy
   | Tilde
   | Question
-  | If | Else | For | In | To | Downto | While | Switch
+  | If | Else | For | In | To | Downto | While | Switch | Guard
   | When
   | EqualGreater | MinusGreater
   | External
@@ -130,6 +130,7 @@ let toString = function
   | Tilde -> "tilde"
   | Question -> "?"
   | If -> "if"
+  | Guard -> "guard"
   | Else -> "else"
   | For -> "for"
   | In -> "in"
@@ -177,6 +178,7 @@ let keywordTable = function
 | "assert" -> Assert
 | "lazy" -> Lazy
 | "if" -> If
+| "guard" -> Guard
 | "else" -> Else
 | "for" -> For
 | "in" -> In
@@ -204,7 +206,7 @@ let keywordTable = function
 
 let isKeyword = function
   | True | False | Open | Let | Rec | And | As
-  | Exception | Assert | Lazy | If | Else | For | In | To
+  | Exception | Assert | Lazy | If | Guard | Else | For | In | To
   | Downto | While | Switch | When | External | Typ | Private
   | Mutable | Constraint | Include | Module | Of
   | Land | Lor | List | With

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -261,6 +261,41 @@ Missing expression
 ========================================================"
 `;
 
+exports[`guard.js 1`] = `
+"=====Parsetree==========================================
+;;((if a
+    then (((if c then [%napkinscript.exprhole ] else ()))[@ns.guard ])
+    else ((if b then [%napkinscript.exprhole ] else ())[@ns.guard ]))
+  [@ns.guard ])
+=====Errors=============================================
+
+File \\"/syntax/tests/parsing/errors/expressions/guard.js\\", line 4, characters 5-32:
+
+
+2 │      guard b else {
+3 │          ()
+[31m4[0m │      }
+5 │      // }, missing a body
+6 │  }
+
+It seems that this expression block is empty
+
+
+File \\"/syntax/tests/parsing/errors/expressions/guard.js\\", line 10, characters 1-25:
+
+
+8 │  guard c else {
+9 │      ()
+[31m10[0m │  }
+11 │  // eof, missing a body
+
+It seems that this expression block is incomplete
+
+
+
+========================================================"
+`;
+
 exports[`if.js 1`] = `
 "=====Parsetree==========================================
 ;;if match then let a = 1 in a + 1

--- a/tests/parsing/errors/expressions/guard.js
+++ b/tests/parsing/errors/expressions/guard.js
@@ -1,0 +1,11 @@
+guard a else {
+    guard b else {
+        ()
+    }
+    // }, missing a body
+}
+
+guard c else {
+    ()
+}
+// eof, missing a body

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -486,6 +486,90 @@ exports[`for.js 1`] = `
 ;;for p = 0 to x + 1 do () done"
 `;
 
+exports[`guard.js 1`] = `
+"let safeDivideZero num denom = ((if denom != 0 then num / denom else 0)
+  [@ns.braces ][@ns.guard ])
+let safeDivideNone num denom =
+  ((if denom != 0 then Some (num / denom) else None)
+  [@ns.braces ][@ns.guard ])
+let safeDivideExn num denom =
+  ((if denom != 0 then num / denom else raise DivisionByZero)
+  [@ns.braces ][@ns.guard ])
+let nested x y z =
+  ((if x
+    then
+      (((if y
+         then (((if z then Js.log \\"Hello\\" else raise BadZ))[@ns.guard ])
+         else raise BadY))
+      [@ns.guard ])
+    else raise BadX)
+  [@ns.braces ][@ns.guard ])
+let returningUnit shouldLog = ((if shouldLog then Js.log \\"Hello\\")
+  [@ns.braces ][@ns.guard ])
+let nested x y z =
+  ((if x
+    then Js.log \\"Hello\\"
+    else
+      ((if y
+        then raise BadX
+        else ((if z then raise BadY else raise BadZ)[@ns.guard ]))
+      [@ns.guard ]))
+  [@ns.braces ][@ns.guard ])
+let isValid width height color status =
+  ((if ((let size = width * height in size < 100)[@ns.braces ])
+    then (((if color != Red then true else false))[@ns.guard ])
+    else false)
+  [@ns.braces ][@ns.guard ])
+let guardlet () =
+  ((match foo () with
+    | Some x ->
+        (doSomethingWithX x;
+         (((match foo () with
+            | Some x ->
+                (((match foo () with
+                   | Some x -> doSomethingWithX x
+                   | _ -> raise FailedToUnwrap))
+                [@ns.guard ])
+            | _ -> raise FailedToUnwrap))
+         [@ns.guard ]))
+    | _ -> \\"return\\")
+  [@ns.braces ][@ns.guard ])
+;;((if
+      ((let one = (x > 10) && (n > 2) in let two = \\"test\\" in (one + 2) + two)
+      [@ns.braces ])
+    then
+      (\\"hello\\";
+       ((if x > 10
+         then
+           (\\"hello\\";
+            (let foo x = ((if x > 10 then Js.log x else \\"\\")
+               [@ns.braces ][@ns.guard ]) in
+             ((if x > 10
+               then
+                 (Js.log x;
+                  (let bar a b c =
+                     ((if a > 10
+                       then (((if c > 2 then \\"hello\\"))[@ns.guard ])
+                       else
+                         (\\"test\\"; ((if b > 20 then \\"ok\\" else c)[@ns.guard ])))
+                     [@ns.braces ][@ns.guard ]) in
+                   let bar ((a)[@b ]) b c =
+                     ((if ((a)[@d ]) > 10
+                       then (((if c > 2 then ((\\"ok\\")[@g \\"hello\\"])))
+                         [@f ][@ns.guard ])
+                       else
+                         (((\\"test\\")
+                          [@e ]);
+                          ((if b > 20 then \\"ok\\" else c)
+                          [@ns.guard ])))
+                     [@ns.braces ][@ac ][@ns.guard ]) in
+                   ((if test then \\"hello\\" else ())[@ns.guard ]))))
+               [@ns.guard ])))
+         else \\"fail\\")
+       [@ns.guard ]))
+    else \\"fail\\")[@ns.guard ])"
+`;
+
 exports[`ident.js 1`] = `
 "let x = foo
 let y = Foo.Bar.x

--- a/tests/parsing/grammar/expressions/guard.js
+++ b/tests/parsing/grammar/expressions/guard.js
@@ -1,0 +1,153 @@
+let safeDivideZero = (num, denom) => {
+  guard denom !== 0 else {
+    0
+  }
+  num / denom
+}
+let safeDivideNone = (num, denom) => {
+  guard denom !== 0 else {
+    None
+  }
+  Some(num / denom)
+}
+
+let safeDivideExn = (num, denom) => {
+  guard denom !== 0 else {
+    raise(DivisionByZero)
+  }
+  num / denom
+}
+
+let nested = (x,y,z) => {
+  guard x else {
+    raise(BadX)
+  }
+  guard y else {
+    raise(BadY)
+  }
+  guard z else {
+    raise(BadZ)
+  }
+
+  Js.log("Hello")
+}
+
+let returningUnit = shouldLog => {
+  guard shouldLog
+  Js.log("Hello")
+}
+
+// NOT advised for use, since this syntax allows you to be flat
+// This is really running preconditions before throwing, and handling errors
+// on the error cases
+// Just here to show if doesn't fail
+let nested = (x,y,z) => {
+  guard x else {
+    guard y else {
+      guard z else {
+        raise(BadZ)
+      }
+      raise(BadY)
+    }
+    raise(BadX)
+  }
+
+  Js.log("Hello")
+}
+
+// Not recommended, but blocks are still valid
+let isValid = (width, height, color, status) => {
+  guard {
+    let size = width * height;
+    size < 100
+  } else {
+    false
+  }
+
+  guard color !== Red else {
+    false
+  }
+
+  true
+}
+
+let guardlet = () => {
+  guard let Some(x) = foo() else {
+    "return"
+  }
+  doSomethingWithX(x)
+
+  guard let Some(x) = foo() else {
+    raise(FailedToUnwrap)
+  }
+
+  guard let Some(x) = foo() else {
+    raise(FailedToUnwrap)
+  }
+  doSomethingWithX(x)
+}
+
+// Here down is module-level application
+// You'll see that these continually nest - so each guard statement puts the remaining body in the
+// then branch
+guard {
+  let one = x > 10 && n > 2
+  let two = "test"
+  one + 2 + two
+} else {
+  "fail"
+}
+"hello"
+
+guard x > 10 else {
+  "fail"
+}
+"hello"
+
+let foo = x => {
+  guard x > 10 else {
+    ""
+  }
+  Js.log(x)
+}
+
+guard x > 10
+Js.log(x)
+
+// nested
+let bar = (a,b,c) => {
+  guard a > 10 else {
+    "test"
+    guard b > 20 else {
+      c
+    }
+    "ok"
+  }
+  guard c > 2
+
+  "hello"
+}
+
+// Maintains attributes
+let bar = (@b a,b,c) => {
+  @ac
+  guard @d a > 10 else {
+    @e "test"
+    guard b > 20 else {
+      c
+    }
+    "ok"
+  }
+  @f
+  guard c > 2
+
+  @g("hello")
+  "ok"
+}
+
+// top-level
+guard test else {
+  ()
+}
+
+"hello"

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -913,6 +913,25 @@ comment
 "
 `;
 
+exports[`guard.res 1`] = `
+"let safeDivideZero = (num, denom) => {
+  guard /* i1 */ denom /* i2 */ !== /* i3 */ 0 /* i4 */ else {
+    0
+  }
+  // t5
+
+  guard let Some(
+    x,
+  ) = /* i6 */ /* i7 */ /* i8 */ /* i9 */ /* i10 */ foo() /* i12 */ else {
+    \\"return\\"
+  }
+  // t13
+
+  num /* i14 */ / /* i15 */ denom // t16
+}
+"
+`;
+
 exports[`ifLet.res 1`] = `
 "if let /* c0 */ /* c1 */ Some(
   /* c2 */ x /* c3 */,

--- a/tests/printer/comments/guard.res
+++ b/tests/printer/comments/guard.res
@@ -1,0 +1,9 @@
+let safeDivideZero = (num, denom) => {
+  guard /* i1 */ denom /* i2 */ !== /* i3 */ 0 /* i4 */ else {
+    0 // t5
+  }
+  guard let /* i6 */ Some(/* i7 */ x/* i8 */ ) /* i9 */ = /* i10 */ foo(/* i11 */ ) /* i12 */ else {
+    "return" //t13
+  }
+  num /* i14 */ / /* i15 */ denom // t16
+}

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -2143,6 +2143,154 @@ let f = (type \\\\\\"😎\\", x) => Js.log(x)
 "
 `;
 
+exports[`guard.js 1`] = `
+"let safeDivideZero = (num, denom) => {
+  guard denom !== 0 else {
+    0
+  }
+  num / denom
+}
+let safeDivideNone = (num, denom) => {
+  guard denom !== 0 else {
+    None
+  }
+  Some(num / denom)
+}
+
+let safeDivideExn = (num, denom) => {
+  guard denom !== 0 else {
+    raise(DivisionByZero)
+  }
+  num / denom
+}
+
+let nested = (x, y, z) => {
+  guard x else {
+    raise(BadX)
+  }
+  guard y else {
+    raise(BadY)
+  }
+  guard z else {
+    raise(BadZ)
+  }
+  Js.log(\\"Hello\\")
+}
+
+let returningUnit = shouldLog => {
+  guard shouldLog
+  Js.log(\\"Hello\\")
+}
+
+// NOT advised for use, since this syntax allows you to be flat
+// This is really running preconditions before throwing, and handling errors
+// on the error cases
+// Just here to show if doesn't fail
+let nested = (x, y, z) => {
+  guard x else {
+    guard y else {
+      guard z else {
+        raise(BadZ)
+      }
+      raise(BadY)
+    }
+    raise(BadX)
+  }
+  Js.log(\\"Hello\\")
+}
+
+// Not recommended, but blocks are still valid
+let isValid = (width, height, color, status) => {
+  guard {
+    let size = width * height
+    size < 100
+  } else {
+    false
+  }
+  guard color !== Red else {
+    false
+  }
+  true
+}
+
+let guardlet = () => {
+  guard let Some(x) = foo() else {
+    \\"return\\"
+  }
+  doSomethingWithX(x)
+
+  guard let Some(x) = foo() else {
+    raise(FailedToUnwrap)
+  }
+  guard let Some(x) = foo() else {
+    raise(FailedToUnwrap)
+  }
+  doSomethingWithX(x)
+}
+
+// Here down is module-level application
+// You'll see that these continually nest - so each guard statement puts the remaining body in the
+// then branch
+guard {
+  let one = x > 10 && n > 2
+  let two = \\"test\\"
+  one + 2 + two
+} else {
+  \\"fail\\"
+}
+\\"hello\\"
+
+guard x > 10 else {
+  \\"fail\\"
+}
+\\"hello\\"
+
+let foo = x => {
+  guard x > 10 else {
+    \\"\\"
+  }
+  Js.log(x)
+}
+
+guard x > 10
+Js.log(x)
+
+// nested
+let bar = (a, b, c) => {
+  guard a > 10 else {
+    \\"test\\"
+    guard b > 20 else {
+      c
+    }
+    \\"ok\\"
+  }
+  guard c > 2
+  \\"hello\\"
+}
+
+// Maintains attributes
+let bar = (@b a, b, c) => {
+  @ac
+  guard @d a > 10 else {
+    @e \\"test\\"
+    guard b > 20 else {
+      c
+    }
+    \\"ok\\"
+  }
+  @f
+  guard c > 2
+  @g(\\"hello\\") \\"ok\\"
+}
+
+// top-level
+guard test else {
+  ()
+}
+\\"hello\\"
+"
+`;
+
 exports[`ident.js 1`] = `
 "let x = a
 

--- a/tests/printer/expr/guard.js
+++ b/tests/printer/expr/guard.js
@@ -1,0 +1,153 @@
+let safeDivideZero = (num, denom) => {
+  guard denom !== 0 else {
+    0
+  }
+  num / denom
+}
+let safeDivideNone = (num, denom) => {
+  guard denom !== 0 else {
+    None
+  }
+  Some(num / denom)
+}
+
+let safeDivideExn = (num, denom) => {
+  guard denom !== 0 else {
+    raise(DivisionByZero)
+  }
+  num / denom
+}
+
+let nested = (x,y,z) => {
+  guard x else {
+    raise(BadX)
+  }
+  guard y else {
+    raise(BadY)
+  }
+  guard z else {
+    raise(BadZ)
+  }
+
+  Js.log("Hello")
+}
+
+let returningUnit = shouldLog => {
+  guard shouldLog
+  Js.log("Hello")
+}
+
+// NOT advised for use, since this syntax allows you to be flat
+// This is really running preconditions before throwing, and handling errors
+// on the error cases
+// Just here to show if doesn't fail
+let nested = (x,y,z) => {
+  guard x else {
+    guard y else {
+      guard z else {
+        raise(BadZ)
+      }
+      raise(BadY)
+    }
+    raise(BadX)
+  }
+
+  Js.log("Hello")
+}
+
+// Not recommended, but blocks are still valid
+let isValid = (width, height, color, status) => {
+  guard {
+    let size = width * height;
+    size < 100
+  } else {
+    false
+  }
+
+  guard color !== Red else {
+    false
+  }
+
+  true
+}
+
+let guardlet = () => {
+  guard let Some(x) = foo() else {
+    "return"
+  }
+  doSomethingWithX(x)
+
+  guard let Some(x) = foo() else {
+    raise(FailedToUnwrap)
+  }
+
+  guard let Some(x) = foo() else {
+    raise(FailedToUnwrap)
+  }
+  doSomethingWithX(x)
+}
+
+// Here down is module-level application
+// You'll see that these continually nest - so each guard statement puts the remaining body in the
+// then branch
+guard {
+  let one = x > 10 && n > 2
+  let two = "test"
+  one + 2 + two
+} else {
+  "fail"
+}
+"hello"
+
+guard x > 10 else {
+  "fail"
+}
+"hello"
+
+let foo = x => {
+  guard x > 10 else {
+    ""
+  }
+  Js.log(x)
+}
+
+guard x > 10
+Js.log(x)
+
+// nested
+let bar = (a,b,c) => {
+  guard a > 10 else {
+    "test"
+    guard b > 20 else {
+      c
+    }
+    "ok"
+  }
+  guard c > 2
+
+  "hello"
+}
+
+// Maintains attributes
+let bar = (@b a,b,c) => {
+  @ac
+  guard @d a > 10 else {
+    @e "test"
+    guard b > 20 else {
+      c
+    }
+    "ok"
+  }
+  @f
+  guard c > 2
+
+  @g("hello")
+  "ok"
+}
+
+// top-level
+guard test else {
+  ()
+}
+
+"hello"


### PR DESCRIPTION
This introduces syntax sugar to allow early return. This comes in 2 forms:

Conditional....
```reason
let safeDivideZero = (num, denom) => {
  guard denom !== 0 else {
    0
  }
  num / denom
}
```
And pattern based....
```
let getSnippet = (message) => {
  guard let Some(author) = message.author else {
    "Someone sent you a message"
  }
  author ++ ": " ++ message.body
}
```



Which de-sugar into these respectively
```
let safeDivideZero = (num, denom) => {
  if denom !== 0 {
    num / denom
  } else {
    0
  }
}
```
and
```
let getSnippet = (message) => {
  switch(message.author){
    | Some(author) =>  author ++ ": " ++ message.body
    | _ => "Someone sent you a message"
  }
}
```

This reduces rightward drift and nesting, and allows top-down control flow through preconditions

> Using a guard statement for requirements improves the readability of your code, compared to doing the same check with an if statement. It lets you write the code that’s typically executed without wrapping it in an else block, and it lets you keep the code that handles a violated requirement next to the requirement.


Precedence
-----------
https://github.com/facebook/reason/issues/1302
Swift
 - https://docs.swift.org/swift-book/LanguageGuide/ControlFlow.html#ID525
 - https://ericcerney.com/swift-guard-statement/ gives a good explanation of the benefits over alternate options
