### PR TITLE
Fix printing of constrained expr rhs js object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Fix printing of constrained expressions in rhs of js objects [#240](https://github.com/rescript-lang/syntax/pull/240)
 * Improve printing of trailing comments under lhs of "pipe" expression in [#329](https://github.com/rescript-lang/syntax/pull/239/files)
 * Improve printing of jsx children and props with leading line comment in [#236](https://github.com/rescript-lang/syntax/pull/236)
 * Improve conversion of quoted strings from Reason in [#238](https://github.com/rescript-lang/syntax/pull/238)

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4660,7 +4660,11 @@ and printBsObjectRow (lbl, expr) cmtTbl =
   let doc = Doc.concat [
     lblDoc;
     Doc.text ": ";
-    printExpressionWithComments expr cmtTbl
+    (let doc = printExpressionWithComments expr cmtTbl in
+    match Parens.expr expr with
+    | Parens.Parenthesized -> addParens doc
+    | Braced braces -> printBraces doc expr braces
+    | Nothing -> doc);
   ] in
   printComments doc cmtTbl cmtLoc
 

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -1193,6 +1193,54 @@ let person = {
   },
   \\"age\\": 32,
 }
+
+// print parens around constrained expr in rhs
+let user = {\\"name\\": (ceo.name: string)}
+// braces should be preserved on rhs
+let user = {\\"name\\": {ceo.name}}
+let user = {
+  \\"name\\": {
+    ceo.name
+  },
+}
+// braced + constrained expr
+let user = {\\"name\\": {(ceo.name: string)}}
+
+React.jsx(
+  ReactDOM.stringToComponent(\\"div\\"),
+  {
+    let ariaCurrent = #page
+    {
+      \\"aria-current\\": (
+        ariaCurrent: [
+          | #page
+          | #step
+          | #location
+          | #date
+          | #time
+          | #\\"true\\"
+          | #\\"false\\"
+        ]
+      ),
+    }
+  },
+)
+
+React.jsx(
+  ReactDOM.stringToComponent(\\"div\\"),
+  {
+    let children = {msg->React.string}
+    {\\"children\\": (children: React.element)}
+  },
+)
+
+(@warning(\\"-3\\") React.jsx)(
+  ReactDOM.stringToComponent(\\"div\\"),
+  {
+    let \\\\\\"data-foo\\" = \\"payload\\"
+    {\\"data-foo\\": (\\\\\\"data-foo\\": string)}
+  },
+)
 "
 `;
 
@@ -3343,6 +3391,18 @@ let x =
     superLongName: 5,
     superLongName: 20,
   }
+
+// print parens around constrained expr in rhs
+let user = {name: (ceo.name: string)}
+// braces should be preserved on rhs
+let user = {name: {ceo.name}}
+let user = {
+  name: {
+    ceo.name
+  },
+}
+// braced + constrained expr
+let user = {name: {(ceo.name: string)}}
 "
 `;
 

--- a/tests/printer/expr/bsObj.js
+++ b/tests/printer/expr/bsObj.js
@@ -12,3 +12,47 @@ let person = {
   },
   "age": 32
 }
+
+// print parens around constrained expr in rhs
+let user = {"name": (ceo.name: string)}
+// braces should be preserved on rhs
+let user = {"name": {ceo.name}}
+let user = {"name": {
+  ceo.name
+}}
+// braced + constrained expr
+let user = {"name": {(ceo.name: string)}}
+
+React.jsx(
+  ReactDOM.stringToComponent("div"),
+  {
+    let ariaCurrent = #page
+    {
+      "aria-current": (ariaCurrent : [
+      | #page
+      | #step
+      | #location
+      | #date
+      | #time
+      | #"true"
+      | #"false"
+      ])
+    }
+  }
+)
+
+React.jsx(
+  ReactDOM.stringToComponent("div"),
+  {
+    let children = {msg->React.string}
+    {"children": (children: React.element)}
+  }
+)
+
+(@warning("-3") React.jsx)(
+  ReactDOM.stringToComponent("div"),
+  {
+    let \"data-foo" = "payload"
+    {"data-foo": (\"data-foo": string)}
+  }
+)

--- a/tests/printer/expr/record.js
+++ b/tests/printer/expr/record.js
@@ -18,3 +18,13 @@ let withSpreadAndNaturalBreak = {...fields, firstField: superLongIdentiiiiiiiiff
 let x = @attr {x: 1, y: 2}
 let x = @attr {...initialState, superLongName: 1, superLongName: 2, superLongName: 5}
 let x = @attr {...initialState, superLongName: 1, superLongName: 2, superLongName: 5, superLongName: 20}
+
+// print parens around constrained expr in rhs
+let user = {name: (ceo.name: string)}
+// braces should be preserved on rhs
+let user = {name: {ceo.name}}
+let user = {name: {
+  ceo.name
+}}
+// braced + constrained expr
+let user = {name: {(ceo.name: string)}}


### PR DESCRIPTION
Constrained expressions would not contain parens, and result into an invalid parse after printing.
**input**
```rescript
{"name": (name: string)}
```

**before**
```rescript
{"name": name: string} // invalid syntax

```

**after**
```rescript
{"name": (name: string)}
```