### PR TITLE
Remove support for nativeint

### DIFF
--- a/src/res_scanner.ml
+++ b/src/res_scanner.ml
@@ -196,9 +196,10 @@ let scanNumber scanner =
           ^ literal
           ^ "`?"
         in
+        let pos = position scanner in
         scanner.err
-          ~startPos:(position scanner)
-          ~endPos:(position scanner)
+          ~startPos:pos
+          ~endPos:pos
           (Diagnostics.message msg)
       );
       next scanner;

--- a/src/res_scanner.ml
+++ b/src/res_scanner.ml
@@ -190,6 +190,17 @@ let scanNumber scanner =
        || scanner.ch >= CharacterCodes.Upper.g && scanner.ch <= CharacterCodes.Upper.z
     then (
       let ch = scanner.ch in
+      if CharacterCodes.Lower.n = ch then (
+        let msg =
+          "Unsupported number type (nativeint). Did you mean `"
+          ^ literal
+          ^ "`?"
+        in
+        scanner.err
+          ~startPos:(position scanner)
+          ~endPos:(position scanner)
+          (Diagnostics.message msg)
+      );
       next scanner;
       Some (Char.unsafe_chr ch)
     ) else

--- a/tests/idempotency/ocaml/stdlib/nativeint.ml
+++ b/tests/idempotency/ocaml/stdlib/nativeint.ml
@@ -38,16 +38,16 @@ external to_float : nativeint -> float
 external of_int32: int32 -> nativeint = "%nativeint_of_int32"
 external to_int32: nativeint -> int32 = "%nativeint_to_int32"
 
-let zero = 0n
-let one = 1n
-let minus_one = -1n
-let succ n = add n 1n
-let pred n = sub n 1n
-let abs n = if n >= 0n then n else neg n
-let size = Sys.word_size
-let min_int = shift_left 1n (size - 1)
-let max_int = sub min_int 1n
-let lognot n = logxor n (-1n)
+(* let zero = 0n *)
+(* let one = 1n *)
+(* let minus_one = -1n *)
+(* let succ n = add n 1n *)
+(* let pred n = sub n 1n *)
+(* let abs n = if n >= 0n then n else neg n *)
+(* let size = Sys.word_size *)
+(* let min_int = shift_left 1n (size - 1) *)
+(* let max_int = sub min_int 1n *)
+(* let lognot n = logxor n (-1n) *)
 
 external format : string -> nativeint -> string = "caml_nativeint_format"
 let to_string n = format "%d" n

--- a/tests/idempotency/ocaml/typing/oprint.ml
+++ b/tests/idempotency/ocaml/typing/oprint.ml
@@ -150,7 +150,7 @@ let print_out_value ppf tree =
     | Oval_int i -> parenthesize_if_neg ppf "%i" i (i < 0)
     | Oval_int32 i -> parenthesize_if_neg ppf "%lil" i (i < 0l)
     | Oval_int64 i -> parenthesize_if_neg ppf "%LiL" i (i < 0L)
-    | Oval_nativeint i -> parenthesize_if_neg ppf "%nin" i (i < 0n)
+    (* | Oval_nativeint i -> parenthesize_if_neg ppf "%nin" i (i < 0n) *)
     | Oval_float f -> parenthesize_if_neg ppf "%s" (float_repres f) (f < 0.0)
     | Oval_string (_,_, Ostr_bytes) as tree ->
       pp_print_char ppf '(';

--- a/tests/idempotency/ocaml/typing/parmatch.ml
+++ b/tests/idempotency/ocaml/typing/parmatch.ml
@@ -1125,11 +1125,11 @@ let build_other ext env = match env with
       (function Tpat_constant(Const_int64 i) -> i | _ -> assert false)
       (function i -> Tpat_constant(Const_int64 i))
       0L Int64.succ p env
-| ({pat_desc=(Tpat_constant (Const_nativeint _))} as p,_) :: _ ->
-    build_other_constant
-      (function Tpat_constant(Const_nativeint i) -> i | _ -> assert false)
-      (function i -> Tpat_constant(Const_nativeint i))
-      0n Nativeint.succ p env
+(* | ({pat_desc=(Tpat_constant (Const_nativeint _))} as p,_) :: _ -> *)
+    (* build_other_constant *)
+      (* (function Tpat_constant(Const_nativeint i) -> i | _ -> assert false) *)
+      (* (function i -> Tpat_constant(Const_nativeint i)) *)
+      (* 0n Nativeint.succ p env *)
 | ({pat_desc=(Tpat_constant (Const_string _))} as p,_) :: _ ->
     build_other_constant
       (function Tpat_constant(Const_string (s, _)) -> String.length s

--- a/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
@@ -28,6 +28,22 @@ let x = \\"\\\\\\\\0AAA\\"
 ========================================================"
 `;
 
+exports[`nativeint.res 1`] = `
+"=====Parsetree==========================================
+let nativeint = 3n
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/scanner/nativeint.res:1:18  
+  1 │ let nativeint = 3n
+  2 │ 
+  
+  Unsupported number type (nativeint). Did you mean \`3\`?
+
+
+========================================================"
+`;
+
 exports[`oldDerefOp.js 1`] = `
 "=====Parsetree==========================================
 let newVelocity = velocity +. (a *. secondPerFrame)

--- a/tests/parsing/errors/scanner/nativeint.res
+++ b/tests/parsing/errors/scanner/nativeint.res
@@ -1,0 +1,1 @@
+let nativeint = 3n

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -317,7 +317,6 @@ let complexNumber = 1.6
 let x = 0b0000_0001
 let int32 = 42l
 let int64 = 42L
-let nativeint = 42n
 let x = (-44.20e99)
 let x = (-44.20_34e99)
 let x = (-44.20e+9)

--- a/tests/parsing/grammar/expressions/constants.js
+++ b/tests/parsing/grammar/expressions/constants.js
@@ -19,7 +19,6 @@ let x = 0b0000_0001
 
 let int32 = 42l
 let int64 = 42L
-let nativeint = 42n
 
 let x = -44.20e99
 let x = -44.20_34e99

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -461,7 +461,6 @@ exports[`number.js 1`] = `
 
 let int32 = 42l
 let int64 = 42L
-let nativeint = 42n
 
 let x = -44.20e99
 let x = -44.20_34e99

--- a/tests/printer/other/number.js
+++ b/tests/printer/other/number.js
@@ -2,7 +2,6 @@ let x = 0b0000_0001
 
 let int32 = 42l
 let int64 = 42L
-let nativeint = 42n
 
 let x = -44.20e99
 let x = -44.20_34e99


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/207

Nativeint has been removed in the compiler and does not make sense for a js backend.

cc @bobzhang 