### PR TITLE
Fix the ^ syntax error message

### DIFF
--- a/src/res_diagnostics.ml
+++ b/src/res_diagnostics.ml
@@ -66,9 +66,11 @@ let explain t =
   | UnknownUchar uchar ->
     begin match uchar with
     | '^' ->
-      "Hmm, not sure what I should do here with this character.\nIf you're trying to deref an expression, use `foo.contents` instead."
+      "Not sure what to do with this character.\n" ^
+      "  If you're trying to dereference a mutable value, use `myValue.contents` instead.\n" ^
+      "  To concatenate strings, use `\"a\" ++ \"b\"` instead."
     | _ ->
-      "Hmm, I have no idea what this character means…"
+      "I have no idea what this character means…"
     end
   | Expected {context; token = t} ->
     let hint = match context with

--- a/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
@@ -105,8 +105,9 @@ let newX = x +. (newVelocity *. secondPerFrame)
   2 │ let newX = x +. newVelocity *. secondPerFrame^;
   3 │ 
   
-  Hmm, not sure what I should do here with this character.
-If you're trying to deref an expression, use \`foo.contents\` instead.
+  Not sure what to do with this character.
+  If you're trying to dereference a mutable value, use \`myValue.contents\` instead.
+  To concatenate strings, use \`\\"a\\" ++ \\"b\\"\` instead.
 
 
   Syntax error!
@@ -115,8 +116,9 @@ If you're trying to deref an expression, use \`foo.contents\` instead.
   2 │ let newX = x +. newVelocity *. secondPerFrame^;
   3 │ 
   
-  Hmm, not sure what I should do here with this character.
-If you're trying to deref an expression, use \`foo.contents\` instead.
+  Not sure what to do with this character.
+  If you're trying to dereference a mutable value, use \`myValue.contents\` instead.
+  To concatenate strings, use \`\\"a\\" ++ \\"b\\"\` instead.
 
 
 ========================================================"


### PR DESCRIPTION
- Some folks might think it's for string concatenation.
- "hmm" might be a bit too cute.
- We should leave 2 spaces in front of a message's new lines, since our error report system is indented 2 spaces. Technically we should be using a formatter for this but whatever.
