### PR TITLE
Parse <Foo.bar /> elements

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -618,7 +618,7 @@ let verifyJsxOpeningClosingName p nameExpr =
   let closing = match p.Parser.token with
   | Lident lident -> Parser.next p; Longident.Lident lident
   | Uident _ ->
-    (parseModuleLongIdent ~lowercase:false p).txt
+    (parseModuleLongIdent ~lowercase:true p).txt
   | _ -> Longident.Lident ""
   in
   match nameExpr.Parsetree.pexp_desc with
@@ -2422,7 +2422,7 @@ and parseJsxName p =
     let loc = mkLoc identStart identEnd in
     Location.mkloc (Longident.Lident ident) loc
   | Uident _ ->
-    let longident = parseModuleLongIdent ~lowercase:false p in
+    let longident = parseModuleLongIdent ~lowercase:true p in
     Location.mkloc (Longident.Ldot (longident.txt, "createElement")) longident.loc
   | _ ->
     let msg = "A jsx name should start with a lowercase or uppercase identifier, like: div in <div /> or Navbar in <Navbar />"

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -327,6 +327,82 @@ module LicenseList = struct  end
 ========================================================"
 `;
 
+exports[`jsx.js 1`] = `
+"=====Parsetree==========================================
+let x = ((di ~children:[] ())[@JSX ]) - (v / ([%rescript.exprhole ]))
+let x = ((Unclosed.createElement ~children:[] ())[@JSX ])
+let x =
+  ((Foo.Bar.createElement ~children:[] ())[@JSX ]) > ([%rescript.exprhole ])
+let x =
+  ((Foo.Bar.Baz.createElement ~children:[] ())[@JSX ]) >
+    ([%rescript.exprhole ])
+let x =
+  ((Foo.bar.createElement ~children:[] ())[@JSX ]) > ([%rescript.exprhole ])
+let x =
+  ((Foo.bar.createElement ~baz:((baz)[@ns.namedArgLoc ]) ~children:[] ())
+  [@JSX ])
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/expressions/jsx.js 1:12  
+  1 │ let x = <di-v />
+  2 │ let x = <Unclosed >;
+  3 │ let x = <Foo.Bar></Free.Will>;
+  
+  I'm not sure what to parse here when looking at \\"-\\".
+
+  Syntax error!
+  parsing/errors/expressions/jsx.js 2:20  
+  1 │ let x = <di-v />
+  2 │ let x = <Unclosed >;
+  3 │ let x = <Foo.Bar></Free.Will>;
+  4 │ let x = <Foo.Bar.Baz></Foo.Bar.Boo>
+  
+  Did you forget a \`</\` here? 
+
+  Syntax error!
+  parsing/errors/expressions/jsx.js 3:9-28  
+  1 │ let x = <di-v />
+  2 │ let x = <Unclosed >;
+  3 │ let x = <Foo.Bar></Free.Will>;
+  4 │ let x = <Foo.Bar.Baz></Foo.Bar.Boo>
+  5 │ let x = <Foo.bar> </Foo.baz>
+  
+  Missing </Foo.Bar>
+
+  Syntax error!
+  parsing/errors/expressions/jsx.js 4:9-34  
+  2 │ let x = <Unclosed >;
+  3 │ let x = <Foo.Bar></Free.Will>;
+  4 │ let x = <Foo.Bar.Baz></Foo.Bar.Boo>
+  5 │ let x = <Foo.bar> </Foo.baz>
+  6 │ let x = <Foo.bar.baz />
+  
+  Missing </Foo.Bar.Baz>
+
+  Syntax error!
+  parsing/errors/expressions/jsx.js 5:9-27  
+  3 │ let x = <Foo.Bar></Free.Will>;
+  4 │ let x = <Foo.Bar.Baz></Foo.Bar.Boo>
+  5 │ let x = <Foo.bar> </Foo.baz>
+  6 │ let x = <Foo.bar.baz />
+  7 │ 
+  
+  Missing </Foo.bar>
+
+  Syntax error!
+  parsing/errors/expressions/jsx.js 6:17  
+  4 │ let x = <Foo.Bar.Baz></Foo.Bar.Boo>
+  5 │ let x = <Foo.bar> </Foo.baz>
+  6 │ let x = <Foo.bar.baz />
+  7 │ 
+  
+  I'm not sure what to parse here when looking at \\".\\".
+
+
+========================================================"
+`;
+
 exports[`misc.js 1`] = `
 "=====Parsetree==========================================
 let x = ([%rescript.exprhole ]) + 1

--- a/tests/parsing/errors/expressions/jsx.js
+++ b/tests/parsing/errors/expressions/jsx.js
@@ -1,0 +1,6 @@
+let x = <di-v />
+let x = <Unclosed >;
+let x = <Foo.Bar></Free.Will>;
+let x = <Foo.Bar.Baz></Foo.Bar.Boo>
+let x = <Foo.bar> </Foo.baz>
+let x = <Foo.bar.baz />

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -541,8 +541,42 @@ let _ =
       ~children:[] ())
   [@JSX ])
 let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
-let _ = ((Nav.Navbar.createElement ~children:[] ())[@JSX ])
-let _ = ((Nav.navbar.createElement ~children:[] ())[@JSX ])
+let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
+let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
+let _ =
+  ((Navbar.createElement ~className:((\\"menu\\")[@ns.namedArgLoc ]) ~children:[]
+      ())
+  [@JSX ])
+let _ = ((Dot.Up.createElement ~children:[] ())[@JSX ])
+let _ = ((Dot.Up.createElement ~children:[] ())[@JSX ])
+let _ = ((Dot.Up.createElement ~children:[] ())[@JSX ])
+let _ =
+  ((Dot.Up.createElement
+      ~children:[((Dot.low.createElement ~children:[] ())[@JSX ])] ())
+  [@JSX ])
+let _ =
+  ((Dot.Up.createElement
+      ~children:[((Dot.Up.createElement ~children:[] ())[@JSX ])] ())
+  [@JSX ])
+let _ =
+  ((Dot.Up.createElement ~className:((\\"menu\\")[@ns.namedArgLoc ]) ~children:[]
+      ())
+  [@JSX ])
+let _ = ((Dot.low.createElement ~children:[] ())[@JSX ])
+let _ = ((Dot.low.createElement ~children:[] ())[@JSX ])
+let _ = ((Dot.low.createElement ~children:[] ())[@JSX ])
+let _ =
+  ((Dot.low.createElement
+      ~children:[((Dot.Up.createElement ~children:[] ())[@JSX ])] ())
+  [@JSX ])
+let _ =
+  ((Dot.low.createElement
+      ~children:[((Dot.low.createElement ~children:[] ())[@JSX ])] ())
+  [@JSX ])
+let _ =
+  ((Dot.low.createElement ~className:((\\"menu\\")[@ns.namedArgLoc ])
+      ~children:[] ())
+  [@JSX ])
 let _ = ((el ~punned:((punned)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
 let _ = ((el ?punned:((punned)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
 let _ = ((el ~punned:((punned)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -542,6 +542,7 @@ let _ =
   [@JSX ])
 let _ = ((Navbar.createElement ~children:[] ())[@JSX ])
 let _ = ((Nav.Navbar.createElement ~children:[] ())[@JSX ])
+let _ = ((Nav.navbar.createElement ~children:[] ())[@JSX ])
 let _ = ((el ~punned:((punned)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
 let _ = ((el ?punned:((punned)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
 let _ = ((el ~punned:((punned)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])

--- a/tests/parsing/grammar/expressions/jsx.js
+++ b/tests/parsing/grammar/expressions/jsx.js
@@ -18,9 +18,24 @@ let _ = <div className="menu"></div>
 let _ = <div className="menu" onClick={_ => Js.log("click")}> </div>
 let _ = <div className="menu" onClick={_ => Js.log("click")}></div>
 
+let _ = <Navbar />
 let _ = <Navbar> </Navbar>
-let _ = <Nav.Navbar> </Nav.Navbar>
-let _ = <Nav.navbar> </Nav.navbar>
+let _ = <Navbar></Navbar>
+let _ = <Navbar className="menu"> </Navbar>
+
+let _ = <Dot.Up />
+let _ = <Dot.Up> </Dot.Up>
+let _ = <Dot.Up></Dot.Up>
+let _ = <Dot.Up><Dot.low /></Dot.Up>
+let _ = <Dot.Up><Dot.Up /></Dot.Up>
+let _ = <Dot.Up className="menu"> </Dot.Up>
+
+let _ = <Dot.low />
+let _ = <Dot.low> </Dot.low>
+let _ = <Dot.low></Dot.low>
+let _ = <Dot.low><Dot.Up /></Dot.low>
+let _ = <Dot.low><Dot.low /></Dot.low>
+let _ = <Dot.low className="menu"> </Dot.low>
 
 // punning
 let _ = <el punned> </el>

--- a/tests/parsing/grammar/expressions/jsx.js
+++ b/tests/parsing/grammar/expressions/jsx.js
@@ -20,6 +20,7 @@ let _ = <div className="menu" onClick={_ => Js.log("click")}></div>
 
 let _ = <Navbar> </Navbar>
 let _ = <Nav.Navbar> </Nav.Navbar>
+let _ = <Nav.navbar> </Nav.navbar>
 
 // punning
 let _ = <el punned> </el>

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -2420,6 +2420,8 @@ exports[`jsx.js 1`] = `
 let x = <Foo className=\\"container\\" />
 let x = <Foo.Bar className=\\"container\\" />
 let x = <Foo.Bar.Baz className=\\"container\\" />
+let x = <Foo.bar className=\\"container\\" />
+let x = <Foo.baz className=\\"multiline\\" />
 
 let x =
   <div

--- a/tests/printer/expr/jsx.js
+++ b/tests/printer/expr/jsx.js
@@ -2,6 +2,10 @@ let x = <div className="container" className2="container2" className3="container
 let x = <Foo className="container" />
 let x = <Foo.Bar className="container" />
 let x = <Foo.Bar.Baz className="container" />
+let x = <Foo.bar className="container" />
+let x = <Foo.baz
+ className="multiline"
+/>
 
 
 let x =


### PR DESCRIPTION
Found in #124.

Reason parser used to parse JSX elements like `<Foo.bar />`:
https://astexplorer.net/#/gist/e21abaf96358b68be3ed3da19930be58/32e083720817c639502960b54984dff8396a3f7b.

React ppx also builds on top of this to allow custom `make` names, e.g.
```reason
let t = <Foo.bar />
let t = <Foo.Bar />
```
is transformed into:
```reason
let t = React.createElement(Foo.bar, Foo.barProps()); /* We can call `bar` instead of `make` */
let t = React.createElement(Foo.Bar.make, Foo.Bar.makeProps());
```

(shameless plug, can be tested in https://jchavarri.github.io/ppx-explorer/ 😜 )