### PR TITLE
improve indentation of fast pipe chain in let binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Improve indentation of fast pipe chain in let binding in [#244](https://github.com/rescript-lang/syntax/pull/244)
 * Improve printing of non-callback arguments in call expressions with callback in [#241](https://github.com/rescript-lang/syntax/pull/241/files)
 * Fix printing of constrained expressions in rhs of js objects [#240](https://github.com/rescript-lang/syntax/pull/240)
 * Improve printing of trailing comments under lhs of "pipe" expression in [#329](https://github.com/rescript-lang/syntax/pull/239/files)

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -3186,6 +3186,27 @@ let highlight_dumb = (ppf, lb, loc) => {
 
   foo
 }
+
+let f = x => {
+  let a =
+    x
+    ->Js.Dict.get(\\"wm-received\\")
+    ->Option.flatMap(Js.Json.decodeString)
+    ->Option.map(Js.Date.fromString)
+
+  let b =
+    x
+    ->Js.Dict.get(\\"wm-property\\")
+    ->Option.flatMap(Js.Json.decodeString)
+    ->Option.flatMap(x =>
+      switch x {
+      | \\"like-of\\" => Some(#like)
+      | \\"repost-of\\" => Some(#repost)
+      | _ => None
+      }
+    )
+  (a, b)
+}
 "
 `;
 

--- a/tests/printer/expr/let.js
+++ b/tests/printer/expr/let.js
@@ -36,3 +36,24 @@ let highlight_dumb = (ppf, lb, loc) => {
 
   foo
 }
+
+let f = x => {
+  let a =
+    x
+    ->Js.Dict.get("wm-received")
+    ->Option.flatMap(Js.Json.decodeString)
+    ->Option.map(Js.Date.fromString)
+
+  let b =
+    x
+    ->Js.Dict.get("wm-property")
+    ->Option.flatMap(Js.Json.decodeString)
+    ->Option.flatMap(x =>
+      switch x {
+      | "like-of" => Some(#like)
+      | "repost-of" => Some(#repost)
+      | _ => None
+      }
+    )
+  (a, b)
+}


### PR DESCRIPTION
Fix https://github.com/rescript-lang/syntax/issues/242

**before**
```rescript
let b = x
->Js.Dict.get("wm-property")
->Option.flatMap(Js.Json.decodeString)
->Option.flatMap(x =>
  switch x {
  | "like-of" => Some(#like)
  | "repost-of" => Some(#repost)
  | _ => None
  }
)
```

**after**
```rescript
let b =
  x
  ->Js.Dict.get("wm-property")
  ->Option.flatMap(Js.Json.decodeString)
  ->Option.flatMap(x =>
    switch x {
    | "like-of" => Some(#like)
    | "repost-of" => Some(#repost)
    | _ => None
    }
  )
```