### PR TITLE
Print attributes without the @bs prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Print attributes/extension without bs prefix where possible in [#230](https://github.com/rescript-lang/syntax/pull/230)
 * Cleanup gentype attribute printing [fe05e1051aa94b16f6993ddc5ba9651f89e86907](https://github.com/rescript-lang/syntax/commit/fe05e1051aa94b16f6993ddc5ba9651f89e86907)
 * Implement light weight syntax for poly-variants [f84c5760b3f743f65e934195c87fc06bf88bff75](https://github.com/rescript-lang/syntax/commit/f84c5760b3f743f65e934195c87fc06bf88bff75)
 * Fix bug in fast pipe conversion from Reason. [3d5f2daba5418b821c577ba03e2de1afb0dd66de](https://github.com/rescript-lang/syntax/commit/3d5f2daba5418b821c577ba03e2de1afb0dd66de)

--- a/src/res_ast_conversion.ml
+++ b/src/res_ast_conversion.ml
@@ -321,6 +321,36 @@ let stringLiteralMapper stringData =
 let normalize =
   let open Ast_mapper in
   { default_mapper with
+    attribute = (fun mapper attr ->
+      match attr with
+      | (id, payload) ->
+        (* Reminder, keep this in sync with src/res_printer.ml *)
+        let contents = match id.txt with
+        | "bs.val" -> "val"
+        | "bs.module" -> "module"
+        | "bs.scope" -> "scope"
+        | "bs.splice" | "bs.variadic" -> "variadic"
+        | "bs.set" -> "set"
+        | "bs.set_index" -> "set_index"
+        | "bs.get" -> "get"
+        | "bs.get_index" -> "get_index"
+        | "bs.new" -> "new"
+        | "bs.obj" -> "obj"
+        | "bs.return" -> "return"
+        | "bs.uncurry" -> "uncurry"
+        | "bs.this" -> "this"
+        | "bs.meth" -> "meth"
+        | "bs.deriving" -> "deriving"
+        | "bs.string" -> "string"
+        | "bs.int" -> "int"
+        | "bs.ignore" -> "ignore"
+        | "bs.unwrap" -> "unwrap"
+        | "bs.as" -> "as"
+        | "bs.optional" -> "optional"
+        | txt -> txt
+        in
+        ({id with txt = contents}, default_mapper.payload mapper payload)
+    );
     attributes = (fun mapper attrs ->
       attrs
       |> List.filter (fun attr ->

--- a/src/res_ast_conversion.ml
+++ b/src/res_ast_conversion.ml
@@ -321,6 +321,17 @@ let stringLiteralMapper stringData =
 let normalize =
   let open Ast_mapper in
   { default_mapper with
+    extension = (fun mapper ext ->
+      match ext with
+      | (id, payload) ->
+        let contents = match id.txt with
+        | "bs.raw" -> "raw"
+        | "bs.obj" -> "obj"
+        | txt -> txt
+        in
+        ({id with txt = contents}, default_mapper.payload mapper payload)
+
+    );
     attribute = (fun mapper attr ->
       match attr with
       | (id, payload) ->

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -879,7 +879,7 @@ let rec walkStructure s t comments =
         attach t.trailing expr2.pexp_loc trailing
       )
     | Pexp_extension (
-        {txt = "bs.obj"},
+        {txt = "bs.obj" | "obj"},
         PStr [{
           pstr_desc = Pstr_eval({pexp_desc = Pexp_record (rows, _)}, [])
         }]

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2919,7 +2919,7 @@ and parseRecordExprWithStringKeys ~startPos firstRow p =
     Ast_helper.Exp.record ~loc rows None
   ) in
   Ast_helper.Exp.extension ~loc
-    (Location.mkloc "bs.obj" loc, Parsetree.PStr [recordStrExpr])
+    (Location.mkloc "obj" loc, Parsetree.PStr [recordStrExpr])
 
 and parseRecordExpr ~startPos ?(spread=None) rows p =
   let exprs =

--- a/src/res_js_ffi.ml
+++ b/src/res_js_ffi.ml
@@ -39,7 +39,7 @@ let importDescr ~attrs ~scope ~importSpec ~loc = {
 }
 
 let toParsetree importDescr =
-  let bsVal = (Location.mknoloc "bs.val", Parsetree.PStr []) in
+  let bsVal = (Location.mknoloc "val", Parsetree.PStr []) in
   let attrs = match importDescr.jid_scope with
   | Global -> [bsVal]
   (* @genType.import("./MyMath"),
@@ -63,7 +63,7 @@ let toParsetree importDescr =
       Ast_helper.Str.eval expr
     in
     let bsScope = (
-      Location.mknoloc "bs.scope",
+      Location.mknoloc "scope",
       Parsetree. PStr [structureItem]
     ) in
     [bsVal; bsScope]

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -193,7 +193,7 @@ let isHuggableExpression expr =
   | Pexp_tuple _
   | Pexp_constant (Pconst_string (_, Some _))
   | Pexp_construct ({txt = Longident.Lident ("::" | "[]")}, _)
-  | Pexp_extension ({txt = "bs.obj"}, _)
+  | Pexp_extension ({txt = "bs.obj" | "obj"}, _)
   | Pexp_record _ -> true
   | _ when isBlockExpr expr -> true
   | _ when isBracedExpr expr -> true
@@ -205,7 +205,7 @@ let isHuggableRhs expr =
   | Pexp_array _
   | Pexp_tuple _
   | Pexp_construct ({txt = Longident.Lident ("::" | "[]")}, _)
-  | Pexp_extension ({txt = "bs.obj"}, _)
+  | Pexp_extension ({txt = "bs.obj" | "obj"}, _)
   | Pexp_record _ -> true
   | _ when isBracedExpr expr -> true
   | _ -> false

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -1973,11 +1973,16 @@ and printPackageConstraint i cmtTbl (longidentLoc, typ) =
   ]
 
 and printExtension ~atModuleLvl (stringLoc, payload) cmtTbl =
+  let txt = match stringLoc.Location.txt with
+  | "bs.raw" -> "raw"
+  | "bs.obj" -> "obj"
+  | txt -> txt
+  in
   let extName =
     let doc = Doc.concat [
       Doc.text "%";
       if atModuleLvl then Doc.text "%" else Doc.nil;
-      Doc.text stringLoc.Location.txt;
+      Doc.text txt
     ] in
     printComments doc cmtTbl stringLoc.Location.loc
   in

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4730,10 +4730,34 @@ and printPayload (payload : Parsetree.payload) cmtTbl =
     ]
 
 and printAttribute ((id, payload) : Parsetree.attribute) cmtTbl =
+  let contents = match id.txt with
+  | "bs.val" -> "val"
+  | "bs.module" -> "module"
+  | "bs.scope" -> "scope"
+  | "bs.splice" | "bs.variadic" -> "variadic"
+  | "bs.set" -> "set"
+  | "bs.set_index" -> "set_index"
+  | "bs.get" -> "get"
+  | "bs.get_index" -> "get_index"
+  | "bs.new" -> "new"
+  | "bs.obj" -> "obj"
+  | "bs.return" -> "return"
+  | "bs.uncurry" -> "uncurry"
+  | "bs.this" -> "this"
+  | "bs.meth" -> "meth"
+  | "bs.deriving" -> "deriving"
+  | "bs.string" -> "string"
+  | "bs.int" -> "int"
+  | "bs.ignore" -> "ignore"
+  | "bs.unwrap" -> "unwrap"
+  | "bs.as" -> "as"
+  | "bs.optional" -> "optional"
+  | txt -> txt
+  in
   Doc.group (
     Doc.concat [
       Doc.text "@";
-      Doc.text id.txt;
+      Doc.text contents;
       printPayload payload cmtTbl
     ]
   )

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2709,7 +2709,7 @@ and printExpression (e : Parsetree.expression) cmtTbl =
   | Pexp_extension extension ->
     begin match extension with
     | (
-        {txt = "bs.obj"},
+        {txt = "bs.obj" | "obj"},
         PStr [{
           pstr_loc = loc;
           pstr_desc = Pstr_eval({pexp_desc = Pexp_record (rows, _)}, [])

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1007,12 +1007,15 @@ let x = 1
 
 exports[`extension.re 1`] = `
 "// here
-%%bs.raw(\` eval(
+%%raw(\` eval(
 __gc,
 1,
 0
 )
   \`)
+
+let x = %raw(\\"10\\")
+let y = %raw(\\"20\\")
 "
 `;
 
@@ -1327,7 +1330,9 @@ let x = 1
 `;
 
 exports[`string.re 1`] = `
-"%%bs.raw(\\"define(x.y, 'userAgent', {value: 'USER_AGENT_STRING'})\\")
+"%%raw(\\"define(x.y, 'userAgent', {value: 'USER_AGENT_STRING'})\\")
+
+%%raw(\\"define(x.y, 'userAgent', {value: 'USER_AGENT_STRING'})\\")
 
 let x = \`This is a long string with a slash and line break \\\\\\\\
 carriage return\`

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1246,7 +1246,7 @@ module Form = %form(
     name: string,
     email: string,
     message: string,
-    @bs.as(\\"form-name\\")
+    @as(\\"form-name\\")
     formName: string,
   }
   type output = input

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1086,6 +1086,9 @@ exports[`jsObject.re 1`] = `
 "let component = props[\\"Component\\"]
 
 let element = props[\\"element\\"]
+
+let y = {\\"age\\": 30}
+let y = {\\"age\\": 30, \\"name\\": \\"steve\\"}
 "
 `;
 

--- a/tests/conversion/reason/extension.re
+++ b/tests/conversion/reason/extension.re
@@ -5,3 +5,6 @@ __gc,
 0
 )
   |}]
+
+let x = [%bs.raw "10"]
+let y = [%raw "20"]

--- a/tests/conversion/reason/jsObject.re
+++ b/tests/conversion/reason/jsObject.re
@@ -1,3 +1,6 @@
 let component = props##"Component"
 
 let element = props##element
+
+let y = {"age": 30}
+let y = {"age": 30, "name": "steve"}

--- a/tests/conversion/reason/string.re
+++ b/tests/conversion/reason/string.re
@@ -1,6 +1,9 @@
 %bs.raw
 "define(x.y, 'userAgent', {value: 'USER_AGENT_STRING'})";
 
+%raw
+"define(x.y, 'userAgent', {value: 'USER_AGENT_STRING'})";
+
 let x = {js|This is a long string with a slash and line break \
 carriage return|js};
 

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -281,10 +281,10 @@ let x = ((let a = 1 in let b = 2 in a + b)[@ns.braces ])
 `;
 
 exports[`bsObject.js 1`] = `
-"let x = [%bs.obj { age = 30 }]
-let y = [%bs.obj { age = 30 }]
-let y = [%bs.obj { age = 30; name = \\"steve\\" }]
-let y = [%bs.obj { age = 30; name = \\"steve\\" }]
+"let x = [%obj { age = 30 }]
+let y = [%obj { age = 30 }]
+let y = [%obj { age = 30; name = \\"steve\\" }]
+let y = [%obj { age = 30; name = \\"steve\\" }]
 let x = ((\\"age\\")[@ns.braces ])
 let x = ((\\"age\\".(0))[@ns.braces ])
 let x = ((\\"age\\" |. Js.log)[@ns.braces ])

--- a/tests/parsing/grammar/structure/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/structure/__snapshots__/parse.spec.js.snap
@@ -62,27 +62,25 @@ exports[`jsFfiSugar.js 1`] = `
 "include
   struct
     external setTimeout : (unit -> unit) -> unit -> float = \\"setTimeout\\"
-    [@@bs.val ]
+    [@@val ]
   end[@@ns.jsFfi ]
 include
   struct
-    external timeout : (unit -> unit) -> unit -> float = \\"setTimeout\\"
-    [@@bs.val ]
+    external timeout : (unit -> unit) -> unit -> float = \\"setTimeout\\"[@@val ]
   end[@@ns.jsFfi ]
 include
   struct
     external setTimeout : (unit -> unit) -> unit -> float = \\"setTimeout\\"
-    [@@bs.val ]
-    external clearTimeout : float -> unit = \\"clearTimeout\\"[@@bs.val ]
+    [@@val ]
+    external clearTimeout : float -> unit = \\"clearTimeout\\"[@@val ]
   end[@@ns.jsFfi ]
 include
   struct
-    external random : unit -> float = \\"random\\"[@@bs.val ][@@bs.scope \\"Math\\"]
+    external random : unit -> float = \\"random\\"[@@val ][@@scope \\"Math\\"]
   end[@@ns.jsFfi ]
 include
   struct
-    external href : string = \\"href\\"[@@bs.val ][@@bs.scope
-                                                (\\"window\\", \\"location\\")]
+    external href : string = \\"href\\"[@@val ][@@scope (\\"window\\", \\"location\\")]
   end[@@ns.jsFfi ]
 include
   struct

--- a/tests/ppx/react/__snapshots__/render.spec.js.snap
+++ b/tests/ppx/react/__snapshots__/render.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`commentAtTop.res 1`] = `
-"@bs.obj
+"@obj
 external makeProps: (~msg: 'msg, ~key: string=?, unit) => {\\"msg\\": 'msg} = \\"\\" // test React JSX file
 
 let make =
@@ -17,14 +17,14 @@ let make = {
 
 exports[`externalWithCustomName.res 1`] = `
 "module Foo = {
-  @bs.obj
+  @obj
   external componentProps: (
     ~a: int,
     ~b: string,
     ~key: string=?,
     unit,
   ) => {\\"a\\": int, \\"b\\": string} = \\"\\"
-  @bs.module(\\"Foo\\")
+  @module(\\"Foo\\")
   external component: React.componentLike<
     {\\"a\\": int, \\"b\\": string},
     React.element,
@@ -40,7 +40,7 @@ let t = React.createElement(
 
 exports[`innerModule.res 1`] = `
 "module Bar = {
-  @bs.obj
+  @obj
   external makeProps: (
     ~a: 'a,
     ~b: 'b,
@@ -57,7 +57,7 @@ exports[`innerModule.res 1`] = `
       make(~b=\\\\\\"Props\\"[\\"b\\"], ~a=\\\\\\"Props\\"[\\"a\\"], ())
     \\\\\\"InnerModule$Bar\\"
   }
-  @bs.obj
+  @obj
   external componentProps: (
     ~a: 'a,
     ~b: 'b,
@@ -80,7 +80,7 @@ exports[`innerModule.res 1`] = `
 `;
 
 exports[`topLevel.res 1`] = `
-"@bs.obj
+"@obj
 external makeProps: (
   ~a: 'a,
   ~b: 'b,

--- a/tests/ppx/react/externalWithCustomName.res
+++ b/tests/ppx/react/externalWithCustomName.res
@@ -1,5 +1,5 @@
 module Foo = {
-  @react.component @bs.module("Foo")
+  @react.component @module("Foo")
   external component: (~a: int, ~b: string, _) => React.element = "component"
 }
 

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -1381,7 +1381,7 @@ let /* before */ module(/* h1 */ Hashtbl /* h2 */: /* h3 */ MutableTable /* h4 *
 let /* before */ exception /* c0 */ Exit /* c1 */ /* after */ = exc
 
 // Ppat_extension
-let /* before */ %bs.raw(\\"eval(gc())\\") /* after */ = stuff
+let /* before */ %raw(\\"eval(gc())\\") /* after */ = stuff
 
 // Ppat_interval
 let /* c0 */ 'a' .. 'z' /* c1 */ = x

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -1732,32 +1732,32 @@ type /* c0 */ color /* c1 */ = /* before manifest */ Colour.t /* after manifest 
 }
 
 type domProps = {
-  @bs.optional
+  @optional
   viewTarget: string,
-  @bs.optional
+  @optional
   visibility: string,
   /* width::string? => */
-  @bs.optional
+  @optional
   widths: string,
-  @bs.optional
+  @optional
   wordSpacing: string,
-  @bs.optional
+  @optional
   writingMode: string,
-  @bs.optional
+  @optional
   x: string,
-  @bs.optional
+  @optional
   x1: string,
 }
 
-@bs.deriving(abstract)
+@deriving(abstract)
 type t = {
   /* MDX shortnames for more advanced components */
-  @bs.as(\\"Cite\\")
+  @as(\\"Cite\\")
   cite: React.component<{
     \\"author\\": option<string>,
     \\"children\\": React.element,
   }>,
-  @bs.as(\\"Info\\") @bs.optional
+  @as(\\"Info\\") @optional
   info: React.component<props>,
 }
 

--- a/tests/printer/comments/pattern.res
+++ b/tests/printer/comments/pattern.res
@@ -67,7 +67,7 @@ let /* before */ module(/* h1 */ Hashtbl /* h2 */: /* h3 */ MutableTable /* h4 *
 let /* before */ exception /* c0 */ Exit /* c1 */ /* after */ = exc
 
 // Ppat_extension
-let /* before */ %bs.raw("eval(gc())") /* after */ = stuff
+let /* before */ %raw("eval(gc())") /* after */ = stuff
 
 // Ppat_interval
 let /* c0 */ 'a' .. 'z' /* c1 */ = x

--- a/tests/printer/comments/typeDefinition.js
+++ b/tests/printer/comments/typeDefinition.js
@@ -58,32 +58,32 @@ type /* c0 */ color /* c1 */ = /* before manifest */ Colour.t /* after manifest 
 }
 
 type domProps =  {
-  @bs.optional
+  @optional
   viewTarget: string,
-  @bs.optional
+  @optional
   visibility: string,
   /*width::string? =>*/
-  @bs.optional
+  @optional
   widths: string,
-  @bs.optional
+  @optional
   wordSpacing: string,
-  @bs.optional
+  @optional
   writingMode: string,
-  @bs.optional
+  @optional
   x: string,
-  @bs.optional
+  @optional
   x1: string,
 }
 
-@bs.deriving(abstract)
+@deriving(abstract)
 type t = {
   /* MDX shortnames for more advanced components */
-  @bs.as("Cite")
+  @as("Cite")
   cite: React.component<{
     "author": option<string>,
     "children": React.element,
   }>,
-  @bs.as("Info") @bs.optional
+  @as("Info") @optional
   info: React.component<props>,
 }
 

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -638,8 +638,8 @@ let x =
     regainPerform()
   }
 
-let x = a && %bs.raw(\\"true\\")
-let x = a && %bs.raw(\\"true\\") && %bs.raw(\\"false\\")
+let x = a && %raw(\\"true\\")
+let x = a && %raw(\\"true\\") && %raw(\\"false\\")
 
 let x = a && module(Foo)
 let x = a && module(Foo) && module(Bar)
@@ -794,7 +794,7 @@ let reifyStyle = (type a, x: 'a): (style<a>, a) => {
     @val external canvasGradient: constructor = \\"CanvasGradient\\" /* internal */
     @val external canvasPattern: constructor = \\"CanvasPattern\\" /* internal */
     let instanceOf = (
-      %bs.raw(\`function(x,y) {return +(x instanceof y)}\`): (
+      %raw(\`function(x,y) {return +(x instanceof y)}\`): (
         'a,
         constructor,
       ) => bool
@@ -1800,15 +1800,15 @@ let x = <div \\\\\\"aria-foo\\"=\\\\\\"type\\"> \\\\\\"module\\" \\\\\\"let\\" <
 
 exports[`extension.js 1`] = `
 "let x = %eval
-let node = %bs.raw(\\"0\\")
-let node = %bs.raw(@attr (\\"0\\"))
-let node = %bs.raw(@attrStructureLvl (@attrOnExpr \\"0\\"))
+let node = %raw(\\"0\\")
+let node = %raw(@attr (\\"0\\"))
+let node = %raw(@attrStructureLvl (@attrOnExpr \\"0\\"))
 
-let node = %bs.raw(
+let node = %raw(
   @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3
   (@attrOnExpr \\"0\\")
 )
-let node = %bs.raw(
+let node = %raw(
   @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3
   (
     @attrOnExpr @attrOnExpr2 @attrOnExpr3 @attrOnExpr4 @attrOnExpr5
@@ -1827,7 +1827,7 @@ switch %external(__DEV__) {
 | None => Js.log(\\"production mode\\")
 }
 
-let node = @attr %bs.raw(\\"0\\")
+let node = @attr %raw(\\"0\\")
 "
 `;
 
@@ -2792,7 +2792,7 @@ let x =
       open React
       React.render()
     }
-    extension=%bs.raw(\\"eval()\\")
+    extension=%raw(\\"eval()\\")
     jsObject={\\"x\\": 1, \\"y\\": 2}
     withAttr={@attr foo}
   />
@@ -2872,7 +2872,7 @@ let x =
       open React
       React.render()
     }
-    %bs.raw(\\"eval()\\")
+    %raw(\\"eval()\\")
     {\\"x\\": 1, \\"y\\": 2}
     {@attr ident}
   </div>

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -791,9 +791,8 @@ let () = {
 let reifyStyle = (type a, x: 'a): (style<a>, a) => {
   module Internal = {
     type rec constructor
-    @bs.val
-    external canvasGradient: constructor = \\"CanvasGradient\\" /* internal */
-    @bs.val external canvasPattern: constructor = \\"CanvasPattern\\" /* internal */
+    @val external canvasGradient: constructor = \\"CanvasGradient\\" /* internal */
+    @val external canvasPattern: constructor = \\"CanvasPattern\\" /* internal */
     let instanceOf = (
       %bs.raw(\`function(x,y) {return +(x instanceof y)}\`): (
         'a,
@@ -3255,19 +3254,19 @@ let d = #abcd
 
 external openSync: (
   path,
-  @bs.string
+  @string
   [
-    | @bs.as(\\"r\\") #Read
-    | @bs.as(\\"r+\\") #Read_write
-    | @bs.as(\\"rs+\\") #Read_write_sync
-    | @bs.as(\\"w\\") #Write
-    | @bs.as(\\"wx\\") #Write_fail_if_exists
-    | @bs.as(\\"w+\\") #Write_read
-    | @bs.as(\\"wx+\\") #Write_read_fail_if_exists
-    | @bs.as(\\"a\\") #Append
-    | @bs.as(\\"ax\\") #Append_fail_if_exists
-    | @bs.as(\\"a+\\") #Append_read
-    | @bs.as(\\"ax+\\") #Append_read_fail_if_exists
+    | @as(\\"r\\") #Read
+    | @as(\\"r+\\") #Read_write
+    | @as(\\"rs+\\") #Read_write_sync
+    | @as(\\"w\\") #Write
+    | @as(\\"wx\\") #Write_fail_if_exists
+    | @as(\\"w+\\") #Write_read
+    | @as(\\"wx+\\") #Write_read_fail_if_exists
+    | @as(\\"a\\") #Append
+    | @as(\\"ax\\") #Append_fail_if_exists
+    | @as(\\"a+\\") #Append_read
+    | @as(\\"ax+\\") #Append_read_fail_if_exists
   ],
 ) => unit = \\"openSync\\"
 "

--- a/tests/printer/expr/binary.js
+++ b/tests/printer/expr/binary.js
@@ -252,8 +252,8 @@ let x = a && lazy false && lazy true
 let x = a && {open React; killPerform()}
 let x = a && {open React; killPerform()} && {open Dom; regainPerform()}
 
-let x = a && %bs.raw("true")
-let x = a && %bs.raw("true") && %bs.raw("false")
+let x = a && %raw("true")
+let x = a && %raw("true") && %raw("false")
 
 let x = a && module(Foo)
 let x = a && module(Foo) && module(Bar)

--- a/tests/printer/expr/block.js
+++ b/tests/printer/expr/block.js
@@ -19,7 +19,7 @@ let reifyStyle = (type a, x: 'a): (style<a>, a) => {
     @val external canvasGradient: constructor = "CanvasGradient" /* internal */
     @val external canvasPattern: constructor = "CanvasPattern" /* internal */
     let instanceOf = (
-      %bs.raw(`function(x,y) {return +(x instanceof y)}`): ('a, constructor) => bool
+      %raw(`function(x,y) {return +(x instanceof y)}`): ('a, constructor) => bool
     ) /* internal */
   }
 

--- a/tests/printer/expr/block.js
+++ b/tests/printer/expr/block.js
@@ -16,8 +16,8 @@ let () = {
 let reifyStyle = (type a, x: 'a): (style<a>, a) => {
   module Internal = {
     type rec constructor
-    @bs.val external canvasGradient: constructor = "CanvasGradient" /* internal */
-    @bs.val external canvasPattern: constructor = "CanvasPattern" /* internal */
+    @val external canvasGradient: constructor = "CanvasGradient" /* internal */
+    @val external canvasPattern: constructor = "CanvasPattern" /* internal */
     let instanceOf = (
       %bs.raw(`function(x,y) {return +(x instanceof y)}`): ('a, constructor) => bool
     ) /* internal */

--- a/tests/printer/expr/extension.js
+++ b/tests/printer/expr/extension.js
@@ -1,10 +1,10 @@
 let x = %eval
-let node = %bs.raw("0")
-let node = %bs.raw(@attr "0")
-let node = %bs.raw(@attrStructureLvl (@attrOnExpr "0"))
+let node = %raw("0")
+let node = %raw(@attr "0")
+let node = %raw(@attrStructureLvl (@attrOnExpr "0"))
 
-let node = %bs.raw(@attrStructureLvl @attrStructureLvl2 @attrStructureLvl3 (@attrOnExpr "0"))
-let node = %bs.raw(
+let node = %raw(@attrStructureLvl @attrStructureLvl2 @attrStructureLvl3 (@attrOnExpr "0"))
+let node = %raw(
   @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3
   (
     @attrOnExpr @attrOnExpr2 @attrOnExpr3 @attrOnExpr4 @attrOnExpr5
@@ -23,4 +23,4 @@ switch %external(__DEV__) {
 | None => Js.log("production mode")
 }
 
-let node = @attr %bs.raw("0")
+let node = @attr %raw("0")

--- a/tests/printer/expr/jsx.js
+++ b/tests/printer/expr/jsx.js
@@ -173,7 +173,7 @@ let x =
     pack=module(Foo: Bar)
     pack={module(Foo: Bar)}
     openExpr={open React; React.render()}
-    extension=%bs.raw("eval()")
+    extension=%raw("eval()")
     jsObject={"x": 1, "y": 2} 
     withAttr={@attr foo}
  />
@@ -245,7 +245,7 @@ let x =
     {module(Foo: Bar)}
     module(Foo: Bar)
     {open React; React.render()}
-    %bs.raw("eval()")
+    %raw("eval()")
     {"x": 1, "y": 2} 
     {@attr ident} 
   </div>

--- a/tests/printer/expr/polyvariant.js
+++ b/tests/printer/expr/polyvariant.js
@@ -118,17 +118,17 @@ let d = #abcd
 
 external openSync: (
   path,
-  @bs.string [
-    | @bs.as("r") #Read
-    | @bs.as("r+") #Read_write
-    | @bs.as("rs+") #Read_write_sync
-    | @bs.as("w") #Write
-    | @bs.as("wx") #Write_fail_if_exists
-    | @bs.as("w+") #Write_read
-    | @bs.as("wx+") #Write_read_fail_if_exists
-    | @bs.as("a") #Append
-    | @bs.as("ax") #Append_fail_if_exists
-    | @bs.as("a+") #Append_read
-    | @bs.as("ax+") #Append_read_fail_if_exists
+  @string [
+    | @as("r") #Read
+    | @as("r+") #Read_write
+    | @as("rs+") #Read_write_sync
+    | @as("w") #Write
+    | @as("wx") #Write_fail_if_exists
+    | @as("w+") #Write_read
+    | @as("wx+") #Write_read_fail_if_exists
+    | @as("a") #Append
+    | @as("ax") #Append_fail_if_exists
+    | @as("a+") #Append_read
+    | @as("ax+") #Append_read_fail_if_exists
   ],
 ) => unit = "openSync"

--- a/tests/printer/ffi/__snapshots__/render.spec.js.snap
+++ b/tests/printer/ffi/__snapshots__/render.spec.js.snap
@@ -36,7 +36,7 @@ include {
 
 @ns.jsFfi
 include {
-  @bs.val external document: Dom.document = \\"document\\"
+  @val external document: Dom.document = \\"document\\"
 }
 "
 `;

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -300,7 +300,7 @@ module Range = {
     children: React.element,
   }
 
-  @bs.module(\\"react-range\\") @react.component
+  @module(\\"react-range\\") @react.component
   external make: (
     ~min: int,
     ~max: int,

--- a/tests/printer/other/fatSlider.res
+++ b/tests/printer/other/fatSlider.res
@@ -11,7 +11,7 @@ module Range = {
     children: React.element,
   }
   
-  @bs.module("react-range") @react.component
+  @module("react-range") @react.component
   external make: (
     ~min: int,
     ~max: int,

--- a/tests/printer/pattern/__snapshots__/render.spec.js.snap
+++ b/tests/printer/pattern/__snapshots__/render.spec.js.snap
@@ -361,7 +361,7 @@ let get_age3 = ({age: module(P: S), name: _}) => age2
 
 let get_age3 = ({age: exception Exit, name: _}) => age2
 
-let get_age3 = ({age: %bs.raw(\\"__GC\\"), name: _}) => age2
+let get_age3 = ({age: %raw(\\"__GC\\"), name: _}) => age2
 "
 `;
 

--- a/tests/printer/pattern/record.res
+++ b/tests/printer/pattern/record.res
@@ -59,4 +59,4 @@ let get_age3 = ({age: module(P: S), name: _}) => age2
 
 let get_age3 = ({age: exception Exit, name: _}) => age2
 
-let get_age3 = ({age: %bs.raw("__GC"), name: _}) => age2
+let get_age3 = ({age: %raw("__GC"), name: _}) => age2

--- a/tests/printer/signature/__snapshots__/render.spec.js.snap
+++ b/tests/printer/signature/__snapshots__/render.spec.js.snap
@@ -24,7 +24,7 @@ exception Exit = Ns.Lib.Terminate
 `;
 
 exports[`extension.resi 1`] = `
-"%%bs.raw(\\"eval(js)\\")
+"%%raw(\\"eval(js)\\")
 
 @attr
 %%extension(payload)

--- a/tests/printer/signature/extension.resi
+++ b/tests/printer/signature/extension.resi
@@ -1,4 +1,4 @@
-%%bs.raw("eval(js)")
+%%raw("eval(js)")
 
 @attr
 %%extension(payload)

--- a/tests/printer/structure/__snapshots__/render.spec.js.snap
+++ b/tests/printer/structure/__snapshots__/render.spec.js.snap
@@ -76,20 +76,20 @@ expr
 `;
 
 exports[`extension.js 1`] = `
-"%%bs.raw(\\"__eval__gc()\\")
+"%%raw(\\"__eval__gc()\\")
 
 @attr
-%%bs.raw(\\"__eval__gc()\\")
+%%raw(\\"__eval__gc()\\")
 
 @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3
-%%bs.raw(\\"__eval__gc()\\")
+%%raw(\\"__eval__gc()\\")
 
 @attrStructureLvl
 @attrStructureLvl2
 @attrStructureLvl3
 @attrStructureLvl4
 @attrStructureLvl5
-%%bs.raw(\\"__eval__gc()\\")
+%%raw(\\"__eval__gc()\\")
 "
 `;
 

--- a/tests/printer/structure/__snapshots__/render.spec.js.snap
+++ b/tests/printer/structure/__snapshots__/render.spec.js.snap
@@ -94,7 +94,7 @@ exports[`extension.js 1`] = `
 `;
 
 exports[`external.js 1`] = `
-"@bs.val external null: reactElement = \\"null\\"
+"@val external null: reactElement = \\"null\\"
 
 external string: string => reactElement = \\"%identity\\"
 
@@ -115,7 +115,7 @@ include WebGl
 include (
   /* Use varargs to avoid the ReactJS warning for duplicate keys in children */
   {
-    @bs.val @bs.module(\\"react\\")
+    @val @module(\\"react\\")
     external createElementInternalHack: 'a = \\"createElement\\"
     @bs.send
     external apply: (

--- a/tests/printer/structure/extension.js
+++ b/tests/printer/structure/extension.js
@@ -1,10 +1,10 @@
-%%bs.raw("__eval__gc()")
+%%raw("__eval__gc()")
 
 @attr
-%%bs.raw("__eval__gc()")
+%%raw("__eval__gc()")
 
 @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3
-%%bs.raw("__eval__gc()")
+%%raw("__eval__gc()")
 
 @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3 @attrStructureLvl4 @attrStructureLvl5
-%%bs.raw("__eval__gc()")
+%%raw("__eval__gc()")

--- a/tests/printer/structure/external.js
+++ b/tests/printer/structure/external.js
@@ -1,4 +1,4 @@
-@bs.val external null: reactElement = "null";
+@val external null: reactElement = "null";
 
 external string: string => reactElement = "%identity";
 

--- a/tests/printer/structure/include.js
+++ b/tests/printer/structure/include.js
@@ -6,7 +6,7 @@ include WebGl
 include (
   /* Use varargs to avoid the ReactJS warning for duplicate keys in children */
   {
-    @bs.val @bs.module("react")
+    @val @module("react")
     external createElementInternalHack: 'a = "createElement"
     @bs.send
     external apply: (

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -212,24 +212,24 @@ type t = @attr
   floatWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
 ) => unit
 
-external debounce: (int, @bs.meth unit) => unit = \\"debounce\\"
+external debounce: (int, @meth unit) => unit = \\"debounce\\"
 
-external debounce: int => @bs.meth (unit => unit) = \\"debounce\\"
+external debounce: int => @meth (unit => unit) = \\"debounce\\"
 
-external debounce: (int, @bs.meth (unit => unit)) => @bs.meth (unit => unit) =
+external debounce: (int, @meth (unit => unit)) => @meth (unit => unit) =
   \\"debounce\\"
 
 external debounce: (
   int,
-  @bs.meth (unit => unit),
-  @bs.meth (unit => unit),
-) => @bs.meth (unit => unit) = \\"debounce\\"
+  @meth (unit => unit),
+  @meth (unit => unit),
+) => @meth (unit => unit) = \\"debounce\\"
 
 external debounce: (
   int,
-  @bs.meth (unit => unit),
-  @bs.meth (unit => @bs.meth (unit => unit)),
-) => @bs.meth (unit => unit) = \\"debounce\\"
+  @meth (unit => unit),
+  @meth (unit => @meth (unit => unit)),
+) => @meth (unit => unit) = \\"debounce\\"
 
 type returnTyp = (int, int) => @magic float
 type returnTyp = (
@@ -260,10 +260,10 @@ type t = (
 ) => int
 type t = (. @attr ~x: int, ~y: int, . @attr ~z: int, @attr ~omega: int) => unit
 
-@bs.val
+@val
 external requestAnimationFrame: (float => unit) => unit =
   \\"requestAnimationFrame\\"
-@bs.val
+@val
 external requestAnimationFrame: @attr ((float => unit) => unit) =
   \\"requestAnimationFrame\\"
 
@@ -559,7 +559,7 @@ let t: @attrs list<{\\"age\\": int}> = x
 
 external color: @attr colour<'t> = \\"c_color\\"
 
-@bs.send @bs.return(nullable)
+@send @return(nullable)
 external getAttribute: (Js.t<'a>, string) => option<string> = \\"getAttribute\\"
 
 let dangerousHtml: string => Js.t<'a> = html => {\\"__html\\": html}
@@ -603,7 +603,7 @@ type madness = [< #\\"type\\" & (\\\\\\"let\\") & (\\\\\\"Super exotic\\") | #\\
 let error_of_exn: exn => option<[#Ok(error) | #Already_displayed]> = x
 
 external make: (
-  ~_type: @bs.string
+  ~_type: @string
   [
     | #basis
     | #basisClosed

--- a/tests/printer/typexpr/arrow.js
+++ b/tests/printer/typexpr/arrow.js
@@ -67,15 +67,15 @@ type t = @attr (fooWithSuperLongIdentifierNameLooooooooooooooooooooooooooooooooo
 type t = @attr @attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong @attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong (fooWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong, barWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong, bazWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong) => @attr2 @attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong @attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong (stringWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong, floatWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong) => unit
 
 
-external debounce: (int, @bs.meth unit) => unit = "debounce";
+external debounce: (int, @meth unit) => unit = "debounce";
 
-external debounce: int => @bs.meth (unit => unit) = "debounce";
+external debounce: int => @meth (unit => unit) = "debounce";
 
-external debounce: (int, @bs.meth (unit => unit)) => @bs.meth (unit => unit) = "debounce";
+external debounce: (int, @meth (unit => unit)) => @meth (unit => unit) = "debounce";
 
-external debounce: (int, @bs.meth (unit => unit), @bs.meth (unit => unit)) => @bs.meth (unit => unit) = "debounce";
+external debounce: (int, @meth (unit => unit), @meth (unit => unit)) => @meth (unit => unit) = "debounce";
 
-external debounce: (int, @bs.meth (unit => unit), @bs.meth ( unit => @bs.meth (unit => unit))) => @bs.meth (unit => unit) = "debounce";
+external debounce: (int, @meth (unit => unit), @meth ( unit => @meth (unit => unit))) => @meth (unit => unit) = "debounce";
 
 type returnTyp = (int, int) => @magic float
 type returnTyp = (intWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong, intWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong) => @magic float
@@ -93,8 +93,8 @@ type t = (. @attr int, . @attr2 int) => unit
 type t = (. @attrOnInt int, @attrOnInt int, . @attrOnInt int, @attrOnInt int) => int
 type t = (. @attr ~x: int, ~y: int, . @attr ~z: int, @attr ~omega: int) => unit 
 
-@bs.val external requestAnimationFrame: (float => unit) => unit = "requestAnimationFrame"
-@bs.val external requestAnimationFrame: @attr (float => unit) => unit = "requestAnimationFrame"
+@val external requestAnimationFrame: (float => unit) => unit = "requestAnimationFrame"
+@val external requestAnimationFrame: @attr (float => unit) => unit = "requestAnimationFrame"
 
 type arrows = (int, (float => unit) => unit, float) => unit
 

--- a/tests/printer/typexpr/typeConstr.js
+++ b/tests/printer/typexpr/typeConstr.js
@@ -26,7 +26,7 @@ let t: @attrs list<{"age": int}> = x
 
 external color : @attr colour<'t> = "c_color"
 
-@bs.send @bs.return(nullable)
+@send @return(nullable)
 external getAttribute: (Js.t<'a>, string) => option<string> = "getAttribute"
 
 let dangerousHtml: string => Js.t<'a> = html => {"__html": html}

--- a/tests/printer/typexpr/variant.js
+++ b/tests/printer/typexpr/variant.js
@@ -21,7 +21,7 @@ type madness = [< | #\"type" & (\"let") & (\"Super exotic") | #\"Bad Idea" ]
 let error_of_exn: exn => option<[ | #Ok(error) | #Already_displayed ]> = x
 
 external make: (
-  ~_type: @bs.string
+  ~_type: @string
   [
   | #basis
   | #basisClosed


### PR DESCRIPTION
*before*
```rescript
@bs.val
@bs.module
```

*after*
```rescript
@val
@module
```

Exceptions:
- @bs.open
- @bs.pipe.send