### PR TITLE
Parse error when a non-standalone attribute is used standalone.

### DIFF
--- a/src/res_diagnostics.ml
+++ b/src/res_diagnostics.ml
@@ -102,7 +102,7 @@ let explain t =
           "Did you forget to write an expression here?"
         | (Grammar.LetBinding, _)::_, _ ->
           "This let-binding misses an expression"
-        | _::_, (Rbracket | Rbrace) ->
+        | _::_, (Rbracket | Rbrace | Eof) ->
           "Missing expression"
         | _ ->
           "I'm not sure what to parse here when looking at \"" ^ name ^ "\"."

--- a/tests/parsing/errors/signature/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/signature/__snapshots__/parse.spec.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`attributes.resi 1`] = `
+"=====Parsetree==========================================
+module type MissingItem  = sig [%%rescript.sigitemhole ] end
+[%%rescript.sigitemhole ]
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/signature/attributes.resi:2:3-7  
+  1 │ module type MissingItem = {
+  2 │   @attr
+  3 │ }
+  4 │ 
+  
+  Did you forget to attach \`attr\` to an item?
+  Standalone attributes start with \`@@\` like: \`@@attr\`
+
+
+  Syntax error!
+  parsing/errors/signature/attributes.resi:5:1-16  
+  3 │ }
+  4 │ 
+  5 │ @attrWithoutItem
+  6 │ 
+  
+  Did you forget to attach \`attrWithoutItem\` to an item?
+  Standalone attributes start with \`@@\` like: \`@@attrWithoutItem\`
+
+
+========================================================"
+`;
+
 exports[`closingBraces.resi 1`] = `
 "=====Parsetree==========================================
 val x : int

--- a/tests/parsing/errors/signature/attributes.resi
+++ b/tests/parsing/errors/signature/attributes.resi
@@ -1,0 +1,5 @@
+module type MissingItem = {
+  @attr
+}
+
+@attrWithoutItem

--- a/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`attributes.res 1`] = `
+"=====Parsetree==========================================
+module MissingExpression = struct ;;[%rescript.exprhole ][@@attr ] end
+;;[%rescript.exprhole ][@@attrWithNoExpression ]
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/structure/attributes.res:2:3-7  
+  1 │ module MissingExpression = {
+  2 │   @attr
+  3 │ }
+  4 │ 
+  
+  Did you forget to attach \`attr\` to an item?
+  Standalone attributes start with \`@@\` like: \`@@attr\`
+
+
+  Syntax error!
+  parsing/errors/structure/attributes.res:5:1-21  
+  3 │ }
+  4 │ 
+  5 │ @attrWithNoExpression
+  6 │ 
+  
+  Did you forget to attach \`attrWithNoExpression\` to an item?
+  Standalone attributes start with \`@@\` like: \`@@attrWithNoExpression\`
+
+
+========================================================"
+`;
+
 exports[`closingBraces.res 1`] = `
 "=====Parsetree==========================================
 let x = 1

--- a/tests/parsing/errors/structure/attributes.res
+++ b/tests/parsing/errors/structure/attributes.res
@@ -1,0 +1,5 @@
+module MissingExpression = {
+  @attr
+}
+
+@attrWithNoExpression

--- a/tests/parsing/recovery/expression/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/recovery/expression/__snapshots__/parse.spec.js.snap
@@ -11,7 +11,8 @@ exports[`infinite.js 1`] = `"let smallest = ((heap.compare ())[@bs ]) < (a |. (f
 
 exports[`jsx.js 1`] = `
 "let x = ((div ~children:[] ())[@JSX ])
-[@@@ ]"
+[@@@ ]
+;;[%rescript.exprhole ][@@ ]"
 `;
 
 exports[`list.js 1`] = `


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/141