### PR TITLE
Remove scanner rdOffset

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2381,7 +2381,6 @@ and parseAttributesAndBinding (p : Parser.t) =
   let err = p.scanner.err in
   let ch = p.scanner.ch in
   let offset = p.scanner.offset in
-  let rdOffset = p.scanner.rdOffset in
   let lineOffset = p.scanner.lineOffset in
   let lnum = p.scanner.lnum in
   let mode = p.scanner.mode in
@@ -2404,7 +2403,6 @@ and parseAttributesAndBinding (p : Parser.t) =
       p.scanner.err <- err;
       p.scanner.ch <- ch;
       p.scanner.offset <- offset;
-      p.scanner.rdOffset <- rdOffset;
       p.scanner.lineOffset <- lineOffset;
       p.scanner.lnum <- lnum;
       p.scanner.mode <- mode;

--- a/src/res_parser.ml
+++ b/src/res_parser.ml
@@ -128,7 +128,6 @@ let lookahead p callback =
   let err = p.scanner.err in
   let ch = p.scanner.ch in
   let offset = p.scanner.offset in
-  let rdOffset = p.scanner.rdOffset in
   let lineOffset = p.scanner.lineOffset in
   let lnum = p.scanner.lnum in
   let mode = p.scanner.mode in
@@ -146,7 +145,6 @@ let lookahead p callback =
   p.scanner.err <- err;
   p.scanner.ch <- ch;
   p.scanner.offset <- offset;
-  p.scanner.rdOffset <- rdOffset;
   p.scanner.lineOffset <- lineOffset;
   p.scanner.lnum <- lnum;
   p.scanner.mode <- mode;

--- a/src/res_scanner.mli
+++ b/src/res_scanner.mli
@@ -12,7 +12,6 @@ type t = {
     -> unit;
   mutable ch: charEncoding; (* current character *)
   mutable offset: int; (* character offset *)
-  mutable rdOffset: int; (* reading offset (position after current character) *)
   mutable lineOffset: int; (* current line offset *)
   mutable lnum: int; (* current line number *)
   mutable mode: mode list;

--- a/tests/res_test.ml
+++ b/tests/res_test.ml
@@ -183,7 +183,6 @@ module ParserApiTest = struct
     assert (parser.scanner.lnum == 1);
     assert (parser.scanner.lineOffset == 0);
     assert (parser.scanner.offset == 6);
-    assert (parser.scanner.rdOffset == 7);
     assert (parser.token = Res_token.Let);
     print_endline "✅ Parser make: initializes parser defaulting to line 1 "
 
@@ -193,7 +192,6 @@ module ParserApiTest = struct
     assert (parser.scanner.lnum == 2);
     assert (parser.scanner.lineOffset == 0);
     assert (parser.scanner.offset == 3);
-    assert (parser.scanner.rdOffset == 4);
     assert (parser.token = Res_token.Let);
     print_endline "✅ Parser make: initializes parser with line set to 2"
 


### PR DESCRIPTION
This actually slows this down for a tiiiny bit because of the extra
addition in `next` and `peek`... but not significant regression
