### PR TITLE
Improve printing of jsx children and props with leading line comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Improve printing of jsx children and props with leading line comment in [#236](https://github.com/rescript-lang/syntax/pull/236)
 * Improve conversion of quoted strings from Reason in [#238](https://github.com/rescript-lang/syntax/pull/238)
 * Print attributes/extension without bs prefix where possible in [#230](https://github.com/rescript-lang/syntax/pull/230)
 * Cleanup gentype attribute printing [fe05e1051aa94b16f6993ddc5ba9651f89e86907](https://github.com/rescript-lang/syntax/commit/fe05e1051aa94b16f6993ddc5ba9651f89e86907)

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -2913,6 +2913,39 @@ module App = {
     <> <div /> </>
   }
 }
+
+// leading line comment on rhs jsx prop should indent nicely
+<ContributorsRow
+  amount={
+    // ->BN.new_(\\"86400\\")
+    // There are 86400 seconds in a day.
+    amount->BN.div(BN.new_(\\"86400\\"))->BN.toString
+  }
+/>
+
+// leading line comment on rhs jsx prop should indent nicely
+<ContributorsRow
+  amount={
+    // There are 86400 seconds in a day.
+    compute(amount)
+  }
+/>
+
+// leading line comment on braced children should indent nicely
+<div>
+  {
+    // comment
+    content
+  }
+  {
+    // comment
+    if condition() {
+      renderBranch()
+    } else {
+      doSomeOtherThings()
+    }
+  }
+</div>
 "
 `;
 

--- a/tests/printer/expr/jsx.js
+++ b/tests/printer/expr/jsx.js
@@ -284,3 +284,35 @@ module App = {
     <> <div /> </>
   }
 }
+
+// leading line comment on rhs jsx prop should indent nicely
+<ContributorsRow
+  amount={
+    // ->BN.new_("86400")
+    // There are 86400 seconds in a day.
+    amount->BN.div(BN.new_("86400"))->BN.toString
+  }
+/>
+
+// leading line comment on rhs jsx prop should indent nicely
+<ContributorsRow
+  amount={
+    // There are 86400 seconds in a day.
+    compute(amount)
+  }
+/>
+
+// leading line comment on braced children should indent nicely
+<div>
+  {// comment
+    content
+  }
+
+  { // comment
+    if condition() {
+      renderBranch()
+    } else {
+      doSomeOtherThings()
+    }
+  }
+</div>


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/231.

The comment would either not be printed or the indentation would be weird:

**before**
```Rescript
<Component amount={amount->BN.div(BN.new_("86400"))->BN.toString} />

<Component>
  {// test
  amount->BN.div(BN.new_("86400"))->BN.toString}
</Component>
```

**after**
```Rescript
<Component
  amount={
    // test
    amount->BN.div(BN.new_("86400"))->BN.toString
  }
/>

<Component>
  {
    // test
    amount->BN.div(BN.new_("86400"))->BN.toString
  }
</Component>
```