### PR TITLE
Give good error when a type declaration has an inline record type when not permitted

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -4024,6 +4024,14 @@ and parseStringFieldDeclaration p =
     Parser.expect ~grammar:Grammar.TypeExpression Colon p;
     let typ = parsePolyTypeExpr p in
     Some(Parsetree.Otag (fieldName, attrs, typ))
+  | Lident name ->
+    let nameLoc = mkLoc p.startPos p.endPos in
+    Parser.err p (Diagnostics.message "An inline record type declaration is only allowed in a variant constructor's declaration");
+    Parser.next p;
+    let fieldName = Location.mkloc name nameLoc in
+    Parser.expect ~grammar:Grammar.TypeExpression Colon p;
+    let typ = parsePolyTypeExpr p in
+    Some(Parsetree.Otag (fieldName, attrs, typ))
   | _token ->
     None
 

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -209,7 +209,7 @@ let isParameterStart = function
 
 (* TODO: overparse Uident ? *)
 let isStringFieldDeclStart = function
-  | Token.String _ | At -> true
+  | Token.String _ | Lident _ | At -> true
   | _ -> false
 
 (* TODO: overparse Uident ? *)

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -38,6 +38,56 @@ type nonrec record = {
 ========================================================"
 `;
 
+exports[`inlineRecord.res 1`] = `
+"=====Parsetree==========================================
+type nonrec entity =
+  | Director 
+  | Student of
+  {
+  name: string ;
+  reportCard: < passing: bool  ;score: int   >  Js.t } 
+type nonrec user =
+  {
+  name: string ;
+  address: < street: string  ;country: string   >  Js.t }
+let make (props : < handleClick: Click.t -> unit  ;value: string   >  Js.t) =
+  render props
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/typeDef/inlineRecord.res 6:9-15  
+  4 ┆ name: string,
+  5 ┆ reportCard: {
+  6 ┆   passing: bool,
+  7 ┆   score: int
+  8 ┆ }
+  
+  An inline record type declaration is only allowed in a variant constructor's declaration
+
+  Syntax error!
+  parsing/errors/typeDef/inlineRecord.res 14:5-10  
+  12 ┆ name: string,
+  13 ┆ address: {
+  14 ┆   street: string,
+  15 ┆   country: string,
+  16 ┆ }
+  
+  An inline record type declaration is only allowed in a variant constructor's declaration
+
+  Syntax error!
+  parsing/errors/typeDef/inlineRecord.res 19:21-31  
+  17 │ }
+  18 │ 
+  19 │ let make = (props: {handleClick: Click.t => unit, value: string}) => r
+       ender(props)
+  20 │ 
+  
+  An inline record type declaration is only allowed in a variant constructor's declaration
+
+
+========================================================"
+`;
+
 exports[`namedParameters.js 1`] = `
 "=====Parsetree==========================================
 type nonrec draw = stroke:pencil -> unit

--- a/tests/parsing/errors/typeDef/inlineRecord.res
+++ b/tests/parsing/errors/typeDef/inlineRecord.res
@@ -1,0 +1,19 @@
+type entity =
+  | Director
+  | Student({
+      name: string,
+      reportCard: {
+        passing: bool,
+        score: int
+      }
+    })
+
+type user = {
+  name: string,
+  address: {
+    street: string,
+    country: string,
+  }
+}
+
+let make = (props: {handleClick: Click.t => unit, value: string}) => render(props)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/97