### PR TITLE
Improve printing of non-callback arguments in Pexp_apply with callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Improve printing of non-callback arguments in call expressions with callback in [#241](https://github.com/rescript-lang/syntax/pull/241/files)
 * Fix printing of constrained expressions in rhs of js objects [#240](https://github.com/rescript-lang/syntax/pull/240)
 * Improve printing of trailing comments under lhs of "pipe" expression in [#329](https://github.com/rescript-lang/syntax/pull/239/files)
 * Improve printing of jsx children and props with leading line comment in [#236](https://github.com/rescript-lang/syntax/pull/236)

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -1580,6 +1580,81 @@ let /* a */ decoratorTags /* b */ = items->Js.Array2.filter(items => {
   items.category === ChristmasLighting ||
   items.category === Unknown
 })
+
+// callback in last position
+showDialog(
+  \`
+  Do you really want to leave this workspace?
+  Some more text with detailed explanations...
+  \`,
+  ~danger=true,
+  ~confirmText=\\"Yes, I am sure!\\",
+  ~onConfirm={() => ()},
+)
+
+// callback in first position
+showDialog(
+  ~onConfirm={() => ()},
+  ~danger=true,
+  ~confirmText=\\"Yes, I am sure!\\",
+  \`
+  Do you really want to leave this workspace?
+  Some more text with detailed explanations...
+  \`,
+)
+
+// callback in last position, with comment in between args
+showDialog(
+  dialogMessage,
+  // comment
+  ~danger=true,
+  ~confirmText=\\"Yes, I am sure!\\",
+  ~onConfirm=() => (),
+)
+
+// callback in last position, with comment in between args
+showDialog(
+  dialogMessage,
+  ~danger=true,
+  /* comment below */
+  ~confirmText=\\"Yes, I am sure!\\",
+  ~onConfirm=() => (),
+)
+
+// callback in first position, with single line comment in between args
+showDialog(
+  ~onConfirm=() => (),
+  dialogMessage,
+  // comment
+  ~danger=true,
+  ~confirmText=\\"Yes, I am sure!\\",
+)
+
+// callback in first position, with comment in between args
+showDialog(
+  ~onConfirm=() => (),
+  dialogMessage,
+  ~danger=true,
+  /* comment below */
+  ~confirmText=\\"Yes, I am sure!\\",
+)
+
+React.useEffect5(
+  (
+    context.activate,
+    context.chainId,
+    dispatch,
+    setTriedLoginAlready,
+    triedLoginAlready,
+  ),
+  () => {
+    doThings()
+    None
+  }, // intentionally only running on mount (make sure it's only mounted once :))
+)
+
+apply(a, b, c, /* before */ () => () /* after */)
+apply(/* before */ () => () /* after */, a, b, c)
 "
 `;
 

--- a/tests/printer/expr/callback.js
+++ b/tests/printer/expr/callback.js
@@ -319,3 +319,72 @@ let /* a */ decoratorTags /* b */ = items->Js.Array2.filter(items => {
   || items.category === ChristmasLighting
   || items.category === Unknown
 })
+
+// callback in last position
+showDialog(
+  `
+  Do you really want to leave this workspace?
+  Some more text with detailed explanations...
+  `,
+  ~danger=true,
+  ~confirmText="Yes, I am sure!",
+  ~onConfirm={() => ()},
+)
+
+// callback in first position
+showDialog(
+  ~onConfirm={() => ()},
+  ~danger=true,
+  ~confirmText="Yes, I am sure!",
+  `
+  Do you really want to leave this workspace?
+  Some more text with detailed explanations...
+  `,
+)
+
+// callback in last position, with comment in between args
+showDialog(dialogMessage,
+// comment
+ ~danger=true, ~confirmText="Yes, I am sure!", ~onConfirm=() => ())
+ 
+// callback in last position, with comment in between args
+showDialog(
+  dialogMessage,
+ ~danger=true, 
+ /* comment below */
+ ~confirmText="Yes, I am sure!",
+ ~onConfirm=() => ())
+
+// callback in first position, with single line comment in between args
+showDialog(
+  ~onConfirm=() => (),
+  dialogMessage,
+  // comment
+  ~danger=true,
+  ~confirmText="Yes, I am sure!"
+ )
+ 
+// callback in first position, with comment in between args
+showDialog(
+  ~onConfirm=() => (),
+  dialogMessage,
+  ~danger=true, 
+  /* comment below */
+  ~confirmText="Yes, I am sure!",
+)
+
+React.useEffect5((
+  context.activate,
+  context.chainId,
+  dispatch,
+  setTriedLoginAlready,
+  triedLoginAlready,
+),
+() => {
+  doThings()
+  None
+}, // intentionally only running on mount (make sure it's only mounted once :))
+)
+
+apply(a, b, c, /* before */ () => () /* after */)
+apply(/* before */ () => () /* after */, a, b, c)


### PR DESCRIPTION
Fix https://github.com/rescript-lang/syntax/issues/212

Sometimes one of the non-callback arguments will break in a function application where the first or last argument is a callback. There might be a single line comment in there, or a multiline string. We want to break all the arguments in this case for readability.

**before**
```rescript
showDialog(
  `
  Do you really want to leave this workspace?
  Some more text with detailed explanations...
  `, danger=true, ~confirmText="Yes, I am sure!", ~onConfirm={() => ()},
)
```

**after**
```rescript
showDialog(
  `
  Do you really want to leave this workspace?
  Some more text with detailed explanations...
  `,
  ~danger=true,
  ~confirmText="Yes, I am sure!",
  ~onConfirm={() => ()},
)
```