### PR TITLE
Light weight exotic poly variant syntax

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -444,6 +444,164 @@ let processUnderscoreApplication args =
   in
   (args, wrap)
 
+let hexValue x =
+  match x with
+  | '0' .. '9' ->
+    (Char.code x) - 48
+  | 'A' .. 'Z' ->
+    (Char.code x) - 55
+  | 'a' .. 'z' ->
+    (Char.code x) - 97
+  | _ -> 16
+
+let parseStringLiteral s =
+  let len = String.length s in
+  let b = Buffer.create (String.length s) in
+
+  let rec loop i =
+    if i = len then
+      ()
+    else
+      let c = String.unsafe_get s i in
+      match c with
+      | '\\' as c ->
+        let nextIx = i + 1 in
+        if nextIx < len then
+          let nextChar = String.unsafe_get s nextIx in
+          begin match nextChar with
+          (* this is interesting:
+           * let x = "foo\
+           * bar"
+           * The `\` escapes the newline, as if there was nothing here.
+           * Essentialy transforming this piece of code in `let x = "foobar"`
+           *
+           * What is even more interesting is that any space or tabs after the
+           * escaped newline are also dropped.
+           * let x = "foo\
+           *          bar"
+           * is the same as `let x = "foobar"`
+           *)
+          | '\010' | '\013' ->
+            let i = ref (nextIx + 1) in
+            while !i < len && (
+              let c = String.unsafe_get s !i in
+              c = ' ' || c = '\t'
+            ) do
+              incr i
+            done;
+            loop !i
+          | 'n' ->
+            Buffer.add_char b '\010';
+            loop (nextIx + 1)
+          | 'r' ->
+            Buffer.add_char b '\013';
+            loop (nextIx + 1)
+          | 'b' ->
+            Buffer.add_char b '\008';
+            loop (nextIx + 1)
+          | 't' ->
+            Buffer.add_char b '\009';
+            loop (nextIx + 1)
+          | '\\' as c ->
+            Buffer.add_char b c;
+            loop (nextIx + 1)
+          | ' ' as c ->
+              Buffer.add_char b c;
+            loop (nextIx + 1)
+          | '\'' as c ->
+              Buffer.add_char b c;
+            loop (nextIx + 1)
+          | '\"' as c ->
+            Buffer.add_char b c;
+            loop (nextIx + 1)
+          | '0' .. '9' ->
+            if nextIx + 2 < len then
+              let c0 = nextChar in
+              let c1 = (String.unsafe_get s (nextIx + 1)) in
+              let c2 = (String.unsafe_get s (nextIx + 2)) in
+              let c =
+                100 * (Char.code c0 - 48) +
+                10 * (Char.code c1  - 48) +
+                (Char.code c2 - 48)
+              in
+              if (c < 0 || c > 255) then (
+                Buffer.add_char b '\\';
+                Buffer.add_char b c0;
+                Buffer.add_char b c1;
+                Buffer.add_char b c2;
+                loop (nextIx + 3)
+              ) else (
+                Buffer.add_char b (Char.unsafe_chr c);
+                loop (nextIx + 3)
+              )
+            else (
+              Buffer.add_char b '\\';
+              Buffer.add_char b nextChar;
+              loop (nextIx + 1)
+            )
+          | 'o' ->
+            if nextIx + 3 < len then
+              let c0 = (String.unsafe_get s (nextIx + 1)) in
+              let c1 = (String.unsafe_get s (nextIx + 2)) in
+              let c2 = (String.unsafe_get s (nextIx + 3)) in
+              let c =
+                64 * (Char.code c0 - 48) +
+                8 * (Char.code c1  - 48) +
+                (Char.code c2 - 48)
+              in
+              if (c < 0 || c > 255) then (
+                Buffer.add_char b '\\';
+                Buffer.add_char b '0';
+                Buffer.add_char b c0;
+                Buffer.add_char b c1;
+                Buffer.add_char b c2;
+                loop (nextIx + 4)
+              ) else (
+                Buffer.add_char b (Char.unsafe_chr c);
+                loop (nextIx + 4)
+              )
+            else (
+              Buffer.add_char b '\\';
+              Buffer.add_char b nextChar;
+              loop (nextIx + 1)
+            )
+          | 'x' as c ->
+            if nextIx + 2 < len then
+              let c0 = (String.unsafe_get s (nextIx + 1)) in
+              let c1 = (String.unsafe_get s (nextIx + 2)) in
+              let c = (16 * (hexValue c0)) + (hexValue c1) in
+              if (c < 0 || c > 255) then (
+                Buffer.add_char b '\\';
+                Buffer.add_char b 'x';
+                Buffer.add_char b c0;
+                Buffer.add_char b c1;
+                loop (nextIx + 3)
+              ) else (
+                Buffer.add_char b (Char.unsafe_chr c);
+                loop (nextIx + 3)
+              )
+            else (
+              Buffer.add_char b '\\';
+              Buffer.add_char b c;
+              loop (nextIx + 2)
+            )
+          | _ ->
+            Buffer.add_char b c;
+            Buffer.add_char b nextChar;
+            loop (nextIx + 1)
+          end
+        else (
+          Buffer.add_char b c;
+          ()
+        )
+      | c ->
+        Buffer.add_char b c;
+        loop (i + 1)
+    in
+    loop 0;
+    Buffer.contents b
+
+
 let rec parseLident p =
   let recoverLident p =
     if (
@@ -509,6 +667,7 @@ let parseHashIdent ~startPos p =
   match p.token with
   | String text ->
     Parser.next p;
+    let text = if p.mode = ParseForTypeChecker then parseStringLiteral text else text in
     (text, mkLoc startPos p.prevEndPos)
   | _ ->
     parseIdent ~startPos ~msg:ErrorMessages.variantIdent p
@@ -680,163 +839,6 @@ let parseOpenDescription ~attrs p =
   let loc = mkLoc startPos p.prevEndPos in
   Parser.eatBreadcrumb p;
   Ast_helper.Opn.mk ~loc ~attrs ~override modident
-
-let hexValue x =
-  match x with
-  | '0' .. '9' ->
-    (Char.code x) - 48
-  | 'A' .. 'Z' ->
-    (Char.code x) - 55
-  | 'a' .. 'z' ->
-    (Char.code x) - 97
-  | _ -> 16
-
-let parseStringLiteral s =
-  let len = String.length s in
-  let b = Buffer.create (String.length s) in
-
-  let rec loop i =
-    if i = len then
-      ()
-    else
-      let c = String.unsafe_get s i in
-      match c with
-      | '\\' as c ->
-        let nextIx = i + 1 in
-        if nextIx < len then
-          let nextChar = String.unsafe_get s nextIx in
-          begin match nextChar with
-          (* this is interesting:
-           * let x = "foo\
-           * bar"
-           * The `\` escapes the newline, as if there was nothing here.
-           * Essentialy transforming this piece of code in `let x = "foobar"`
-           *
-           * What is even more interesting is that any space or tabs after the
-           * escaped newline are also dropped.
-           * let x = "foo\
-           *          bar"
-           * is the same as `let x = "foobar"`
-           *)
-          | '\010' | '\013' ->
-            let i = ref (nextIx + 1) in
-            while !i < len && (
-              let c = String.unsafe_get s !i in
-              c = ' ' || c = '\t'
-            ) do
-              incr i
-            done;
-            loop !i
-          | 'n' ->
-            Buffer.add_char b '\010';
-            loop (nextIx + 1)
-          | 'r' ->
-            Buffer.add_char b '\013';
-            loop (nextIx + 1)
-          | 'b' ->
-            Buffer.add_char b '\008';
-            loop (nextIx + 1)
-          | 't' ->
-            Buffer.add_char b '\009';
-            loop (nextIx + 1)
-          | '\\' as c ->
-            Buffer.add_char b c;
-            loop (nextIx + 1)
-          | ' ' as c ->
-              Buffer.add_char b c;
-            loop (nextIx + 1)
-          | '\'' as c ->
-              Buffer.add_char b c;
-            loop (nextIx + 1)
-          | '\"' as c ->
-            Buffer.add_char b c;
-            loop (nextIx + 1)
-          | '0' .. '9' ->
-            if nextIx + 2 < len then
-              let c0 = nextChar in
-              let c1 = (String.unsafe_get s (nextIx + 1)) in
-              let c2 = (String.unsafe_get s (nextIx + 2)) in
-              let c =
-                100 * (Char.code c0 - 48) +
-                10 * (Char.code c1  - 48) +
-                (Char.code c2 - 48)
-              in
-              if (c < 0 || c > 255) then (
-                Buffer.add_char b '\\';
-                Buffer.add_char b c0;
-                Buffer.add_char b c1;
-                Buffer.add_char b c2;
-                loop (nextIx + 3)
-              ) else (
-                Buffer.add_char b (Char.unsafe_chr c);
-                loop (nextIx + 3)
-              )
-            else (
-              Buffer.add_char b '\\';
-              Buffer.add_char b nextChar;
-              loop (nextIx + 1)
-            )
-          | 'o' ->
-            if nextIx + 3 < len then
-              let c0 = (String.unsafe_get s (nextIx + 1)) in
-              let c1 = (String.unsafe_get s (nextIx + 2)) in
-              let c2 = (String.unsafe_get s (nextIx + 3)) in
-              let c =
-                64 * (Char.code c0 - 48) +
-                8 * (Char.code c1  - 48) +
-                (Char.code c2 - 48)
-              in
-              if (c < 0 || c > 255) then (
-                Buffer.add_char b '\\';
-                Buffer.add_char b '0';
-                Buffer.add_char b c0;
-                Buffer.add_char b c1;
-                Buffer.add_char b c2;
-                loop (nextIx + 4)
-              ) else (
-                Buffer.add_char b (Char.unsafe_chr c);
-                loop (nextIx + 4)
-              )
-            else (
-              Buffer.add_char b '\\';
-              Buffer.add_char b nextChar;
-              loop (nextIx + 1)
-            )
-          | 'x' as c ->
-            if nextIx + 2 < len then
-              let c0 = (String.unsafe_get s (nextIx + 1)) in
-              let c1 = (String.unsafe_get s (nextIx + 2)) in
-              let c = (16 * (hexValue c0)) + (hexValue c1) in
-              if (c < 0 || c > 255) then (
-                Buffer.add_char b '\\';
-                Buffer.add_char b 'x';
-                Buffer.add_char b c0;
-                Buffer.add_char b c1;
-                loop (nextIx + 3)
-              ) else (
-                Buffer.add_char b (Char.unsafe_chr c);
-                loop (nextIx + 3)
-              )
-            else (
-              Buffer.add_char b '\\';
-              Buffer.add_char b c;
-              loop (nextIx + 2)
-            )
-          | _ ->
-            Buffer.add_char b c;
-            Buffer.add_char b nextChar;
-            loop (nextIx + 1)
-          end
-        else (
-          Buffer.add_char b c;
-          ()
-        )
-      | c ->
-        Buffer.add_char b c;
-        loop (i + 1)
-    in
-    loop 0;
-    Buffer.contents b
 
 let parseTemplateStringLiteral s =
   let len = String.length s in
@@ -1137,6 +1139,7 @@ let rec parsePattern ?(alias=true) ?(or_=true) p =
       let (ident, loc) = match p.token with
       | String text ->
         Parser.next p;
+        let text = if p.mode = ParseForTypeChecker then parseStringLiteral text else text in
         (text, mkLoc startPos p.prevEndPos)
       | _ ->
         parseIdent ~msg:ErrorMessages.variantIdent ~startPos p

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -506,7 +506,12 @@ let parseIdent ~msg ~startPos p =
 
 let parseHashIdent ~startPos p =
   Parser.expect Hash p;
-  parseIdent ~startPos ~msg:ErrorMessages.variantIdent p
+  match p.token with
+  | String text ->
+    Parser.next p;
+    (text, mkLoc startPos p.prevEndPos)
+  | _ ->
+    parseIdent ~startPos ~msg:ErrorMessages.variantIdent p
 
 (* Ldot (Ldot (Lident "Foo", "Bar"), "baz") *)
 let parseValuePath p =
@@ -1129,7 +1134,13 @@ let rec parsePattern ?(alias=true) ?(or_=true) p =
       let loc = mkLoc startPos ident.loc.loc_end in
       Ast_helper.Pat.type_ ~loc ~attrs ident
     ) else (
-      let (ident, loc) = parseIdent ~msg:ErrorMessages.variantIdent ~startPos p in
+      let (ident, loc) = match p.token with
+      | String text ->
+        Parser.next p;
+        (text, mkLoc startPos p.prevEndPos)
+      | _ ->
+        parseIdent ~msg:ErrorMessages.variantIdent ~startPos p
+      in
       begin match p.Parser.token with
       | Lparen ->
         parseVariantPatternArgs p ident startPos attrs

--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -29,7 +29,7 @@ let classifyIdentContent ~allowUident txt =
       let c = String.unsafe_get txt i in
       if i == 0 && not (
         (allowUident && (c >= 'A' && c <= 'Z')) ||
-        (c >= 'a' && c <= 'z') || c = '_' || (c >= '0' && c <= '9')) then
+        (c >= 'a' && c <= 'z') || c = '_') then
         ExoticIdent
       else if not (
            (c >= 'a' && c <= 'z')
@@ -54,6 +54,15 @@ let printIdentLike ~allowUident txt =
       Doc.text txt;
       Doc.text"\""
     ]
+  | NormalIdent -> Doc.text txt
+
+let printPolyVarIdent txt =
+  match classifyIdentContent ~allowUident:true txt with
+  | ExoticIdent -> Doc.concat [
+     Doc.text "\"";
+     Doc.text txt;
+     Doc.text"\""
+   ]
   | NormalIdent -> Doc.text txt
 
   (* ReScript doesn't have parenthesized identifiers.
@@ -376,7 +385,7 @@ let printIdentLike ~allowUident txt =
              Doc.group (
                Doc.concat [
                  Doc.text "#";
-                 printIdentLike ~allowUident:true name;
+                 printPolyVarIdent name;
                  match types with
                  | [] -> Doc.nil
                  | types ->

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -342,7 +342,7 @@ let classifyIdentContent ?(allowUident=false) txt =
       let c = String.unsafe_get txt i in
       if i == 0 && not (
         (allowUident && (c >= 'A' && c <= 'Z')) ||
-        (c >= 'a' && c <= 'z') || c = '_' || (c >= '0' && c <= '9')) then
+        (c >= 'a' && c <= 'z') || c = '_' ) then
         ExoticIdent
       else if not (
            (c >= 'a' && c <= 'z')

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -369,6 +369,17 @@ let printIdentLike ?allowUident txt =
     ]
   | NormalIdent -> Doc.text txt
 
+(* Exotic identifiers in poly-vars have a "lighter" syntax: #"ease-in" *)
+let printPolyVarIdent txt =
+  match classifyIdentContent ~allowUident:true txt with
+  | ExoticIdent -> Doc.concat [
+      Doc.text "\"";
+      Doc.text txt;
+      Doc.text"\""
+    ]
+  | NormalIdent -> Doc.text txt
+
+
 let printLident l = match l with
   | Longident.Lident txt -> printIdentLike txt
   | Longident.Ldot (path, txt) ->
@@ -1655,7 +1666,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
       Doc.group (
         Doc.concat [
           printAttributes attrs cmtTbl;
-          Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true txt]
+          Doc.concat [Doc.text "#"; printPolyVarIdent txt]
         ]
       )
     | Rtag ({txt}, attrs, truth, types) ->
@@ -1669,7 +1680,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
       Doc.group (
         Doc.concat [
           printAttributes attrs cmtTbl;
-          Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true txt];
+          Doc.concat [Doc.text "#"; printPolyVarIdent txt];
           cases
         ]
       )
@@ -1691,7 +1702,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
     | Some([]) ->
       Doc.nil
     | Some(labels) ->
-      Doc.concat (List.map (fun label -> Doc.concat [Doc.line; Doc.text "#" ; printIdentLike ~allowUident:true label] ) labels)
+      Doc.concat (List.map (fun label -> Doc.concat [Doc.line; Doc.text "#" ; printPolyVarIdent label] ) labels)
     in
     let closingSymbol = if hasLabels then Doc.text " >" else Doc.nil in
     Doc.group (
@@ -2220,10 +2231,10 @@ and printPattern (p : Parsetree.pattern) cmtTbl =
     in
     Doc.group(Doc.concat [constrName; argsDoc])
   | Ppat_variant (label, None) ->
-    Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true label]
+    Doc.concat [Doc.text "#"; printPolyVarIdent label]
   | Ppat_variant (label, variantArgs) ->
     let variantName =
-      Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true label] in
+      Doc.concat [Doc.text "#"; printPolyVarIdent label] in
     let argsDoc = match variantArgs with
     | None -> Doc.nil
     | Some({ppat_desc = Ppat_construct ({txt = Longident.Lident "()"}, _)}) ->
@@ -2686,7 +2697,7 @@ and printExpression (e : Parsetree.expression) cmtTbl =
     )
   | Pexp_variant (label, args) ->
     let variantName =
-      Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true label] in
+      Doc.concat [Doc.text "#"; printPolyVarIdent label] in
     let args = match args with
     | None -> Doc.nil
     | Some({pexp_desc = Pexp_construct ({txt = Longident.Lident "()"}, _)}) ->

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -135,6 +135,12 @@ let computeAreaPlus = (sp: shapePlus) =>
   | #...shape as s => computeArea(s)
   }
 
+let computeAreaExotic = (sp) =>
+  switch sp {
+  | #"R-Triangle+"(_p1, _p2, _p3) => () 
+  | #...shape as s => ignore(s); ()
+  }
+
 let top = #Point(3.0, 5.0)
 let left = #Point(0.0, 0.0)
 let right = #Point(3.0, 0.0)
@@ -183,6 +189,11 @@ type t21 = [#"va r ia nt"]
 type t22 = [#"Variant ⛰"]
 type \"let" = int
 type \"type" = [ #"Point🗿"(\"let", float) ]
+type t23 = [
+  | #"1"
+  | #"10space"
+  | #"123"
+]
 
 type exoticUser = {
   \"let": string,

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -178,11 +178,11 @@ module type Conjunctive = {
 };
 
 // exotic idents in poly-vars
-type t20 = [#\"type"]
-type t21 = [#\"va r ia nt"]
-type t22 = [#\"Variant ⛰"]
+type t20 = [#"type"]
+type t21 = [#"va r ia nt"]
+type t22 = [#"Variant ⛰"]
 type \"let" = int
-type \"type" = [ #\"Point🗿"(\"let", float) ]
+type \"type" = [ #"Point🗿"(\"let", float) ]
 
 type exoticUser = {
   \"let": string,

--- a/tests/oprint/oprint.res.snapshot
+++ b/tests/oprint/oprint.res.snapshot
@@ -100,6 +100,11 @@ type shapePlus = [
   | #Triangle(point, point, point)
 ]
 let computeAreaPlus: shapePlus => float
+let computeAreaExotic: [<
+  | #Circle(point, float)
+  | #"R-Triangle+"('a, 'b, 'c)
+  | #Rectangle(point, point)
+] => unit
 let top: [> #Point(float, float)]
 let left: [> #Point(float, float)]
 let right: [> #Point(float, float)]
@@ -137,11 +142,12 @@ module type Conjunctive = {
   let f: [< #T([< u2]) & ([< u2]) & ([< u1])] => unit
   let g: [< #S & ([< u2]) & ([< u2]) & ([< u1])] => unit
 }
-type t20 = [#\"type"]
-type t21 = [#\"va r ia nt"]
-type t22 = [#\"Variant ⛰"]
+type t20 = [#"type"]
+type t21 = [#"va r ia nt"]
+type t22 = [#"Variant ⛰"]
 type \"let" = int
-type \"type" = [#\"Point🗿"(\"let", float)]
+type \"type" = [#"Point🗿"(\"let", float)]
+type t23 = [#"1" | #"10space" | #"123"]
 type exoticUser = {\"let": string, \"type": float}
 module Js = {
   module Fn = {

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -1146,7 +1146,8 @@ let constrainedExpr = (x : int)"
 exports[`polyvariant.js 1`] = `
 "let x = \`Red
 let z = \`Rgb ()
-let v = \`Vertex (1., 2., 3., 4.)"
+let v = \`Vertex (1., 2., 3., 4.)
+let animation = \`ease-in"
 `;
 
 exports[`primary.js 1`] = `

--- a/tests/parsing/grammar/expressions/polyvariant.js
+++ b/tests/parsing/grammar/expressions/polyvariant.js
@@ -1,7 +1,8 @@
 let x = #Red
 
-
 // sugar for Rgb(())
 let z = #Rgb()
 
 let v = #Vertex(1., 2., 3., 4.)
+
+let animation = #"ease-in"

--- a/tests/parsing/grammar/pattern/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/pattern/__snapshots__/parse.spec.js.snap
@@ -528,7 +528,8 @@ let cmp selectedChoice value =
   | (#a : typ) -> true
   | (lazy #a) -> true
   | exception #a -> true
-  | _ -> false"
+  | _ -> false
+;;match polyVar with | \`ease-in -> () | \`ease-out⛰ -> () | _ -> ()"
 `;
 
 exports[`record.js 1`] = `

--- a/tests/parsing/grammar/pattern/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/pattern/__snapshots__/parse.spec.js.snap
@@ -529,7 +529,11 @@ let cmp selectedChoice value =
   | (lazy #a) -> true
   | exception #a -> true
   | _ -> false
-;;match polyVar with | \`ease-in -> () | \`ease-out⛰ -> () | _ -> ()"
+;;match polyVar with
+  | \`ease-in -> ()
+  | \`ease-out⛰ -> ()
+  | \`ease+++ (\`1Blue, \`r+) -> ()
+  | _ -> ()"
 `;
 
 exports[`record.js 1`] = `

--- a/tests/parsing/grammar/pattern/polyvariants.js
+++ b/tests/parsing/grammar/pattern/polyvariants.js
@@ -102,5 +102,6 @@ let cmp = (selectedChoice, value) =>
 switch polyVar {
 | #"ease-in" => ()
 | #"ease-out⛰" => ()
+| #"ease+++"(#"1Blue", #"r+") => ()
 | _ => ()
 }

--- a/tests/parsing/grammar/pattern/polyvariants.js
+++ b/tests/parsing/grammar/pattern/polyvariants.js
@@ -98,3 +98,9 @@ let cmp = (selectedChoice, value) =>
   | exception #...a => true
   | _ => false
   }
+
+switch polyVar {
+| #"ease-in" => ()
+| #"ease-out⛰" => ()
+| _ => ()
+}

--- a/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
@@ -130,7 +130,19 @@ exports[`poly.js 1`] = `
       Js.t = \\"./src/logger.mock.js\\""
 `;
 
-exports[`polyVariant.res 1`] = `"type nonrec animation = [ \`ease-in  | \`ease-out  | \`never ease ✍️ ]"`;
+exports[`polyVariant.res 1`] = `
+"type nonrec animation = [ \`ease-in  | \`ease-out  | \`never ease ✍️ ]
+module type Conjunctive  =
+  sig
+    type nonrec u1 = [ \`A  | \`B ]
+    type nonrec u2 = [ \`A  | \`B  | \`C ]
+    val f : [< \`T of [< u2]&[< u2]&[< u1] ] -> unit
+    val g : [< \`S of [< u2]&[< u2]&[< u1] ] -> unit
+    val g :
+      [< \`Exotic-S+ of [< \`Exotic-u2+ ]&[< \`Exotic-u2- ]&[< \`Exotic-u1+++ ] ]
+        -> unit
+  end"
+`;
 
 exports[`tuple.js 1`] = `
 "type nonrec t = (string * int)

--- a/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
@@ -130,6 +130,8 @@ exports[`poly.js 1`] = `
       Js.t = \\"./src/logger.mock.js\\""
 `;
 
+exports[`polyVariant.res 1`] = `"type nonrec animation = [ \`ease-in  | \`ease-out  | \`never ease ✍️ ]"`;
+
 exports[`tuple.js 1`] = `
 "type nonrec t = (string * int)
 type nonrec t = (int option * string option)

--- a/tests/parsing/grammar/typexpr/polyVariant.res
+++ b/tests/parsing/grammar/typexpr/polyVariant.res
@@ -1,0 +1,5 @@
+type animation = [
+  | #"ease-in"
+  | #"ease-out"
+  | #"never ease ✍️"
+]

--- a/tests/parsing/grammar/typexpr/polyVariant.res
+++ b/tests/parsing/grammar/typexpr/polyVariant.res
@@ -3,3 +3,12 @@ type animation = [
   | #"ease-out"
   | #"never ease ✍️"
 ]
+
+module type Conjunctive = {
+  type u1 = [ | #A | #B]
+  type u2 = [ | #A | #B | #C]
+
+  let f: [< | #T([< u2]) & ([< u2]) & ([< u1])] => unit
+  let g: [< | #S&([< u2]) & ([< u2]) & ([< u1])] => unit
+  let g: [< | #"Exotic-S+"&([< #"Exotic-u2+"]) & ([< #"Exotic-u2-"]) & ([< #"Exotic-u1+++"])] => unit
+};

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -3241,6 +3241,16 @@ let r = #lident(a, b)
 let r = #\\"exotic lident\\"
 let r = #\\"exotic lident\\"(a, b)
 
+let x = #\\"1\\"
+let x = #\\"123\\"
+let x = #\\"10space\\"
+let x = #space10
+
+let a = #\\"1\\"
+let b = #\\"1a\\"
+let c = #a2
+let d = #abcd
+
 external openSync: (
   path,
   @bs.string

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -3233,13 +3233,13 @@ switch x {
 | #...typevar => 42
 }
 
-let r = #\\\\\\"Reducer⛪️\\"
-let r = #\\\\\\"type\\"(\\\\\\"module\\", \\\\\\"let\\")
+let r = #\\"Reducer⛪️\\"
+let r = #\\"type\\"(\\\\\\"module\\", \\\\\\"let\\")
 
 let r = #lident
 let r = #lident(a, b)
-let r = #\\\\\\"exotic lident\\"
-let r = #\\\\\\"exotic lident\\"(a, b)
+let r = #\\"exotic lident\\"
+let r = #\\"exotic lident\\"(a, b)
 
 external openSync: (
   path,

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -3251,6 +3251,8 @@ let b = #\\"1a\\"
 let c = #a2
 let d = #abcd
 
+#BigBlue(#\\"Shade-of-blue+++\\", #\\"Shade-of-blue---\\")
+
 external openSync: (
   path,
   @bs.string

--- a/tests/printer/expr/polyvariant.js
+++ b/tests/printer/expr/polyvariant.js
@@ -104,6 +104,16 @@ let r = #lident(a, b)
 let r = #\"exotic lident"
 let r = #\"exotic lident"(a, b)
 
+let x = #"1"
+let x = #"123"
+let x = #"10space"
+let x = #space10
+
+let a = #"1"
+let b = #"1a"
+let c = #a2
+let d = #abcd
+
 external openSync: (
   path,
   @bs.string [

--- a/tests/printer/expr/polyvariant.js
+++ b/tests/printer/expr/polyvariant.js
@@ -114,6 +114,8 @@ let b = #"1a"
 let c = #a2
 let d = #abcd
 
+#"BigBlue"(#"Shade-of-blue+++", #"Shade-of-blue---")
+
 external openSync: (
   path,
   @bs.string [

--- a/tests/printer/pattern/__snapshots__/render.spec.js.snap
+++ b/tests/printer/pattern/__snapshots__/render.spec.js.snap
@@ -402,14 +402,14 @@ let list = 3
 exports[`variant.res 1`] = `
 "let #shape = x
 let #Shape = x
-let #\\\\\\"type\\" = x
-let #\\\\\\"test 🏚\\" = x
-let #\\\\\\"Shape✅\\" = x
+let #\\"type\\" = x
+let #\\"test 🏚\\" = x
+let #\\"Shape✅\\" = x
 
 let #Shape(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
 
-let #\\\\\\"type\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
-let #\\\\\\"Shape🎡\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
+let #\\"type\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
+let #\\"Shape🎡\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
 
 let cmp = (selectedChoice, value) =>
   switch (selectedChoice, value) {

--- a/tests/printer/pattern/__snapshots__/render.spec.js.snap
+++ b/tests/printer/pattern/__snapshots__/render.spec.js.snap
@@ -153,6 +153,8 @@ exports[`exoticIdent.res 1`] = `
 let {\\\\\\"type\\", \\\\\\"module\\"} = x
 let {\\\\\\"type\\": \\\\\\"let\\", \\\\\\"module\\": \\\\\\"DangerousPattern\\"} = x
 let {Foo.\\\\\\"type\\": \\\\\\"let\\", \\\\\\"module\\": \\\\\\"DangerousPattern\\"} = x
+
+let \\\\\\"1\\" = x
 "
 `;
 
@@ -405,6 +407,11 @@ let #Shape = x
 let #\\"type\\" = x
 let #\\"test 🏚\\" = x
 let #\\"Shape✅\\" = x
+let #\\"1\\" = x
+let #\\"123\\" = x
+let #\\"10space\\" = x
+
+let #space10 = x
 
 let #Shape(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
 
@@ -424,6 +431,10 @@ let cmp = (selectedChoice, value) =>
   | (#...a: typ) => true
   | lazy #...a => true
   | exception #...a => true
+  | #\\"1\\" => true
+  | #\\"123\\" => true
+  | #\\"10space\\" => x
+  | #space10 => x
   | _ => false
   }
 "

--- a/tests/printer/pattern/exoticIdent.res
+++ b/tests/printer/pattern/exoticIdent.res
@@ -3,3 +3,5 @@ let \"type" = x
 let {\"type", \"module"} = x
 let {\"type": \"let", \"module": \"DangerousPattern"} = x
 let {Foo.\"type": \"let", \"module": \"DangerousPattern"} = x
+
+let \"1" = x

--- a/tests/printer/pattern/variant.res
+++ b/tests/printer/pattern/variant.res
@@ -3,6 +3,11 @@ let #Shape = x
 let #\"type" = x
 let #\"test 🏚" = x
 let #\"Shape✅" = x
+let #"1" = x
+let #"123" = x
+let #"10space" = x
+
+let #space10 = x
 
 let #Shape(\"module", \"ExoticIdent") = x
 
@@ -22,5 +27,9 @@ let cmp = (selectedChoice, value) =>
   | (#...a : typ) => true
   | lazy #...a => true
   | exception #...a => true
+  | #"1" => true
+  | #"123" => true
+  | #"10space" => x
+  | #space10 => x
   | _ => false
   }

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -588,17 +588,17 @@ type color = [rgb | #Orange | #Yellow | #Purple]
 
 type t = [#variant]
 type t = [#Variant]
-type t = [#\\\\\\"type\\"]
-type t = [#\\\\\\"va r ia nt\\"]
-type t = [#\\\\\\"Variant ⛰\\"]
+type t = [#\\"type\\"]
+type t = [#\\"va r ia nt\\"]
+type t = [#\\"Variant ⛰\\"]
 
 let id = (x: [> #Red | #Green | #Blue]) => x
 let upper = (x: [< #Red | #Green]) => true
 type point = [#Point(float, float)]
-type \\\\\\"type\\" = [#\\\\\\"Point🗿\\"(\\\\\\"let\\", float)]
+type \\\\\\"type\\" = [#\\"Point🗿\\"(\\\\\\"let\\", float)]
 type shape = [#Rectangle(point, point) | #Circle(point, float)]
 
-type madness = [< #\\\\\\"type\\" & (\\\\\\"let\\") & (\\\\\\"Super exotic\\") | #\\\\\\"Bad Idea\\"]
+type madness = [< #\\"type\\" & (\\\\\\"let\\") & (\\\\\\"Super exotic\\") | #\\"Bad Idea\\"]
 
 let error_of_exn: exn => option<[#Ok(error) | #Already_displayed]> = x
 

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -647,5 +647,21 @@ type x = [
   | #Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
   | #Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz
 ]
+
+type animation = [#\\"ease-in\\" | #\\"ease-out\\" | #\\"never ease ✍️\\"]
+
+module type Conjunctive = {
+  type u1 = [#A | #B]
+  type u2 = [#A | #B | #C]
+
+  let f: [< #T([< u2]) & ([< u2]) & ([< u1])] => unit
+  let g: [< #S & ([< u2]) & ([< u2]) & ([< u1])] => unit
+  let g: [<
+    | #\\"Exotic-S+\\"
+    & ([< #\\"Exotic-u2+\\"])
+    & ([< #\\"Exotic-u2-\\"])
+    & ([< #\\"Exotic-u1+++\\"])
+  ] => unit
+}
 "
 `;

--- a/tests/printer/typexpr/variant.js
+++ b/tests/printer/typexpr/variant.js
@@ -67,3 +67,18 @@ type x = [
   | #Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
   | #Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz
 ]
+
+type animation = [
+  | #"ease-in"
+  | #"ease-out"
+  | #"never ease ✍️"
+]
+
+module type Conjunctive = {
+  type u1 = [ | #A | #B]
+  type u2 = [ | #A | #B | #C]
+
+  let f: [< | #T([< u2]) & ([< u2]) & ([< u1])] => unit
+  let g: [< | #S&([< u2]) & ([< u2]) & ([< u1])] => unit
+  let g: [< | #"Exotic-S+"&([< #"Exotic-u2+"]) & ([< #"Exotic-u2-"]) & ([< #"Exotic-u1+++"])] => unit
+};


### PR DESCRIPTION
Implements https://github.com/BuckleScript/syntax/issues/76 and fixes https://github.com/rescript-lang/syntax/issues/225

The syntax for exotic identifiers in poly-variants is quite heavy: `#\"ease-in"`.
By extending the syntax for poly-variants with a string syntax, we get a lighter weight version that is more pleasant to read and write:
```
poly-var ::=
  HASH STRING
```
Example:
```ocaml
type animation = [ #"ease-in" | #"ease-out" ]
```

There was a previous [PR](https://github.com/rescript-lang/syntax/pull/96) for this. That one didn't ship as we weren't 100% sure of all the implications. Poly variants are essentially strings now, so this would make a great fit. Let's do this.