### PR TITLE
Add error message when type definition name contains a module access path

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -101,7 +101,7 @@ Solution: directly use `concat`."
     "Did you forget to attach `" ^ attrName ^ "` to an item?\n  Standalone attributes start with `@@` like: `@@" ^ attrName ^"`"
 
   let typeDeclarationNameLongident longident =
-    "A type declaration's name cannot contain a module access path. Did you mean `" ^ (Longident.last longident) ^"`?"
+    "A type declaration's name cannot contain a module access. Did you mean `" ^ (Longident.last longident) ^"`?"
 end
 
 
@@ -1977,7 +1977,7 @@ and parsePrimaryExpr ~operand ?(noCall=false) p =
           ~startPos:expr.pexp_loc.loc_start
           ~endPos:expr.pexp_loc.loc_end
           p
-          (Diagnostics.message "Tagged template literals are currently restricted to identifiers like: json`null`.");
+          (Diagnostics.message "Tagged template literals are currently restricted to names like: json`null`.");
         parseTemplateExpr p
       end
     | _ -> expr
@@ -2434,7 +2434,7 @@ and parseJsxName p =
     let longident = parseModuleLongIdent ~lowercase:true p in
     Location.mkloc (Longident.Ldot (longident.txt, "createElement")) longident.loc
   | _ ->
-    let msg = "A jsx name should start with a lowercase or uppercase identifier, like: div in <div /> or Navbar in <Navbar />"
+    let msg = "A jsx name must be a lowercase or uppercase name, like: div in <div /> or Navbar in <Navbar />"
     in
     Parser.err p (Diagnostics.message msg);
     Location.mknoloc (Longident.Lident "_")

--- a/src/res_diagnostics.ml
+++ b/src/res_diagnostics.ml
@@ -41,7 +41,7 @@ let explain t =
       let token = Token.toString t in
       "`" ^ token ^ "` is a reserved keyword."
     | _ ->
-      "At this point, I'm looking for an uppercased identifier like `Belt` or `Array`"
+      "At this point, I'm looking for an uppercased name like `Belt` or `Array`"
     end
   | Lident currentToken ->
     begin match currentToken with
@@ -54,7 +54,7 @@ let explain t =
     | Underscore ->
       "`_` isn't a valid name."
     | _ ->
-      "I'm expecting an lowercased identifier like `name` or `age`"
+      "I'm expecting a lowercase name like `user or `age`"
     end
   | Message txt -> txt
   | UnclosedString ->

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -61,7 +61,7 @@ type t =
 
 let toString = function
   | OpenDescription -> "an open description"
-  | ModuleLongIdent -> "a module identifier"
+  | ModuleLongIdent -> "a module path"
   | Ternary -> "a ternary expression"
   | Es6ArrowExpr -> "an es6 arrow function"
   | Jsx -> "a jsx expression"

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -507,7 +507,7 @@ exports[`taggedTemplateLiterals.js 1`] = `
   1 │ foo()\`null\`
   2 │ 
   
-  Tagged template literals are currently restricted to identifiers like: json\`null\`.
+  Tagged template literals are currently restricted to names like: json\`null\`.
 
 
 ========================================================"

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -172,6 +172,7 @@ exports[`typeDef.js 1`] = `
 "=====Parsetree==========================================
 type stack =
   | Empty 
+type nonrec bar = string
 type nonrec t = [%rescript.typehole ]
 type nonrec state = [%rescript.typehole ]
 =====Errors=============================================
@@ -181,26 +182,37 @@ type nonrec state = [%rescript.typehole ]
   1 │ type rec stack
   2 │   | Empty
   3 │ 
-  4 │ // missing type
+  4 │ // name cannot contain module access paths
   
   Did you forget a \`=\` here?
 
 
   Syntax error!
-  parsing/errors/typeDef/typeDef.js:8:1-4  
+  parsing/errors/typeDef/typeDef.js:5:6-12  
+  3 │ 
+  4 │ // name cannot contain module access paths
+  5 │ type Foo.bar = string
   6 │ 
   7 │ // missing type
-  8 │ type state =
-  9 │ 
+  
+  A type declaration's name cannot contain a module access path. Did you mean \`bar\`?
+
+
+  Syntax error!
+  parsing/errors/typeDef/typeDef.js:11:1-4  
+   9 │ 
+  10 │ // missing type
+  11 │ type state =
+  12 │ 
   
   Missing a type here
 
 
   Syntax error!
-  parsing/errors/typeDef/typeDef.js:9:1  
-  7 │ // missing type
-  8 │ type state =
-  9 │ 
+  parsing/errors/typeDef/typeDef.js:12:1  
+  10 │ // missing type
+  11 │ type state =
+  12 │ 
   
   Missing a type here
 

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -195,7 +195,7 @@ type nonrec state = [%rescript.typehole ]
   6 │ 
   7 │ // missing type
   
-  A type declaration's name cannot contain a module access path. Did you mean \`bar\`?
+  A type declaration's name cannot contain a module access. Did you mean \`bar\`?
 
 
   Syntax error!

--- a/tests/parsing/errors/typeDef/typeDef.js
+++ b/tests/parsing/errors/typeDef/typeDef.js
@@ -1,6 +1,9 @@
 type rec stack
   | Empty
 
+// name cannot contain module access paths
+type Foo.bar = string
+
 // missing type
 type t =
 


### PR DESCRIPTION
```
type Foo.bar = string
```

Proposed error message:
```
 A type declaration's name cannot contain a module access path. Did you mean \`bar\`?
```