### PR TITLE
Move towards "if" keyword for guards on pattern match cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Implement new syntax for guards on pattern match cases in [3248](https://github.com/rescript-lang/syntax/pull/248)
 * Implement intelligent breaking for poly-var type expressions in [#246](https://github.com/rescript-lang/syntax/pull/246)
 * Improve indentation of fast pipe chain in let binding in [#244](https://github.com/rescript-lang/syntax/pull/244)
 * Improve printing of non-callback arguments in call expressions with callback in [#241](https://github.com/rescript-lang/syntax/pull/241/files)

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3230,7 +3230,7 @@ and parseWhileExpression p =
 
 and parsePatternGuard p =
   match p.Parser.token with
-    | When ->
+    | When | If ->
       Parser.next p;
       Some (parseExpr ~context:WhenExpr p)
     | _ ->
@@ -6132,7 +6132,7 @@ and parsePayload p =
       Parser.next p;
       let pattern = parsePattern p in
       let expr = match p.token with
-      | When ->
+      | When | If ->
         Parser.next p;
         Some (parseExpr p)
       | _ ->

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4330,7 +4330,7 @@ and printCase (case: Parsetree.case) cmtTbl =
   | Some expr -> Doc.group (
       Doc.concat [
         Doc.line;
-        Doc.text "when ";
+        Doc.text "if ";
         printExpressionWithComments expr cmtTbl;
       ]
     )
@@ -4791,7 +4791,7 @@ and printPayload (payload : Parsetree.payload) cmtTbl =
     | Some expr ->
       Doc.concat [
         Doc.line;
-        Doc.text "when ";
+        Doc.text "if ";
         printExpressionWithComments expr cmtTbl;
       ]
     | None -> Doc.nil

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -1224,7 +1224,14 @@ exports[`switch.js 1`] = `
 ";;match x with | A -> () | B -> ()
 ;;match a + b with | _ -> ()
 ;;match a + b with | _ -> ()
-;;match (a, b) with | (Some a, Some b) -> (a + b) + c | _ -> 3"
+;;match (a, b) with | (Some a, Some b) -> (a + b) + c | _ -> 3
+;;match person1 with
+  | Teacher _ -> ()
+  | Student { reportCard = { gpa } } when gpa < 0.5 ->
+      Js.log \\"What's happening\\"
+  | Student { reportCard = { gpa } } when gpa > 0.9 ->
+      Js.log \\"Take more free time, you study too much.\\"
+  | Student _ -> Js.log \\"Heyo\\""
 `;
 
 exports[`try.js 1`] = `

--- a/tests/parsing/grammar/expressions/switch.js
+++ b/tests/parsing/grammar/expressions/switch.js
@@ -16,3 +16,14 @@ switch (a, b) {
 | (Some(a), Some(b)) => a + b + c
 | _ => 3
 }
+
+switch person1 {
+| Teacher(_) => () // do nothing
+| Student({reportCard: {gpa}}) if gpa < 0.5 =>
+  Js.log("What's happening")
+| Student({reportCard: {gpa}}) if gpa > 0.9 =>
+  Js.log("Take more free time, you study too much.")
+| Student(_) =>
+  // fall-through, catch-all case
+  Js.log("Heyo")
+}

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -601,9 +601,9 @@ let multiply = (/* c0 */ m1 /* c1 */, /* c2 */ m2 /* c3 */) => {
 }
 
 switch x {
-| Blue when /* c0 */ multicore.enabled /* c1 */ === /* c2 */ true /* c3 */ => ()
+| Blue if /* c0 */ multicore.enabled /* c1 */ === /* c2 */ true /* c3 */ => ()
 | Red
-  when {
+  if {
     // c0
     open /* c1 */ Multicore // c2
     // c3
@@ -651,7 +651,7 @@ exports[`case.res 1`] = `
   } {
   | (None, None) => N.empty
   | (Some(n) /* (Node (l1, v1, d1, r1, h1), _) */, _)
-    when {
+    if {
       open N
       heightGet(n) >=
       switch N.toOpt(s2) {
@@ -1940,7 +1940,7 @@ let walkList: 'node. (
 ) => unit = (~prevLoc=?, ~getLoc, ~walkNode, l, t, comments) => {
   open Location
   switch l {
-  | _ when comments == list{} => ()
+  | _ if comments == list{} => ()
   | list{} =>
     switch prevLoc {
     | Some(loc) => attach(t.trailing, loc, comments)

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -109,7 +109,7 @@ let x = 1
 @attr(? var)
 let x = 1
 
-@attr(? var when x === 1)
+@attr(? var if x === 1)
 let x = 1
 
 %ext(: let x: int)
@@ -129,21 +129,21 @@ exports[`case.js 1`] = `
 "let printExprFunParameters = (~uncurried, parameters) =>
   switch parameters {
   | list{([], Asttypes.Nolabel, None, {Parsetree.ppat_desc: Ppat_any})}
-    when !uncurried =>
+    if !uncurried =>
     Doc.text(\\"_\\")
   | list{(
       [],
       Asttypes.Nolabel,
       None,
       {Parsetree.ppat_desc: Ppat_var(stringLoc)},
-    )} when !uncurried =>
+    )} if !uncurried =>
     Doc.text(stringLoc.txt)
   | list{(
       [],
       Nolabel,
       None,
       {ppat_desc: Ppat_construct({txt: Longident.Lident(\\"()\\")}, None)},
-    )} when !uncurried =>
+    )} if !uncurried =>
     Doc.text(\\"()\\")
   | parameters =>
     let lparen = if uncurried {


### PR DESCRIPTION
### Motivation

Pattern match cases can accept guards to further refine the criteria for matching a case. Pattern guards appear after the pattern and consist of an expression following the `when` keyword. The grammar expresses this as `| PATTERN => EXPRESSION when EXPRESSION`. An example:
```rescript
switch person1 {
| Teacher(_) => () // do nothing
| Student({reportCard: {gpa}}) when gpa < 0.5 =>
  Js.log("What's happening")
| Student(_) =>
  // fall-through, catch-all case
  Js.log("Heyo")
}
```

We inherited the `when` keyword from our ancestors Reason and Ocaml. This keyword is not ideal:
1) It is not a keyword in JavaScript; you need to escape it in interop scenarios.
2) `when` takes up a keyword and is only being used in one small part of the grammar. (Cost/benefit)
3) Some people have trouble remembering the exact word, is it `when` or `where` etc.

Given the above, we're planning to move towards a new syntax for guards on match cases by using the `if` keyword.
```
match-guard ::=
  IF expr
```

Applied to the example above, this would give:
```diff
- | Student({reportCard: {gpa}}) when gpa < 0.5 =>
+ | Student({reportCard: {gpa}}) if gpa < 0.5 =>
```

### Migration path
1) Accept both `when` and `if` for case guards. Printer will output `if`. No breaking change.
2) Remove support for parsing case guards with the `when` keyword. Show a nice error when the user tries to use `when` instead of `if`

This PR implements `1)`

### Prior art

* [rust](https://doc.rust-lang.org/reference/expressions/match-expr.html#match-guards)