### PR TITLE
Enable stack trace for binary; remove an `exit 1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OCAMLOPT=ocamlopt.opt
-OCAMLFLAGS= -w +a-4-42-40-9-48 -warn-error +a -bin-annot -I +compiler-libs -I src -I tests -absname
+OCAMLFLAGS=-g -w +a-4-42-40-9-48 -warn-error +a -bin-annot -I +compiler-libs -I src -I tests -absname
 OCAMLDEP=ocamldep.opt
 %.cmi : %.mli
 	$(OCAMLOPT) $(OCAMLFLAGS) -c $<

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ was more than if I hand wrote the code myself.
 "
 J. Blow.
 
-### Setup & Usage
-
-Currently for devs only.
+### Setup & Usage (For Repo Devs Only)
 
 Required:
 - [NodeJS](https://nodejs.org/)
@@ -38,7 +36,7 @@ npm install
 make # or: make -j9 for faster build
 ```
 
-This will produce the final binary `lib/rescript.exe` used for testing
+This will produce the final binary `lib/rescript.exe` used for testing.
 
 First build is super slow because we're also building our vendored `refmt` (only used for the conversion tool). Subsequent builds should be <2s. If not, please file an issue (build speed is a priority).
 
@@ -77,6 +75,14 @@ Benchmark:
 ```sh
 make bench
 ```
+
+Enable stack trace:
+```sh
+# Before you run the binary
+export OCAMLRUNPARAM="b"
+```
+
+This is likely a known knowledge: add the above line into your shell rc file so that every shell startup you have OCaml stack trace enabled.
 
 ### Development Docs
 


### PR DESCRIPTION
This makes the perf slightly slower (but basically unnoticeable), and the compilation slower, but this repo's files are compiled with stack trace enabled inside the compiler project anyway, so this is more realistic.

On the other hand, having a general try catch in res_cli that swallowed important exceptions such as `String.sub` and `Array.get` would have made debugging much harder.
