### PR TITLE
Improve conversion of quoted strings from Reason.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Improve conversion of quoted strings from Reason in [#238](https://github.com/rescript-lang/syntax/pull/238)
 * Print attributes/extension without bs prefix where possible in [#230](https://github.com/rescript-lang/syntax/pull/230)
 * Cleanup gentype attribute printing [fe05e1051aa94b16f6993ddc5ba9651f89e86907](https://github.com/rescript-lang/syntax/commit/fe05e1051aa94b16f6993ddc5ba9651f89e86907)
 * Implement light weight syntax for poly-variants [f84c5760b3f743f65e934195c87fc06bf88bff75](https://github.com/rescript-lang/syntax/commit/f84c5760b3f743f65e934195c87fc06bf88bff75)

--- a/src/res_driver_reason_binary.ml
+++ b/src/res_driver_reason_binary.ml
@@ -30,6 +30,11 @@ let extractConcreteSyntax filename =
       let len = endPos.pos_cnum - startPos.pos_cnum in
       let txt = (String.sub [@doesNotRaise]) src startPos.pos_cnum len in
       stringData := (txt, loc)::(!stringData);
+      next endPos scanner;
+    | Lbrace ->
+      (* handle {| |} or {sql||sql} quoted strings. We don't care about its contents.
+         Why? // abcdef inside the quoted string would otherwise be picked up as an extra comment *)
+      Res_scanner.tryAdvanceQuotedString scanner;
       next endPos scanner
     | _ ->
       next endPos scanner

--- a/src/res_scanner.mli
+++ b/src/res_scanner.mli
@@ -30,3 +30,5 @@ val popMode: t -> mode -> unit
 val reconsiderLessThan: t -> Res_token.t
 
 val scanTemplateLiteralToken: t -> (Lexing.position * Lexing.position * Res_token.t)
+
+val tryAdvanceQuotedString: t -> unit

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1341,6 +1341,22 @@ let x = \\"\\\\\\"\\"
 let y = \\"\\\\n\\"
 
 (<> {\\"\\\\n\\"->React.string} </>)
+
+// The \`//\` should not result into an extra comment
+let x = j\`https://www.apple.com\`
+let x = \`https://www.apple.com\`
+let x = \`https://www.apple.com\`
+let x = \`https://www.apple.com\`
+let x = sql\`https://www.apple.com\`
+
+// /* */ should not result in an extra comments
+let x = j\`/* https://www.apple.com */\`
+let x = \`/* https://www.apple.com*/\`
+let x = \`/*https://www.apple.com*/\`
+let x = \`/*https://www.apple.com*/\`
+let x = sql\`/*https://www.apple.com*/\`
+
+let x = \`\\\\\`https://\\\\\${appleWebsite}\\\\\`\`
 "
 `;
 

--- a/tests/conversion/reason/string.re
+++ b/tests/conversion/reason/string.re
@@ -11,3 +11,19 @@ let x = "\"";
 let y = "\n";
 
 <> {"\n"->React.string} </>;
+
+// The `//` should not result into an extra comment
+let x = {j|https://www.apple.com|j};
+let x = {|https://www.apple.com|};
+let x = {js|https://www.apple.com|js};
+let x = {|https://www.apple.com|};
+let x = {sql|https://www.apple.com|sql};
+
+// /* */ should not result in an extra comments
+let x = {j|/* https://www.apple.com */|j};
+let x = {|/* https://www.apple.com*/|};
+let x = {js|/*https://www.apple.com*/|js};
+let x = {|/*https://www.apple.com*/|};
+let x = {sql|/*https://www.apple.com*/|sql};
+
+let x = {js|`https://${appleWebsite}`|js};

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -518,6 +518,23 @@ let x = \\"foo\\\\x0Abar\\"
 let x = \\"foo\\\\o012bar\\"
 
 let x = \\"😁 this works now 😆\\"
+let x = \`😁 this works now 😆\`
+
+/* The \`//\` should not result into an extra comment */
+let x = j\`https://www.apple.com\`
+let x = \`https://www.apple.com\`
+let x = \`https://www.apple.com\`
+let x = \`https://www.apple.com\`
+let x = sql\`https://www.apple.com\`
+
+/* /* */ should not result in an extra comments */
+let x = j\`/* https://www.apple.com */\`
+let x = \`/* https://www.apple.com*/\`
+let x = \`/*https://www.apple.com*/\`
+let x = \`/*https://www.apple.com*/\`
+let x = sql\`/*https://www.apple.com*/\`
+
+let x = \`\\\\\`https://\\\\\${appleWebsite}\\\\\`\`
 "
 `;
 

--- a/tests/printer/other/ocamlString.ml
+++ b/tests/printer/other/ocamlString.ml
@@ -7,3 +7,21 @@ let x = "foo\x0Abar"
 let x = "foo\o012bar"
 
 let x = "😁 this works now 😆"
+let x = {|😁 this works now 😆|}
+
+
+(* The `//` should not result into an extra comment *)
+let x = {j|https://www.apple.com|j}
+let x = {|https://www.apple.com|}
+let x = {js|https://www.apple.com|js}
+let x = {|https://www.apple.com|}
+let x = {sql|https://www.apple.com|sql}
+
+(* /* */ should not result in an extra comments *)
+let x = {j|/* https://www.apple.com */|j}
+let x = {|/* https://www.apple.com*/|}
+let x = {js|/*https://www.apple.com*/|js}
+let x = {|/*https://www.apple.com*/|}
+let x = {sql|/*https://www.apple.com*/|sql}
+
+let x = {js|`https://${appleWebsite}`|js}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/237

The conversion from Reason to ReScript naively picks up `//` as comments inside quoted strings..

input:
```reason
let x = {j|https://www.apple.com|j};
let x = {|https://www.apple.com|};
let x = {js|https://www.apple.com|js};
```

output:
```rescript
let x = j`https://www.apple.com` //www.apple.com|j};
let x = `https://www.apple.com` //www.apple.com|};
let x = `https://www.apple.com` //www.apple.com|js};
```

This patch fixes this behaviour and doesn't produce any extra comments