### PR TITLE
Convert Reason fast pipe with uncurried functions in the lhs to ReScript correct

### DIFF
--- a/src/res_ast_conversion.ml
+++ b/src/res_ast_conversion.ml
@@ -74,7 +74,7 @@ let rec rewriteReasonFastPipe expr =
     let rhsLoc = {rhs.pexp_loc with loc_end = expr.pexp_loc.loc_end} in
     let newLhs =
       let expr = rewriteReasonFastPipe lhs in
-      {expr with pexp_attributes = subAttrs}
+      {expr with pexp_attributes = List.concat [lhs.pexp_attributes; subAttrs]}
     in
     let newRhs = {
       pexp_loc = rhsLoc;

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1392,6 +1392,23 @@ let () = {
   // ok
   dontDoThisAhome(. a, b)(. c, d)(. e, f)
 }
+
+let _ =
+  library.getBalance(. account)->Promise.Js.catch(_ => Promise.resolved(None))
+
+let _ =
+  library.getBalance(. account)
+  ->Promise.Js.catch(_ => Promise.resolved(None))
+  ->Promise.get(newBalance =>
+    dispatch(
+      LoadAddress(
+        account,
+        newBalance->Belt.Option.flatMap(balance =>
+          Eth.make(balance.toString(.))
+        ),
+      ),
+    )
+  )
 "
 `;
 

--- a/tests/conversion/reason/uncurrried.re
+++ b/tests/conversion/reason/uncurrried.re
@@ -56,3 +56,22 @@ let () = {
   // ok
   dontDoThisAhome(. a, b)(. c, d)(. e, f)
 }
+
+
+let _ =
+  library.getBalance(. account)
+  ->Promise.Js.catch(_ => Promise.resolved(None))
+
+let _ =
+  library.getBalance(. account)
+  ->Promise.Js.catch(_ => {Promise.resolved(None)})
+  ->Promise.get(newBalance => {
+      dispatch(
+        LoadAddress(
+          account,
+          newBalance->Belt.Option.flatMap(balance =>
+            Eth.make(balance.toString(.))
+          ),
+        ),
+      )
+    });

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -135,7 +135,9 @@ let x = a - b
 let x = a -. b
 ;;Constructor (a, b)
 ;;\`Constructor (a, b)
-let _ = ((Constructor (a, b); \`Constructor (a, b))[@ns.braces ])"
+let _ = ((Constructor (a, b); \`Constructor (a, b))[@ns.braces ])
+;;((library.getBalance account)[@bs ]) |.
+    (Promise.Js.catch (fun _ -> ((Promise.resolved None)[@ns.braces ])))"
 `;
 
 exports[`binaryNoEs6Arrow.js 1`] = `

--- a/tests/parsing/grammar/expressions/binary.js
+++ b/tests/parsing/grammar/expressions/binary.js
@@ -43,3 +43,5 @@ let _ = {
   #Constructor(a, b)
 }
 
+library.getBalance(. account)
+->Promise.Js.catch(_ => {Promise.resolved(None)})

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -748,6 +748,27 @@ let aggregateTotal = (forecast, ~audienceType) =>
     views: item[\\"reach\\"][\\"views\\"],
     sample: item[\\"reach\\"][\\"sample\\"],
   })
+
+React.useEffect4(() => {
+  switch (context.library, context.account) {
+  | (Some(library), Some(account)) =>
+    library.getBalance(. account)
+    ->Promise.Js.catch(_ => {Promise.resolved(None)})
+    ->Promise.get(newBalance => {
+      dispatch(
+        LoadAddress(
+          account,
+          newBalance->Belt.Option.flatMap(balance =>
+            Eth.make(balance.toString(.))
+          ),
+        ),
+      )
+    })
+
+    None
+  | _ => None
+  }
+}, (context.library, context.account, context.chainId, dispatch))
 "
 `;
 

--- a/tests/printer/expr/binary.js
+++ b/tests/printer/expr/binary.js
@@ -364,3 +364,27 @@ let aggregateTotal = (forecast, ~audienceType) =>
     views: item["reach"]["views"],
     sample: item["reach"]["sample"],
   })
+
+React.useEffect4(
+  () => {
+    switch (context.library, context.account) {
+    | (Some(library), Some(account)) =>
+      library.getBalance(. account)
+      ->Promise.Js.catch(_ => {Promise.resolved(None)})
+      ->Promise.get(newBalance => {
+          dispatch(
+            LoadAddress(
+              account,
+              newBalance->Belt.Option.flatMap(balance =>
+                Eth.make(balance.toString(.))
+              ),
+            ),
+          )
+        })
+
+      None
+    | _ => None
+    }
+  },
+  (context.library, context.account, context.chainId, dispatch),
+)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/218

The following code should convert to ReScript correctly:
```rescript
let _ =
  library.getBalance(. account)
  ->Promise.Js.catch(_ => Promise.resolved(None))
```