### PR TITLE
Fix eof unclosed multiline comment location report

### DIFF
--- a/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
@@ -152,7 +152,7 @@ exports[`unclosedComment.js 1`] = `
 =====Errors=============================================
 
   Syntax error!
-  parsing/errors/scanner/unclosedComment.js:1:3-3:0  
+  parsing/errors/scanner/unclosedComment.js:1:1-3:0  
   1 │ /* eof
   2 │  * reached
   3 │ 


### PR DESCRIPTION
It previously didn't include the `/*` in the highlight
