### PR TITLE
Implement intelligent breaking for chained or-patterns.

### DIFF
--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2284,7 +2284,12 @@ and printPattern (p : Parsetree.pattern) cmtTbl =
         | _ -> patternDoc
       ]
     ) orChain in
-    Doc.group (Doc.concat docs)
+    let isSpreadOverMultipleLines = match (orChain, List.rev orChain) with
+    | first::_, last::_ ->
+      first.ppat_loc.loc_start.pos_lnum < last.ppat_loc.loc_end.pos_lnum
+    | _ -> false
+    in
+    Doc.breakableGroup ~forceBreak:isSpreadOverMultipleLines (Doc.concat docs)
   | Ppat_extension ext ->
     printExtension ~atModuleLvl:false ext cmtTbl
   | Ppat_lazy p ->

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -471,7 +471,9 @@ type color =
 
 let blahCurriedX = (x, x) =>
   switch x {
-  | Red(10) | Black(20) | Green(10) => 1 // After or pattern green
+  | Red(10)
+  | Black(20)
+  | Green(10) => 1 // After or pattern green
   | Red(x) => 0 // After red
   | Black(x) => 0 // After black
   | Green(x) => 0

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -202,7 +202,8 @@ switch colour {
 
 let precedence = x =>
   switch x {
-  | HashEqual | ColonEqual => 1
+  | HashEqual
+  | ColonEqual => 1
   | Lor => 2
   | Land => 3
   | Equal
@@ -215,10 +216,19 @@ let precedence = x =>
   | LessEqual
   | GreaterEqual
   | BarGreater => 4
-  | Plus | PlusDot | Minus | MinusDot | PlusPlus => 5
-  | Asterisk | AsteriskDot | Forwardslash | ForwardslashDot => 6
+  | Plus
+  | PlusDot
+  | Minus
+  | MinusDot
+  | PlusPlus => 5
+  | Asterisk
+  | AsteriskDot
+  | Forwardslash
+  | ForwardslashDot => 6
   | Exponentiation => 7
-  | Hash | HashHash | MinusGreater => 8
+  | Hash
+  | HashHash
+  | MinusGreater => 8
   | Dot => 9
   | _ => 0
   }
@@ -226,6 +236,29 @@ let precedence = x =>
 let first = switch first {
 | Some(x) => x
 | None => (\\"\\": format6<_>)
+}
+
+// spread over multiple lines, because author used multiple lines
+switch a {
+| B
+| C
+| D => 1
+| E => 2
+}
+
+// keep on one line, author kept it on one line
+switch a {
+| B | C | D => 1
+| E => 2
+}
+
+// should naturally break over multiple lines
+switch a {
+| Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+| Ccccccccccccccccccccccccccccccccccccccccccccccccccccc
+| Dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+| Eeeeeeeeeeeeee => 1
+| E => 2
 }
 "
 `;

--- a/tests/printer/other/case.js
+++ b/tests/printer/other/case.js
@@ -105,3 +105,22 @@ let first = switch first {
 | Some(x) => x
 | None => ("": format6<_>)
 }
+
+// spread over multiple lines, because author used multiple lines
+switch a {
+| B
+| C | D => 1
+| E => 2
+}
+
+// keep on one line, author kept it on one line
+switch a {
+| B | C | D => 1
+| E => 2
+}
+
+// should naturally break over multiple lines
+switch a {
+| Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb | Ccccccccccccccccccccccccccccccccccccccccccccccccccccc | Dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd | Eeeeeeeeeeeeee => 1
+| E => 2
+}


### PR DESCRIPTION
If you look at the `B | C | D` patterns in the following examples:
```
switch a {
| B
| C
| D => 1
| E => 2
}
switch a {
| B | C | D => 1
| E => 2
}
```
they have two different layouts:
* In the first example the user wrote them over multiple lines.
* The second has them on one line.

This commit implements a new strategy to print these two examples.
We now look at the style of the author: did he write it over multiple lines or not?
* If it is on one line, keep it on one line (unless it breaks the column width).
* If it is written over multiple lines, force break it over multiple lines.

This is also consistent with how we print variant declaration.