### PR TITLE
Parse empty braces, i.e. `{}` as unit expression.

### DIFF
--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2494,6 +2494,7 @@ and printExpression (e : Parsetree.expression) cmtTbl =
   | Parsetree.Pexp_constant c -> printConstant c
   | Pexp_construct _ when ParsetreeViewer.hasJsxAttribute e.pexp_attributes ->
     printJsxFragment e cmtTbl
+  | Pexp_construct ({txt = Longident.Lident "()"; loc}, _) when loc.loc_ghost -> Doc.nil
   | Pexp_construct ({txt = Longident.Lident "()"}, _) -> Doc.text "()"
   | Pexp_construct ({txt = Longident.Lident "[]"}, _) ->
     Doc.concat [


### PR DESCRIPTION
## Motivation
Currently an expression with empty braces results in a syntax error. If you write the same code in Js, it parses. It is quite common while writing code that you write out the “empty braces” first. Not sure if fixing a syntax error is good UX. Let's just parse this as a unit expression. An empty record does not exist, so there’s no conflict here. This is also more consistent with JavaScript and this is a low-risk change from a language perspective: changing a syntax error into a default. The default () seems to be the right semantics for {}.

## What does the difference look like?
**before**

![](https://forum.rescript-lang.org/uploads/default/original/1X/50254af961b63fa08f52c3a752219542229b224d.png)

**after**
```rescript
let f = () => {}
// parses as
let f = () => {
  ()
}

for _ in 0 to 10 {
}
// parses as
for _ in 0 to 10 {
  ()
}
```