### PR TITLE
Update parser + test runner to fail when in non-recover mode

### DIFF
--- a/src/res_cli.ml
+++ b/src/res_cli.ml
@@ -236,11 +236,11 @@ module CliArgProcessor = struct
           backend.stringOfDiagnostics
             ~source:parseResult.source
             ~filename:parseResult.filename
-            parseResult.diagnostics;
-          if recover || not parseResult.invalid then
+            parseResult.diagnostics; 
+          if recover then
             printEngine.printInterface
               ~width ~filename ~comments:parseResult.comments parseResult.parsetree
-          else ()
+          else exit 1
         end
         else
           printEngine.printInterface
@@ -252,10 +252,10 @@ module CliArgProcessor = struct
             ~source:parseResult.source
             ~filename:parseResult.filename
             parseResult.diagnostics;
-          if recover || not parseResult.invalid then
+          if recover then
             printEngine.printImplementation
               ~width ~filename ~comments:parseResult.comments parseResult.parsetree
-          else ()
+          else exit 1
         end
         else
           printEngine.printImplementation

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -1142,7 +1142,11 @@ let switchExpr = match myVar with | Blue -> \\"blue\\" | Red -> \\"red\\"
 let constrainedExpr = (x : int)"
 `;
 
-exports[`polyvariant.js 1`] = `""`;
+exports[`polyvariant.js 1`] = `
+"let x = \`Red
+let z = \`Rgb ()
+let v = \`Vertex (1., 2., 3., 4.)"
+`;
 
 exports[`primary.js 1`] = `
 "let x = a.b

--- a/tests/parsing/grammar/expressions/polyvariant.js
+++ b/tests/parsing/grammar/expressions/polyvariant.js
@@ -1,7 +1,7 @@
-let x = `Red
+let x = #Red
 
 
 // sugar for Rgb(())
-let z = `Rgb()
+let z = #Rgb()
 
-let v = `Vertex(1., 2., 3., 4.)
+let v = #Vertex(1., 2., 3., 4.)


### PR DESCRIPTION
Extracted from #124.

- Makes parser cli return exit code 1 if parsed result is invalid (except when `-recover` is passed)
- Adapt runner to check status after calling `rescript.exe`, fail test if status > 0
- Update test `parsing/grammar/expressions/polyvariant.js ` that was failing to parse