### PR TITLE
Fix printing of trailing comments under lhs of "pipe" expression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Improve printing of trailing comments under lhs of "pipe" expression in [#329](https://github.com/rescript-lang/syntax/pull/239/files)
 * Improve printing of jsx children and props with leading line comment in [#236](https://github.com/rescript-lang/syntax/pull/236)
 * Improve conversion of quoted strings from Reason in [#238](https://github.com/rescript-lang/syntax/pull/238)
 * Print attributes/extension without bs prefix where possible in [#230](https://github.com/rescript-lang/syntax/pull/230)

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -37,6 +37,64 @@ let truth =
   /* c0 */ a /* c1 */ == /* c2 */ b /* c3 */ &&
   /* c4 */ c /* c5 */ == /* c6 */ d /* c7 */ &&
   /* c8 */ e /* c9 */ == /* c10 */ f /* c11 */
+
+promise
+// TODO: This comment needs to be here
+->Js.Promise.then(payload => {
+  Js.log2(\\"this payload was received\\", payload)
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+
+promise
+/* TODO: This comment needs to be here */
+->Js.Promise.then(payload => {
+  Js.log2(\\"this payload was received\\", payload)
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+
+promise
+// comment
+->Js.Promise.then(payload => {
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+// comment 2
+->Js.Promise.catch(err => {
+  Js.log2(\\"this error was caught\\", err)
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+
+promise
+/* comment */
+->Js.Promise.then(payload => {
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+/* comment 2 */
+
+// comment 3
+
+/* comment 4 */
+->Js.Promise.catch(err => {
+  Js.log2(\\"this error was caught\\", err)
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+
+promise
+// TODO: This comment needs to be here
+|> Js.Promise.then(payload => {
+  Js.log2(\\"this payload was received\\", payload)
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+
+promise
+// comment
+|> Js.Promise.then(payload => {
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
+// comment 2
+|> Js.Promise.catch(err => {
+  Js.log2(\\"this error was caught\\", err)
+  Js.Promise.resolve(\\"\\"->Obj.magic)
+})
 "
 `;
 

--- a/tests/printer/comments/binaryExpr.res
+++ b/tests/printer/comments/binaryExpr.res
@@ -34,3 +34,63 @@ let truth =
   /* c0 */ a /* c1 */ == /* c2 */ b /* c3 */ &&
  /* c4 */ c /* c5 */ == /* c6 */ d /* c7 */ &&
   /* c8 */ e /* c9 */ ==  /* c10 */ f  /* c11 */
+
+promise
+// TODO: This comment needs to be here
+->Js.Promise.then(payload => {
+  Js.log2("this payload was received", payload);
+  Js.Promise.resolve(""->Obj.magic);
+})
+
+
+promise
+/* TODO: This comment needs to be here */
+->Js.Promise.then(payload => {
+  Js.log2("this payload was received", payload);
+  Js.Promise.resolve(""->Obj.magic);
+})
+
+promise
+// comment
+->Js.Promise.then(payload => {
+  Js.Promise.resolve(""->Obj.magic);
+})
+// comment 2
+->Js.Promise.catch(err => {
+  Js.log2("this error was caught", err);
+  Js.Promise.resolve(""->Obj.magic);
+})
+
+
+promise
+/* comment */
+->Js.Promise.then(payload => {
+  Js.Promise.resolve(""->Obj.magic);
+})
+/* comment 2 */
+
+// comment 3
+
+/* comment 4 */
+->Js.Promise.catch(err => {
+  Js.log2("this error was caught", err);
+  Js.Promise.resolve(""->Obj.magic);
+})
+
+promise
+// TODO: This comment needs to be here
+|> Js.Promise.then(payload => {
+  Js.log2("this payload was received", payload);
+  Js.Promise.resolve(""->Obj.magic);
+})
+
+promise
+// comment
+|> Js.Promise.then(payload => {
+  Js.Promise.resolve(""->Obj.magic);
+})
+// comment 2
+|> Js.Promise.catch(err => {
+  Js.log2("this error was caught", err);
+  Js.Promise.resolve(""->Obj.magic);
+})


### PR DESCRIPTION
Correctly print trailing below the lhs of a `Pexp_apply` with fast pipe or slow pipe.

Fixes https://github.com/rescript-lang/syntax/issues/234

**input**
```
promise
// comment
->Js.Promise.then(payload => {
  Js.Promise.resolve(""->Obj.magic);
})
```

**before**
```
promise
->Js.Promise.then(payload => {
// comment
  Js.Promise.resolve(""->Obj.magic);
})
```

**after**
```
promise
// comment
->Js.Promise.then(payload => {
  Js.Promise.resolve(""->Obj.magic);
})
```