### PR TITLE
Report error when comma is missing in comma delimited regions.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -904,6 +904,21 @@ let parseCommaDelimitedRegion p ~grammar ~closing ~f =
         loop (node::nodes)
       | token when token = closing || token = Eof ->
         List.rev (node::nodes)
+      | _ when Grammar.isListElement grammar p.token ->
+        (* missing comma between nodes in the region and the current token
+         * looks like the start of something valid in the current region.
+         * Example:
+         *   type student<'extraInfo> = {
+         *     name: string,
+         *     age: int
+         *     otherInfo: 'extraInfo
+         *   }
+         * There is a missing comma between `int` and `otherInfo`.
+         * `otherInfo` looks like a valid start of the record declaration.
+         * We report the error here and then continue parsing the region.
+         *)
+        Parser.expect Comma p;
+        loop (node::nodes)
       | _ ->
         if not (p.token = Eof || p.token = closing || Recover.shouldAbortListParse p) then
           Parser.expect Comma p;
@@ -934,6 +949,21 @@ let parseCommaDelimitedReversedList p ~grammar ~closing ~f =
         loop (node::nodes)
       | token when token = closing || token = Eof ->
         (node::nodes)
+      | _ when Grammar.isListElement grammar p.token ->
+        (* missing comma between nodes in the region and the current token
+         * looks like the start of something valid in the current region.
+         * Example:
+         *   type student<'extraInfo> = {
+         *     name: string,
+         *     age: int
+         *     otherInfo: 'extraInfo
+         *   }
+         * There is a missing comma between `int` and `otherInfo`.
+         * `otherInfo` looks like a valid start of the record declaration.
+         * We report the error here and then continue parsing the region.
+         *)
+        Parser.expect Comma p;
+        loop (node::nodes)
       | _ ->
         if not (p.token = Eof || p.token = closing || Recover.shouldAbortListParse p) then
           Parser.expect Comma p;

--- a/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
@@ -17,6 +17,42 @@ exports[`patternMatching.js 1`] = `
 ========================================================"
 `;
 
+exports[`regionMissingComma.res 1`] = `
+"=====Parsetree==========================================
+external make :
+  ?style:ReactDOMRe.Style.t -> ((?image:bool -> React.element)[@bs ]) =
+    \\"ModalContent\\"
+type nonrec 'extraInfo student =
+  {
+  name: string ;
+  age: int ;
+  otherInfo: 'extraInfo }
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/other/regionMissingComma.res 2:31  
+  1 │ external make: (
+  2 │   ~style: ReactDOMRe.Style.t=?.
+  3 │   ~image: bool=?,
+  4 │ ) => React.element = \\"ModalContent\\"
+  
+  Did you forget a \`,\` here? 
+
+  Syntax error!
+  parsing/errors/other/regionMissingComma.res 8:11-9:11  
+   6 │ type student<'extraInfo> = {
+   7 │   name: string,
+   8 │   age: int
+   9 │   otherInfo: 'extraInfo
+  10 │ }
+  11 │ 
+  
+  Did you forget a \`,\` here? 
+
+
+========================================================"
+`;
+
 exports[`spread.js 1`] = `
 "=====Parsetree==========================================
 let arr = [|x;y|]

--- a/tests/parsing/errors/other/regionMissingComma.res
+++ b/tests/parsing/errors/other/regionMissingComma.res
@@ -1,0 +1,10 @@
+external make: (
+  ~style: ReactDOMRe.Style.t=?.
+  ~image: bool=?,
+) => React.element = "ModalContent"
+
+type student<'extraInfo> = {
+  name: string,
+  age: int
+  otherInfo: 'extraInfo
+}

--- a/tests/printer/comments/modExpr.res
+++ b/tests/printer/comments/modExpr.res
@@ -35,7 +35,7 @@
 // Pmod_functor
 /* c0 */ module /* c1 */ F /* c2 */ = /* before parameters */ (
 /* c3 */ A /* c4 */: /* c5 */ X /* c6 */,
-/* c7 */ B /* c8 */: /* c9 */ Y /* c 10 */
+/* c7 */ B /* c8 */: /* c9 */ Y /* c 10 */,
 /* c7 */ C /* c8 */: /* c9 */ Z /* c 10 */
 ) => /* c11 */ ReturnMod /* c12 */ 
 

--- a/tests/printer/expr/exoticIdent.js
+++ b/tests/printer/expr/exoticIdent.js
@@ -3,7 +3,7 @@ let x = Extension.Type.\"type"
 
 let \"+++" = (a, b) => a + b 
 
-\"+++"(~a=\"let", \"module" ~\"type")
+\"+++"(~a=\"let", \"module", ~\"type")
 
 switch \"type" {
 | () => ()

--- a/tests/printer/ffi/import.res
+++ b/tests/printer/ffi/import.res
@@ -1,7 +1,7 @@
 import {
   @disableGc @disableJit
   delimiter: string,
-  cwd as currentWorkingDirectory : unit => string 
+  cwd as currentWorkingDirectory : unit => string,
   isAbsolute: string => bool,
   toNamespacedPath as \"ToNamespacedPath": string => string,
 } from "path"


### PR DESCRIPTION
When a comma is missing between nodes in a region and the current token looks like the start of something valid in the current region, we should report an error with regards to the missing comma.

Example:
```reason
type student<'extraInfo> = {
  name: string,
  age: int                     // <-------- comma is missing
  otherInfo: 'extraInfo
}
```
There is a missing comma between `int` and `otherInfo`.
`otherInfo` looks like a valid start of the record declaration.
We report the error here of the missing comma and then continue parsing the region.

Fixes https://github.com/rescript-lang/syntax/issues/100