### PR TITLE
Remove parser's line seeding api

### DIFF
--- a/src/res_parser.ml
+++ b/src/res_parser.ml
@@ -74,8 +74,8 @@ let checkProgress ~prevEndPos ~result p =
   then None
   else Some result
 
-let make ?(mode=ParseForTypeChecker) ?line src filename =
-  let scanner = Scanner.make ~filename ?line src in
+let make ?(mode=ParseForTypeChecker) src filename =
+  let scanner = Scanner.make ~filename src in
   let parserState = {
     mode;
     scanner;

--- a/src/res_parser.mli
+++ b/src/res_parser.mli
@@ -23,8 +23,7 @@ type t = {
   mutable regions: regionStatus ref list;
 }
 
-(* `line` seeds the parser's state with an initial line number. *)
-val make: ?mode:mode -> ?line:int -> string -> string -> t
+val make: ?mode:mode -> string -> string -> t
 
 val expect: ?grammar:Grammar.t -> Token.t -> t -> unit
 val optional: t -> Token.t -> bool

--- a/src/res_scanner.ml
+++ b/src/res_scanner.ml
@@ -112,7 +112,7 @@ let peek2 scanner =
   else
     hackyEOFChar
 
-let make ?(line=1) ~filename src =
+let make ~filename src =
   {
     filename;
     src = src;
@@ -120,7 +120,7 @@ let make ?(line=1) ~filename src =
     ch = if src = "" then hackyEOFChar else String.unsafe_get src 0;
     offset = 0;
     lineOffset = 0;
-    lnum = line;
+    lnum = 1;
     mode = [];
   }
 

--- a/src/res_scanner.mli
+++ b/src/res_scanner.mli
@@ -17,7 +17,7 @@ type t = {
   mutable mode: mode list;
 }
 
-val make: ?line:int -> filename:string -> string -> t
+val make: filename:string -> string -> t
 
 (* TODO: make this a record *)
 val scan: t -> (Lexing.position * Lexing.position * Res_token.t)

--- a/tests/res_test.ml
+++ b/tests/res_test.ml
@@ -186,18 +186,8 @@ module ParserApiTest = struct
     assert (parser.token = Res_token.Let);
     print_endline "✅ Parser make: initializes parser defaulting to line 1 "
 
-  let seedLineNumber () =
-    let src = "let x = 1\nlet y = 2\nlet z = 3" in
-    let parser = Res_parser.make ~line:2 src "test.res" in
-    assert (parser.scanner.lnum == 2);
-    assert (parser.scanner.lineOffset == 0);
-    assert (parser.scanner.offset == 3);
-    assert (parser.token = Res_token.Let);
-    print_endline "✅ Parser make: initializes parser with line set to 2"
-
   let run () =
     makeDefault();
-    seedLineNumber()
 
 end
 


### PR DESCRIPTION
Apparently this was needed by @ryyppy for the doc site's snippets diagnostics a while ago. Not sure it's still used. Removing it.
