### PR TITLE
Implement intelligent breaking for poly-var type expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Implement intelligent breaking for poly-var type expressions in [#246](https://github.com/rescript-lang/syntax/pull/246)
 * Improve indentation of fast pipe chain in let binding in [#244](https://github.com/rescript-lang/syntax/pull/244)
 * Improve printing of non-callback arguments in call expressions with callback in [#241](https://github.com/rescript-lang/syntax/pull/241/files)
 * Fix printing of constrained expressions in rhs of js objects [#240](https://github.com/rescript-lang/syntax/pull/240)

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -596,7 +596,10 @@ let id = (x: [> #Red | #Green | #Blue]) => x
 let upper = (x: [< #Red | #Green]) => true
 type point = [#Point(float, float)]
 type \\\\\\"type\\" = [#\\"Point🗿\\"(\\\\\\"let\\", float)]
-type shape = [#Rectangle(point, point) | #Circle(point, float)]
+type shape = [
+  | #Rectangle(point, point)
+  | #Circle(point, float)
+]
 
 type madness = [< #\\"type\\" & (\\\\\\"let\\") & (\\\\\\"Super exotic\\") | #\\"Bad Idea\\"]
 
@@ -648,7 +651,11 @@ type x = [
   | #Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz
 ]
 
-type animation = [#\\"ease-in\\" | #\\"ease-out\\" | #\\"never ease ✍️\\"]
+type animation = [
+  | #\\"ease-in\\"
+  | #\\"ease-out\\"
+  | #\\"never ease ✍️\\"
+]
 
 module type Conjunctive = {
   type u1 = [#A | #B]
@@ -663,5 +670,22 @@ module type Conjunctive = {
     & ([< #\\"Exotic-u1+++\\"])
   ] => unit
 }
+
+// should break because user wrote it over serveral lines
+type currencyPoly = [
+  | #USD
+  | #CAD
+  | #EUR
+]
+
+// should not break, user wrote it on one line
+type currencyPoly = [#USD | #CAD | #EUR]
+//
+// should break, line length exceeded
+type currencyPoly = [
+  | #UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUSD
+  | #CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD
+  | #EUUUUUUUUUUUUUUUUUUUR
+]
 "
 `;

--- a/tests/printer/typexpr/variant.js
+++ b/tests/printer/typexpr/variant.js
@@ -82,3 +82,14 @@ module type Conjunctive = {
   let g: [< | #S&([< u2]) & ([< u2]) & ([< u1])] => unit
   let g: [< | #"Exotic-S+"&([< #"Exotic-u2+"]) & ([< #"Exotic-u2-"]) & ([< #"Exotic-u1+++"])] => unit
 };
+
+
+// should break because user wrote it over serveral lines
+type currencyPoly = [#USD 
+  | #CAD | #EUR]
+
+// should not break, user wrote it on one line
+type currencyPoly = [#USD | #CAD | #EUR]
+//
+// should break, line length exceeded
+type currencyPoly = [#UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUSD | #CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD | #EUUUUUUUUUUUUUUUUUUUR]


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/245

Given:
```rescript
type currencyPoly = [#USD
  | #CAD | #EUR]

type currencyPoly = [#USD | #CAD | #EUR]
```
we have two different layouts:

In the first example the user wrote them over multiple lines.
The second has them on one line.
This commit implements a new strategy to print these two examples.
We now look at the style of the author: did he write it over multiple lines or not?

If it is on one line, keep it on one line (unless it breaks the column width).
If it is written over multiple lines, force break it over multiple lines.
This is also consistent with how we print variant declaration.