### PR TITLE
implement syntax for arity zero vs arity one in uncurried application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Implement syntax for arity zero vs arity one in uncurried application in [#139](https://github.com/rescript-lang/syntax/pull/139)
 * Fix parsing of first class module exprs as part of binary/ternary expr in [#256](https://github.com/rescript-lang/syntax/pull/256)
 
 ## ReScript 9.0.0

--- a/tests/parsing/grammar/expressions/argument.res
+++ b/tests/parsing/grammar/expressions/argument.res
@@ -7,3 +7,7 @@ callback(. firstNode, ~y)
 document.createElementWithOptions(. "div", elementProps(~onClick=_ =>
     Js.log("hello world")
   ))
+
+
+resolve(.)
+resolve(. ())

--- a/tests/parsing/grammar/expressions/expected/argument.res.txt
+++ b/tests/parsing/grammar/expressions/expected/argument.res.txt
@@ -1,4 +1,5 @@
-let foo ~a:((a)[@ns.namedArgLoc ])  = ((a ())[@bs ]) +. 1.
+let foo ~a:((a)[@ns.namedArgLoc ])  =
+  ((a (let __res_unit = () in __res_unit))[@bs ]) +. 1.
 let a = ((fun () -> 2)[@bs ])
 let bar = foo ~a:((a)[@ns.namedArgLoc ])
 let comparisonResult =
@@ -8,3 +9,5 @@ let comparisonResult =
 ;;((document.createElementWithOptions "div"
       (elementProps ~onClick:((fun _ -> Js.log "hello world")
          [@ns.namedArgLoc ])))[@bs ])
+;;((resolve ())[@bs ])
+;;((resolve (let __res_unit = () in __res_unit))[@bs ])

--- a/tests/printer/expr/apply.res
+++ b/tests/printer/expr/apply.res
@@ -70,3 +70,6 @@ f(. {
   exception Exit
   raise(Exit)
 })
+
+resolve(.)
+resolve(. ())

--- a/tests/printer/expr/expected/apply.res.txt
+++ b/tests/printer/expr/expected/apply.res.txt
@@ -90,3 +90,6 @@ f(. {
   exception Exit
   raise(Exit)
 })
+
+resolve(.)
+resolve(. ())


### PR DESCRIPTION
Since there is no syntax space for arity zero vs arity one, we parse
  `fn(. ())` into
  `fn(. {let __res_unit = (); __res_unit})`
  when the parsetree is intended for type checking

`fn(.)` is treated as zero arity application

Fixes https://github.com/rescript-lang/syntax/issues/138