### PR TITLE
Remove some usages of bytes

### DIFF
--- a/src/res_comment.ml
+++ b/src/res_comment.ml
@@ -57,17 +57,16 @@ let trimSpaces s =
   let len = String.length s in
   if len = 0 then s
   else if String.unsafe_get s 0 = ' ' || String.unsafe_get s (len - 1) = ' ' then (
-    let b = Bytes.of_string s in
     let i = ref 0 in
-    while !i < len && (Bytes.unsafe_get b !i) = ' ' do
+    while !i < len && (String.unsafe_get s !i) = ' ' do
       incr i
     done;
     let j = ref (len - 1) in
-    while !j >= !i && (Bytes.unsafe_get b !j) = ' ' do
+    while !j >= !i && (String.unsafe_get s !j) = ' ' do
       decr j
     done;
     if !j >= !i then
-      (Bytes.sub [@doesNotRaise]) b !i (!j - !i + 1) |> Bytes.to_string
+      (String.sub [@doesNotRaise]) s !i (!j - !i + 1)
     else
       ""
   ) else s

--- a/src/res_driver.ml
+++ b/src/res_driver.ml
@@ -50,7 +50,7 @@ let parsingEngine = {
     | _ as diagnostics -> (true, diagnostics)
     in {
       filename = engine.scanner.filename;
-      source = Bytes.to_string engine.scanner.src;
+      source = engine.scanner.src;
       parsetree = structure;
       diagnostics;
       invalid;
@@ -65,7 +65,7 @@ let parsingEngine = {
     | _ as diagnostics -> (true, diagnostics)
     in {
       filename = engine.scanner.filename;
-      source = Bytes.to_string engine.scanner.src;
+      source = engine.scanner.src;
       parsetree = signature;
       diagnostics;
       invalid;

--- a/src/res_driver_reason_binary.ml
+++ b/src/res_driver_reason_binary.ml
@@ -15,7 +15,7 @@ let extractConcreteSyntax filename =
     if String.length filename > 0 then IO.readFile ~filename
     else IO.readStdin ()
   in
-  let scanner = Res_scanner.make (Bytes.of_string src) ~filename in
+  let scanner = Res_scanner.make src ~filename in
 
   let rec next prevEndPos scanner =
     let (startPos, endPos, token) = Res_scanner.scan scanner in

--- a/src/res_io.ml
+++ b/src/res_io.ml
@@ -1,21 +1,15 @@
-(* random chunk size: 2^15, TODO: why do we guess randomly? *)
-let chunkSize = 32768
-
 let readFile ~filename =
   let chan = open_in filename in
-  let buffer = Buffer.create chunkSize in
-  let chunk = (Bytes.create [@doesNotRaise]) chunkSize in
-  let rec loop () =
-    let len = try input chan chunk 0 chunkSize with Invalid_argument _ -> 0 in
-    if len == 0 then (
-      close_in_noerr chan;
-      Buffer.contents buffer
-    ) else (
-      Buffer.add_subbytes buffer chunk 0 len;
-      loop ()
-    )
+  let content =
+    try really_input_string chan (in_channel_length chan)
+    with End_of_file -> ""
   in
-  loop ()
+  close_in_noerr chan;
+  content
+
+
+(* random chunk size: 2^15, TODO: why do we guess randomly? *)
+let chunkSize = 32768
 
 let readStdin () =
   let buffer = Buffer.create chunkSize in

--- a/src/res_parser.ml
+++ b/src/res_parser.ml
@@ -75,7 +75,7 @@ let checkProgress ~prevEndPos ~result p =
   else Some result
 
 let make ?(mode=ParseForTypeChecker) ?line src filename =
-  let scanner = Scanner.make ~filename ?line (Bytes.of_string src) in
+  let scanner = Scanner.make ~filename ?line src in
   let parserState = {
     mode;
     scanner;

--- a/src/res_scanner.mli
+++ b/src/res_scanner.mli
@@ -4,7 +4,7 @@ type charEncoding
 
 type t = {
   filename: string;
-  src: bytes;
+  src: string;
   mutable err:
     startPos: Lexing.position
     -> endPos: Lexing.position
@@ -18,12 +18,12 @@ type t = {
   mutable mode: mode list;
 }
 
-val make: ?line:int -> filename:string -> bytes -> t
+val make: ?line:int -> filename:string -> string -> t
 
 (* TODO: make this a record *)
 val scan: t -> (Lexing.position * Lexing.position * Res_token.t)
 
-val isBinaryOp: bytes -> int -> int -> bool
+val isBinaryOp: string -> int -> int -> bool
 
 val setJsxMode: t -> unit
 val setDiamondMode: t -> unit


### PR DESCRIPTION
Profiler showed that bytes allocation costed a bit. We don't mutate the src, so it can be a string. Fewer conversions

Benchmark of parser now faster! See screenshots of PR
