### PR TITLE
Fix parsing and printing of externals inside ext/attr payload

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -6111,6 +6111,7 @@ and parseAttributeId ~startPos p =
 and parsePayload p =
   match p.Parser.token with
   | Lparen when p.startPos.pos_cnum = p.prevEndPos.pos_cnum  ->
+    Parser.leaveBreadcrumb p Grammar.AttributePayload;
     Parser.next p;
     begin match p.token with
     | Colon ->
@@ -6127,6 +6128,7 @@ and parsePayload p =
         Parsetree.PTyp (parseTypExpr p)
       in
       Parser.expect Rparen p;
+      Parser.eatBreadcrumb p;
       payload
     | Question ->
       Parser.next p;
@@ -6139,6 +6141,7 @@ and parsePayload p =
         None
       in
       Parser.expect Rparen p;
+      Parser.eatBreadcrumb p;
       Parsetree.PPat (pattern, expr)
     | _ ->
       let items = parseDelimitedRegion
@@ -6148,6 +6151,7 @@ and parsePayload p =
         p
       in
       Parser.expect Rparen p;
+      Parser.eatBreadcrumb p;
       Parsetree.PStr items
     end
   | _ -> Parsetree.PStr []

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -58,6 +58,7 @@ type t =
   | ListExpr
   | JsFfiImport
   | Pattern
+  | AttributePayload
 
 let toString = function
   | OpenDescription -> "an open description"
@@ -118,6 +119,7 @@ let toString = function
   | JsxChild -> "jsx child"
   | Pattern -> "pattern"
   | ExprFor -> "a for expression"
+  | AttributePayload -> "an attribute payload"
 
 let isSignatureItemStart = function
   | Token.At
@@ -336,6 +338,7 @@ let isListElement grammar token =
   | Primitive -> begin match token with Token.String _ -> true | _ -> false end
   | JsxAttribute -> isJsxAttributeStart token
   | JsFfiImport -> isJsFfiImportStart token
+  | AttributePayload -> token = Lparen
   | _ -> false
 
 let isListTerminator grammar token =
@@ -362,6 +365,7 @@ let isListTerminator grammar token =
   | ConstructorDeclaration, token when token <> Bar -> true
   | Primitive, Semicolon -> true
   | Primitive, token when isStructureItemStart token -> true
+  | AttributePayload, Rparen -> true
 
   | _ -> false
 

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -122,6 +122,11 @@ let x = 1
   \\"A\\"
   \\"B\\"
 )
+
+@@superPrivate(@module(\\"./logo.svg\\") external logo: string = \\"default\\")
+
+@inlinePrivate(@module(\\"./logo.svg\\") external logo: string = \\"default\\")
+let x = 1
 "
 `;
 

--- a/tests/printer/other/attributes.res
+++ b/tests/printer/other/attributes.res
@@ -14,3 +14,13 @@ let x = 1
 ) 
 
 %%ext("A"; "B")
+
+@@superPrivate(
+  @module("./logo.svg") external logo: string = "default"
+)
+
+@inlinePrivate(
+  @module("./logo.svg") external logo: string = "default"
+)
+let x = 1
+

--- a/tests/printer/structure/__snapshots__/render.spec.js.snap
+++ b/tests/printer/structure/__snapshots__/render.spec.js.snap
@@ -90,6 +90,8 @@ exports[`extension.js 1`] = `
 @attrStructureLvl4
 @attrStructureLvl5
 %%raw(\\"__eval__gc()\\")
+
+%%private(@module(\\"./logo.svg\\") external logo: string = \\"default\\")
 "
 `;
 

--- a/tests/printer/structure/extension.js
+++ b/tests/printer/structure/extension.js
@@ -8,3 +8,7 @@
 
 @attrStructureLvl @attrStructureLvl2 @attrStructureLvl3 @attrStructureLvl4 @attrStructureLvl5
 %%raw("__eval__gc()")
+
+%%private(
+  @module("./logo.svg") external logo: string = "default"
+)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/260

Structure items inside an attribute payload don't need semicolons