### PR TITLE
Experimental: turn most of printer's lists into arrays

### DIFF
--- a/.depend
+++ b/.depend
@@ -1,5 +1,6 @@
 src/reactjs_jsx_ppx_v3.cmx : src/reactjs_jsx_ppx_v3.cmi
 src/reactjs_jsx_ppx_v3.cmi :
+src/res_array.cmx :
 src/res_ast_conversion.cmx : src/res_printer.cmx src/res_ast_conversion.cmi
 src/res_ast_conversion.cmi :
 src/res_ast_debugger.cmx : src/res_driver.cmx src/res_doc.cmx \
@@ -48,7 +49,7 @@ src/res_multi_printer.cmx : src/res_printer.cmx src/res_io.cmx \
     src/res_multi_printer.cmi
 src/res_multi_printer.cmi :
 src/res_outcome_printer.cmx : src/res_token.cmx src/res_doc.cmx \
-    src/res_outcome_printer.cmi
+    src/res_array.cmx src/res_outcome_printer.cmi
 src/res_outcome_printer.cmi :
 src/res_parens.cmx : src/res_parsetree_viewer.cmx src/res_parens.cmi
 src/res_parens.cmi :
@@ -62,7 +63,7 @@ src/res_parsetree_viewer.cmx : src/res_parsetree_viewer.cmi
 src/res_parsetree_viewer.cmi :
 src/res_printer.cmx : src/res_token.cmx src/res_parsetree_viewer.cmx \
     src/res_parens.cmx src/res_doc.cmx src/res_comments_table.cmx \
-    src/res_comment.cmx src/res_printer.cmi
+    src/res_comment.cmx src/res_array.cmx src/res_printer.cmi
 src/res_printer.cmi : src/res_doc.cmi src/res_comments_table.cmx \
     src/res_comment.cmi
 src/res_reporting.cmx : src/res_token.cmx src/res_grammar.cmx

--- a/.depend
+++ b/.depend
@@ -4,7 +4,7 @@ src/res_array.cmx :
 src/res_ast_conversion.cmx : src/res_printer.cmx src/res_ast_conversion.cmi
 src/res_ast_conversion.cmi :
 src/res_ast_debugger.cmx : src/res_driver.cmx src/res_doc.cmx \
-    src/res_ast_debugger.cmi
+    src/res_array.cmx src/res_ast_debugger.cmi
 src/res_ast_debugger.cmi : src/res_driver.cmi
 src/res_cli.cmx : src/res_driver_reason_binary.cmx \
     src/res_driver_ml_parser.cmx src/res_driver_binary.cmx src/res_driver.cmx \
@@ -12,7 +12,7 @@ src/res_cli.cmx : src/res_driver_reason_binary.cmx \
 src/res_comment.cmx : src/res_comment.cmi
 src/res_comment.cmi :
 src/res_comments_table.cmx : src/res_parsetree_viewer.cmx src/res_doc.cmx \
-    src/res_comment.cmx
+    src/res_comment.cmx src/res_array.cmx
 src/res_core.cmx : src/res_token.cmx src/res_scanner.cmx src/res_printer.cmx \
     src/res_parser.cmx src/res_js_ffi.cmx src/res_grammar.cmx src/res_doc.cmx \
     src/res_diagnostics.cmx src/res_comments_table.cmx src/res_core.cmi
@@ -21,7 +21,7 @@ src/res_diagnostics.cmx : src/res_token.cmx src/res_grammar.cmx \
     src/res_diagnostics_printing_utils.cmx src/res_diagnostics.cmi
 src/res_diagnostics.cmi : src/res_token.cmx src/res_grammar.cmx
 src/res_diagnostics_printing_utils.cmx :
-src/res_doc.cmx : src/res_minibuffer.cmx src/res_doc.cmi
+src/res_doc.cmx : src/res_minibuffer.cmx src/res_array.cmx src/res_doc.cmi
 src/res_doc.cmi :
 src/res_driver.cmx : src/res_printer.cmx src/res_parser.cmx src/res_io.cmx \
     src/res_diagnostics.cmx src/res_core.cmx src/res_comment.cmx \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ depend:
 
 API_FILES = \
 	src/reactjs_jsx_ppx_v3.cmx\
+	src/res_array.cmx\
 	src/res_io.cmx\
 	src/res_minibuffer.cmx\
 	src/res_doc.cmx\

--- a/src/res_array.ml
+++ b/src/res_array.ml
@@ -1,0 +1,30 @@
+(* Hopefully these gradually disappear one day when we switch more and more stuff to array *)
+(* These are still needed for a while since lots of AST payloads are lists *)
+
+let mapListi f l =
+  match l with
+  | [] -> [||]
+  | head::rest as l ->
+    let result = (Array.make [@doesNotRaise]) (List.length l) (f 0 head) in
+    let rec loop lst i =
+      match lst with
+      | [] -> result
+      | head::rest ->
+        Array.unsafe_set result i (f i head);
+        loop rest (i + 1)
+    in
+    loop rest 1
+
+let mapList f l =
+  match l with
+  | [] -> [||]
+  | head::rest as l ->
+    let result = (Array.make [@doesNotRaise]) (List.length l) (f head) in
+    let rec loop lst i =
+      match lst with
+      | [] -> result
+      | head::rest ->
+        Array.unsafe_set result i (f head);
+        loop rest (i + 1)
+    in
+    loop rest 1

--- a/src/res_array.ml
+++ b/src/res_array.ml
@@ -28,3 +28,10 @@ let mapList f l =
         loop rest (i + 1)
     in
     loop rest 1
+
+let appendToList arr lst =
+  let rec loop i acc =
+    if i < 0 then acc
+    else loop (i - 1) ((Array.unsafe_get arr i)::acc)
+  in
+  loop (Array.length arr - 1) lst

--- a/src/res_ast_debugger.ml
+++ b/src/res_ast_debugger.ml
@@ -27,20 +27,20 @@ end = struct
     match t with
     | Atom s -> Doc.text s
     | List [] -> Doc.text "()"
-    | List [sexpr] -> Doc.concat [Doc.lparen; toDoc sexpr; Doc.rparen;]
+    | List [sexpr] -> Doc.concat [|Doc.lparen; toDoc sexpr; Doc.rparen;|]
     | List (hd::tail) ->
       Doc.group (
-        Doc.concat [
+        Doc.concat [|
           Doc.lparen;
           toDoc hd;
           Doc.indent (
-            Doc.concat [
+            Doc.concat [|
               Doc.line;
               Doc.join ~sep:Doc.line (List.map toDoc tail);
-            ]
+            |]
           );
           Doc.rparen;
-        ]
+        |]
       )
 
   let toString sexpr =

--- a/src/res_ast_debugger.ml
+++ b/src/res_ast_debugger.ml
@@ -36,7 +36,7 @@ end = struct
           Doc.indent (
             Doc.concat [|
               Doc.line;
-              Doc.join ~sep:Doc.line (List.map toDoc tail);
+              Doc.join ~sep:Doc.line (tail |> Array.of_list |> Array.map toDoc);
             |]
           );
           Doc.rparen;

--- a/src/res_ast_debugger.ml
+++ b/src/res_ast_debugger.ml
@@ -36,7 +36,7 @@ end = struct
           Doc.indent (
             Doc.concat [|
               Doc.line;
-              Doc.join ~sep:Doc.line (tail |> Array.of_list |> Array.map toDoc);
+              Doc.join ~sep:Doc.line (tail |> Res_array.mapList toDoc);
             |]
           );
           Doc.rparen;

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -41,7 +41,9 @@ let log t =
         Doc.indent (
           Doc.concat [|
             Doc.line;
-            Doc.join ~sep:Doc.comma (List.map (fun c -> Doc.text (Comment.txt c)) v)
+            Doc.join
+              ~sep:Doc.comma
+              (v |> Array.of_list |> Array.map (fun c -> Doc.text (Comment.txt c)))
           |]
         );
         Doc.line;
@@ -68,7 +70,9 @@ let log t =
         Doc.indent (
           Doc.concat [|
             Doc.line;
-            Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (List.map (fun c -> Doc.text (Comment.txt c)) v)
+            Doc.join
+              ~sep:(Doc.concat [|Doc.comma; Doc.line|])
+              (v |> Array.of_list |> Array.map (fun c -> Doc.text (Comment.txt c)))
           |]
         );
         Doc.line;

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -24,7 +24,7 @@ let empty = make ()
 let log t =
   let open Location in
   let leadingStuff = Hashtbl.fold (fun (k : Location.t) (v : Comment.t list) acc ->
-    let loc = Doc.concat [
+    let loc = Doc.concat [|
       Doc.lbracket;
       Doc.text (string_of_int k.loc_start.pos_lnum);
       Doc.text ":";
@@ -34,24 +34,24 @@ let log t =
       Doc.text ":";
       Doc.text (string_of_int (k.loc_end.pos_cnum  - k.loc_end.pos_bol));
       Doc.rbracket;
-    ] in
+    |] in
     let doc = Doc.breakableGroup ~forceBreak:true (
-      Doc.concat [
+      Doc.concat [|
         loc;
         Doc.indent (
-          Doc.concat [
+          Doc.concat [|
             Doc.line;
             Doc.join ~sep:Doc.comma (List.map (fun c -> Doc.text (Comment.txt c)) v)
-          ]
+          |]
         );
         Doc.line;
-      ]
+      |]
     ) in
     doc::acc
   ) t.leading []
   in
   let trailingStuff = Hashtbl.fold (fun (k : Location.t) (v : Comment.t list) acc ->
-    let loc = Doc.concat [
+    let loc = Doc.concat [|
       Doc.lbracket;
       Doc.text (string_of_int k.loc_start.pos_lnum);
       Doc.text ":";
@@ -61,34 +61,34 @@ let log t =
       Doc.text ":";
       Doc.text (string_of_int (k.loc_end.pos_cnum  - k.loc_end.pos_bol));
       Doc.rbracket;
-    ] in
+    |] in
     let doc = Doc.breakableGroup ~forceBreak:true (
-      Doc.concat [
+      Doc.concat [|
         loc;
         Doc.indent (
-          Doc.concat [
+          Doc.concat [|
             Doc.line;
-            Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (List.map (fun c -> Doc.text (Comment.txt c)) v)
-          ]
+            Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (List.map (fun c -> Doc.text (Comment.txt c)) v)
+          |]
         );
         Doc.line;
-      ]
+      |]
     ) in
     doc::acc
   ) t.trailing []
   in
   Doc.breakableGroup ~forceBreak:true (
-    Doc.concat [
+    Doc.concat [|
       Doc.text "leading comments:";
       Doc.line;
-      Doc.indent (Doc.concat leadingStuff);
+      Doc.indent (Doc.concat (Array.of_list leadingStuff));
       Doc.line;
       Doc.line;
       Doc.text "trailing comments:";
-      Doc.indent (Doc.concat trailingStuff);
+      Doc.indent (Doc.concat (Array.of_list trailingStuff));
       Doc.line;
       Doc.line;
-    ]
+    |]
   ) |> Doc.toString ~width:80 |> print_endline
   [@@live]
 

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -43,7 +43,7 @@ let log t =
             Doc.line;
             Doc.join
               ~sep:Doc.comma
-              (v |> Array.of_list |> Array.map (fun c -> Doc.text (Comment.txt c)))
+              (v |> Res_array.mapList (fun c -> Doc.text (Comment.txt c)))
           |]
         );
         Doc.line;
@@ -72,7 +72,7 @@ let log t =
             Doc.line;
             Doc.join
               ~sep:(Doc.concat [|Doc.comma; Doc.line|])
-              (v |> Array.of_list |> Array.map (fun c -> Doc.text (Comment.txt c)))
+              (v |> Res_array.mapList (fun c -> Doc.text (Comment.txt c)))
           |]
         );
         Doc.line;

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -81,16 +81,16 @@ Solution: directly use `concat`."
 
   let experimentalIfLet expr =
     let switchExpr = {expr with Parsetree.pexp_attributes = []} in
-    Doc.concat [
+    Doc.concat [|
       Doc.text "If-let is currently highly experimental.";
       Doc.line;
       Doc.text "Use a regular `switch` with pattern matching instead:";
-      Doc.concat [
+      Doc.concat [|
         Doc.hardLine;
         Doc.hardLine;
         ResPrinter.printExpression switchExpr (CommentTable.empty);
-      ]
-    ] |> Doc.toString ~width:80
+      |]
+    |] |> Doc.toString ~width:80
 
   let typeParam = "A type param consists of a singlequote followed by a name like `'a` or `'A`"
   let typeVar = "A type variable consists of a singlequote followed by a name like `'a` or `'A`"
@@ -2264,19 +2264,19 @@ and overParseConstrainedOrCoercedOrArrowExpression p expr =
       in
       let msg =
         Doc.breakableGroup ~forceBreak:true (
-          Doc.concat [
+          Doc.concat [|
             Doc.text "Did you mean to annotate the parameter type or the return type?";
             Doc.indent (
-              Doc.concat [
+              Doc.concat [|
                 Doc.line;
                 Doc.text "1) ";
                 ResPrinter.printExpression arrow1 CommentTable.empty;
                 Doc.line;
                 Doc.text "2) ";
                 ResPrinter.printExpression arrow2 CommentTable.empty;
-              ]
+              |]
             )
-          ]
+          |]
         ) |> Doc.toString ~width:80
       in
       Parser.err
@@ -2294,15 +2294,15 @@ and overParseConstrainedOrCoercedOrArrowExpression p expr =
         ~endPos:typ.ptyp_loc.loc_end
         p
         (Diagnostics.message
-          (Doc.breakableGroup ~forceBreak:true (Doc.concat [
+          (Doc.breakableGroup ~forceBreak:true (Doc.concat [|
             Doc.text "Expressions with type constraints need to be wrapped in parens:";
             Doc.indent (
-              Doc.concat [
+              Doc.concat [|
               Doc.line;
               ResPrinter.addParens (ResPrinter.printExpression expr CommentTable.empty);
-              ]
+              |]
             )
-          ]) |> Doc.toString ~width:80
+          |]) |> Doc.toString ~width:80
         ))
       in
       expr
@@ -4058,15 +4058,15 @@ and parseTypeConstructorArgs ~constrName p =
       let typ = Ast_helper.Typ.constr constrName typeArgs in
       let msg =
         Doc.breakableGroup ~forceBreak:true (
-          Doc.concat [
+          Doc.concat [|
             Doc.text "Type parameters require angle brackets:";
             Doc.indent (
-              Doc.concat [
+              Doc.concat [|
                 Doc.line;
                 ResPrinter.printTypExpr typ CommentTable.empty;
-              ]
+              |]
             )
-          ]
+          |]
         ) |> Doc.toString ~width:80
       in
       Parser.err ~startPos:openingStartPos p (Diagnostics.message msg);
@@ -4465,18 +4465,18 @@ and parseTypeParams ~parent p =
     | Rparen when opening = Token.Lparen ->
       let msg =
         Doc.breakableGroup ~forceBreak:true (
-          Doc.concat [
+          Doc.concat [|
             Doc.text "Type parameters require angle brackets:";
             Doc.indent (
-              Doc.concat [
+              Doc.concat [|
                 Doc.line;
-                Doc.concat [
+                Doc.concat [|
                   ResPrinter.printLongident parent.Location.txt;
                   ResPrinter.printTypeParams params CommentTable.empty;
-                ]
-              ]
+                |]
+              |]
             )
-          ]
+          |]
         ) |> Doc.toString ~width:80
       in
       Parser.err ~startPos:openingStartPos p (Diagnostics.message msg);

--- a/src/res_doc.mli
+++ b/src/res_doc.mli
@@ -6,7 +6,7 @@ val hardLine: t
 val softLine: t
 val literalLine: t
 val text: string -> t
-val concat: t list -> t
+val concat: t array -> t
 val indent: t -> t
 val ifBreaks: t -> t -> t
 val lineSuffix: t -> t

--- a/src/res_doc.mli
+++ b/src/res_doc.mli
@@ -15,7 +15,7 @@ val breakableGroup: forceBreak : bool -> t -> t
 (* `customLayout docs` will pick the layout that fits from `docs`.
  * This is a very expensive computation as every layout from the list
  * will be checked until one fits. *)
-val customLayout: t list -> t
+val customLayout: t array -> t
 val breakParent: t
 val join: sep: t -> t array -> t
 

--- a/src/res_doc.mli
+++ b/src/res_doc.mli
@@ -17,7 +17,7 @@ val breakableGroup: forceBreak : bool -> t -> t
  * will be checked until one fits. *)
 val customLayout: t list -> t
 val breakParent: t
-val join: sep: t -> t list -> t
+val join: sep: t -> t array -> t
 
 val space: t
 val comma: t

--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -49,20 +49,20 @@ let classifyIdentContent ~allowUident txt =
 
 let printIdentLike ~allowUident txt =
   match classifyIdentContent ~allowUident txt with
-  | ExoticIdent -> Doc.concat [
+  | ExoticIdent -> Doc.concat [|
       Doc.text "\\\"";
       Doc.text txt;
       Doc.text"\""
-    ]
+    |]
   | NormalIdent -> Doc.text txt
 
 let printPolyVarIdent txt =
   match classifyIdentContent ~allowUident:true txt with
-  | ExoticIdent -> Doc.concat [
+  | ExoticIdent -> Doc.concat [|
      Doc.text "\"";
      Doc.text txt;
      Doc.text"\""
-   ]
+   |]
   | NormalIdent -> Doc.text txt
 
   (* ReScript doesn't have parenthesized identifiers.
@@ -114,34 +114,34 @@ let printPolyVarIdent txt =
      let rec printOutIdentDoc ?(allowUident=true) (ident : Outcometree.out_ident) =
        match ident with
        | Oide_ident s -> printIdentLike ~allowUident s
-       | Oide_dot (ident, s) -> Doc.concat [
+       | Oide_dot (ident, s) -> Doc.concat [|
            printOutIdentDoc ident;
            Doc.dot;
            Doc.text s;
-         ]
-       | Oide_apply (call, arg) ->Doc.concat [
+         |]
+       | Oide_apply (call, arg) ->Doc.concat [|
            printOutIdentDoc call;
            Doc.lparen;
            printOutIdentDoc arg;
            Doc.rparen;
-         ]
+         |]
 
    let printOutAttributeDoc (outAttribute: Outcometree.out_attribute) =
-     Doc.concat [
+     Doc.concat [|
        Doc.text "@";
        Doc.text outAttribute.oattr_name;
-     ]
+     |]
 
    let printOutAttributesDoc (attrs: Outcometree.out_attribute list) =
      match attrs with
      | [] -> Doc.nil
      | attrs ->
-       Doc.concat [
+       Doc.concat [|
          Doc.group (
            Doc.join ~sep:Doc.line (List.map printOutAttributeDoc attrs)
          );
          Doc.line;
-       ]
+       |]
 
    let rec collectArrowArgs (outType: Outcometree.out_type) args =
      match outType with
@@ -168,58 +168,58 @@ let printPolyVarIdent txt =
       | (true, None) -> (* [#A | #B] *) Doc.softLine
       | (false, None) ->
         (* [> #A | #B] *)
-        Doc.concat [Doc.greaterThan; Doc.line]
+        Doc.concat [|Doc.greaterThan; Doc.line|]
       | (true, Some []) ->
         (* [< #A | #B] *)
-        Doc.concat [Doc.lessThan; Doc.line]
+        Doc.concat [|Doc.lessThan; Doc.line|]
       | (true, Some _) ->
         (* [< #A | #B > #X #Y ] *)
-        Doc.concat [Doc.lessThan; Doc.line]
+        Doc.concat [|Doc.lessThan; Doc.line|]
       | (false, Some _) ->
        (* impossible!? ocaml seems to print ?, see oprint.ml in 4.06 *)
-        Doc.concat [Doc.text "?"; Doc.line]
+        Doc.concat [|Doc.text "?"; Doc.line|]
       in
       Doc.group (
-         Doc.concat [
+         Doc.concat [|
            if nonGen then Doc.text "_" else Doc.nil;
            Doc.lbracket;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                opening;
                printOutVariant outVariant
-             ]
+             |]
            );
            begin match labels with
            | None | Some [] -> Doc.nil
            | Some tags ->
              Doc.group (
-               Doc.concat [
+               Doc.concat [|
                  Doc.space;
                  Doc.join ~sep:Doc.space (
                    List.map (fun lbl -> printIdentLike ~allowUident:true lbl) tags
                  )
-               ]
+               |]
              )
            end;
            Doc.softLine;
            Doc.rbracket;
-         ]
+         |]
        )
      | Otyp_alias (typ, aliasTxt) ->
-       Doc.concat [
+       Doc.concat [|
          printOutTypeDoc typ;
          Doc.text " as '";
          Doc.text aliasTxt
-       ]
+       |]
      | Otyp_constr (
         Oide_dot (Oide_dot (Oide_ident "Js", "Fn") , "arity0"), (* Js.Fn.arity0 *)
         [Otyp_constr (Oide_ident ident, [])] (* int or unit or string *)
        ) ->
         (* Js.Fn.arity0<int> -> (.) => int*)
-        Doc.concat [
+        Doc.concat [|
           Doc.text "(.) => ";
           Doc.text ident;
-        ]
+        |]
      | Otyp_constr (
         Oide_dot (Oide_dot (Oide_ident "Js", "Fn") , ident), (* Js.Fn.arity2 *)
         [(Otyp_arrow _) as arrowType] (* (int, int) => int *)
@@ -229,27 +229,27 @@ let printPolyVarIdent txt =
      | Otyp_constr (outIdent, []) ->
        printOutIdentDoc ~allowUident:false outIdent
      | Otyp_manifest (typ1, typ2) ->
-         Doc.concat [
+         Doc.concat [|
            printOutTypeDoc typ1;
            Doc.text " = ";
            printOutTypeDoc typ2;
-         ]
+         |]
      | Otyp_record record ->
        printRecordDeclarationDoc ~inline:true record
      | Otyp_stuff txt -> Doc.text txt
-     | Otyp_var (ng, s) -> Doc.concat [
+     | Otyp_var (ng, s) -> Doc.concat [|
          Doc.text ("'" ^ (if ng then "_" else ""));
          Doc.text s
-       ]
+       |]
      | Otyp_object (fields, rest) -> printObjectFields fields rest
      | Otyp_class _ -> Doc.nil
      | Otyp_attribute (typ, attribute) ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            printOutAttributeDoc attribute;
            Doc.line;
            printOutTypeDoc typ;
-         ]
+         |]
        )
      (* example: Red | Blue | Green | CustomColour(float, float, float) *)
      | Otyp_sum constructors ->
@@ -266,54 +266,54 @@ let printPolyVarIdent txt =
        let argsDoc = match args with
        | [] -> Doc.nil
        | args ->
-         Doc.concat [
+         Doc.concat [|
            Doc.lessThan;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printOutTypeDoc args
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.greaterThan;
-         ]
+         |]
        in
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            printOutIdentDoc outIdent;
            argsDoc;
-         ]
+         |]
        )
      | Otyp_tuple tupleArgs ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.lparen;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printOutTypeDoc tupleArgs
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.rparen;
-         ]
+         |]
        )
      | Otyp_poly (vars, outType) ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.join ~sep:Doc.space (
              List.map (fun var -> Doc.text ("'" ^ var)) vars
            );
            Doc.dot;
            Doc.space;
            printOutTypeDoc outType;
-         ]
+         |]
        )
      | Otyp_arrow _ as typ ->
        printOutArrowType ~uncurried:false typ
@@ -322,16 +322,16 @@ let printPolyVarIdent txt =
 
    and printOutArrowType ~uncurried typ =
      let (typArgs, typ) = collectArrowArgs typ [] in
-     let args = Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+     let args = Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
        List.map (fun (lbl, typ) ->
          if lbl = "" then
            printOutTypeDoc typ
          else
            Doc.group (
-             Doc.concat [
+             Doc.concat [|
                Doc.text ("~" ^ lbl ^ ": ");
                printOutTypeDoc typ
-             ]
+             |]
            )
        ) typArgs
      ) in
@@ -345,26 +345,26 @@ let printPolyVarIdent txt =
        in
        if needsParens then
          Doc.group (
-           Doc.concat [
+           Doc.concat [|
              if uncurried then Doc.text "(. " else Doc.lparen;
              Doc.indent (
-               Doc.concat [
+               Doc.concat [|
                  Doc.softLine;
                  args;
-               ]
+               |]
              );
              Doc.trailingComma;
              Doc.softLine;
              Doc.rparen;
-           ]
+           |]
          )
        else args
      in
-     Doc.concat [
+     Doc.concat [|
        argsDoc;
        Doc.text " => ";
        printOutTypeDoc typ;
-     ]
+     |]
 
 
    and printOutVariant variant = match variant with
@@ -379,36 +379,36 @@ let printPolyVarIdent txt =
            | [(Outcometree.Otyp_tuple _)] -> false
            | _ -> true
            in
-           Doc.concat [
+           Doc.concat [|
              if i > 0 then
                Doc.text "| "
              else
                Doc.ifBreaks (Doc.text "| ") Doc.nil;
              Doc.group (
-               Doc.concat [
+               Doc.concat [|
                  Doc.text "#";
                  printPolyVarIdent name;
                  match types with
                  | [] -> Doc.nil
                  | types ->
-                   Doc.concat [
+                   Doc.concat [|
                      if ampersand then Doc.text " & " else Doc.nil;
                      Doc.indent (
-                       Doc.concat [
-                         Doc.join ~sep:(Doc.concat [Doc.text " &"; Doc.line])
+                       Doc.concat [|
+                         Doc.join ~sep:(Doc.concat [|Doc.text " &"; Doc.line|])
                           (List.map (fun typ ->
                             let outTypeDoc = printOutTypeDoc typ in
                             if needsParens then
-                              Doc.concat [Doc.lparen; outTypeDoc; Doc.rparen]
+                              Doc.concat [|Doc.lparen; outTypeDoc; Doc.rparen|]
                             else
                               outTypeDoc
                           ) types)
-                       ];
+                       |];
                      );
-                   ]
-               ]
+                   |]
+               |]
              )
-           ]
+           |]
          ) fields
        )
      | Ovar_typ typ -> printOutTypeDoc typ
@@ -419,53 +419,53 @@ let printPolyVarIdent txt =
      | None -> Doc.nil
      in
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.lbrace;
          dots;
          Doc.indent (
-           Doc.concat [
+           Doc.concat [|
              Doc.softLine;
-             Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+             Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                List.map (fun (lbl, outType) -> Doc.group (
-                 Doc.concat [
+                 Doc.concat [|
                    Doc.text ("\"" ^ lbl ^ "\": ");
                    printOutTypeDoc outType;
-                 ]
+                 |]
                )) fields
              )
-           ]
+           |]
          );
          Doc.softLine;
          Doc.trailingComma;
          Doc.rbrace;
-       ]
+       |]
      )
 
 
    and printOutConstructorsDoc constructors =
      Doc.group (
        Doc.indent (
-         Doc.concat [
+         Doc.concat [|
            Doc.line;
            Doc.join ~sep:Doc.line (
              List.mapi (fun i constructor ->
-               Doc.concat [
+               Doc.concat [|
                  if i > 0 then Doc.text "| " else Doc.ifBreaks (Doc.text "| ") Doc.nil;
                  printOutConstructorDoc constructor;
-               ]
+               |]
              ) constructors
            )
-         ]
+         |]
        )
      )
 
    and printOutConstructorDoc (name, args, gadt) =
        let gadtDoc = match gadt with
        | Some outType ->
-         Doc.concat [
+         Doc.concat [|
            Doc.text ": ";
            printOutTypeDoc outType
-         ]
+         |]
        | None -> Doc.nil
        in
        let argsDoc = match args with
@@ -477,64 +477,64 @@ let printPolyVarIdent txt =
           *      mutable updatedTime: float,
           *    })
           *)
-         Doc.concat [
+         Doc.concat [|
            Doc.lparen;
            Doc.indent (
              printRecordDeclarationDoc ~inline:true record;
            );
            Doc.rparen;
-         ]
+         |]
        | _types ->
          Doc.indent (
-           Doc.concat [
+           Doc.concat [|
              Doc.lparen;
              Doc.indent (
-               Doc.concat [
+               Doc.concat [|
                  Doc.softLine;
-                 Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+                 Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                    List.map printOutTypeDoc args
                  )
-               ]
+               |]
              );
              Doc.trailingComma;
              Doc.softLine;
              Doc.rparen;
-           ]
+           |]
          )
        in
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.text name;
            argsDoc;
            gadtDoc
-         ]
+         |]
        )
 
    and printRecordDeclRowDoc (name, mut, arg) =
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          if mut then Doc.text "mutable " else Doc.nil;
          printIdentLike ~allowUident:false name;
          Doc.text ": ";
          printOutTypeDoc arg;
-       ]
+       |]
      )
 
    and printRecordDeclarationDoc ~inline rows =
-     let content = Doc.concat [
+     let content = Doc.concat [|
        Doc.lbrace;
        Doc.indent (
-         Doc.concat [
+         Doc.concat [|
            Doc.softLine;
-           Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+           Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
              List.map printRecordDeclRowDoc rows
            )
-         ]
+         |]
        );
        Doc.trailingComma;
        Doc.softLine;
        Doc.rbrace;
-     ] in
+     |] in
      if not inline then
        Doc.group content
      else content
@@ -544,10 +544,10 @@ let printPolyVarIdent txt =
        (Doc.toString ~width:80 (printOutTypeDoc outType))
 
    let printTypeParameterDoc (typ, (co, cn)) =
-     Doc.concat [
+     Doc.concat [|
        if not cn then Doc.text "+" else if not co then Doc.text "-" else Doc.nil;
        if typ = "_" then Doc.text "_" else Doc.text ("'" ^ typ)
-     ]
+     |]
 
 
    let rec printOutSigItemDoc (outSigItem : Outcometree.out_sig_item) =
@@ -556,7 +556,7 @@ let printPolyVarIdent txt =
      | Osig_ellipsis -> Doc.dotdotdot
      | Osig_value valueDecl ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            printOutAttributesDoc valueDecl.oval_attributes;
            Doc.text (
              match valueDecl.oval_prims with | [] -> "let " | _ -> "external "
@@ -568,45 +568,45 @@ let printPolyVarIdent txt =
            match valueDecl.oval_prims with
            | [] -> Doc.nil
            | primitives -> Doc.indent (
-               Doc.concat [
+               Doc.concat [|
                  Doc.text " =";
                  Doc.line;
                  Doc.group (
                    Doc.join ~sep:Doc.line (List.map (fun prim -> Doc.text ("\"" ^ prim ^ "\"")) primitives)
                  )
-               ]
+               |]
              )
-         ]
+         |]
        )
    | Osig_typext (outExtensionConstructor, _outExtStatus) ->
      printOutExtensionConstructorDoc outExtensionConstructor
    | Osig_modtype (modName, Omty_signature []) ->
-     Doc.concat [
+     Doc.concat [|
        Doc.text "module type ";
        Doc.text modName;
-     ]
+     |]
    | Osig_modtype (modName, outModuleType) ->
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.text "module type ";
          Doc.text modName;
          Doc.text " = ";
          printOutModuleTypeDoc outModuleType;
-       ]
+       |]
      )
    | Osig_module (modName, Omty_alias ident, _) ->
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.text "module ";
          Doc.text modName;
          Doc.text " =";
          Doc.line;
          printOutIdentDoc ident;
-       ]
+       |]
      )
    | Osig_module (modName, outModType, outRecStatus) ->
       Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.text (
            match outRecStatus with
            | Orec_not -> "module "
@@ -616,18 +616,18 @@ let printPolyVarIdent txt =
          Doc.text modName;
          Doc.text " = ";
          printOutModuleTypeDoc outModType;
-       ]
+       |]
      )
    | Osig_type (outTypeDecl, outRecStatus) ->
      (* TODO: manifest ? *)
      let attrs = match outTypeDecl.otype_immediate, outTypeDecl.otype_unboxed with
      | false, false -> Doc.nil
      | true, false ->
-       Doc.concat [Doc.text "@immediate"; Doc.line]
+       Doc.concat [|Doc.text "@immediate"; Doc.line|]
      | false, true ->
-       Doc.concat [Doc.text "@unboxed"; Doc.line]
+       Doc.concat [|Doc.text "@unboxed"; Doc.line|]
      | true, true ->
-       Doc.concat [Doc.text "@immediate @unboxed"; Doc.line]
+       Doc.concat [|Doc.text "@immediate @unboxed"; Doc.line|]
      in
      let kw = Doc.text (
        match outRecStatus with
@@ -638,20 +638,20 @@ let printPolyVarIdent txt =
      let typeParams = match outTypeDecl.otype_params with
      | [] -> Doc.nil
      | _params -> Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.lessThan;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printTypeParameterDoc outTypeDecl.otype_params
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.greaterThan;
-         ]
+         |]
        )
      in
      let privateDoc = match outTypeDecl.otype_private with
@@ -659,63 +659,63 @@ let printPolyVarIdent txt =
      | Public -> Doc.nil
      in
      let kind = match outTypeDecl.otype_type with
-     | Otyp_open -> Doc.concat [
+     | Otyp_open -> Doc.concat [|
          Doc.text " = ";
          privateDoc;
          Doc.text "..";
-       ]
+       |]
      | Otyp_abstract -> Doc.nil
-     | Otyp_record record -> Doc.concat [
+     | Otyp_record record -> Doc.concat [|
          Doc.text " = ";
          privateDoc;
          printRecordDeclarationDoc ~inline:false record;
-       ]
-     | typ -> Doc.concat [
+       |]
+     | typ -> Doc.concat [|
          Doc.text " = ";
          printOutTypeDoc typ
-       ]
+       |]
      in
      let constraints =  match outTypeDecl.otype_cstrs with
      | [] -> Doc.nil
      | _ -> Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.line;
          Doc.indent (
-           Doc.concat [
+           Doc.concat [|
              Doc.hardLine;
              Doc.join ~sep:Doc.line (List.map (fun (typ1, typ2) ->
                Doc.group (
-                 Doc.concat [
+                 Doc.concat [|
                    Doc.text "constraint ";
                    printOutTypeDoc typ1;
                    Doc.text " =";
                    Doc.indent (
-                     Doc.concat [
+                     Doc.concat [|
                        Doc.line;
                        printOutTypeDoc typ2;
-                     ]
+                     |]
                    )
-                 ]
+                 |]
                )
              ) outTypeDecl.otype_cstrs)
-           ]
+           |]
          )
-       ]
+       |]
      ) in
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          attrs;
          Doc.group (
-           Doc.concat [
+           Doc.concat [|
              attrs;
              kw;
              printIdentLike ~allowUident:false outTypeDecl.otype_name;
              typeParams;
              kind
-           ]
+           |]
          );
          constraints
-       ]
+       |]
      )
 
    and printOutModuleTypeDoc (outModType : Outcometree.out_module_type) =
@@ -729,53 +729,53 @@ let printPolyVarIdent txt =
        | [_, None] -> Doc.text "()"
        | args ->
          Doc.group (
-           Doc.concat [
+           Doc.concat [|
              Doc.lparen;
              Doc.indent (
-               Doc.concat [
+               Doc.concat [|
                  Doc.softLine;
-                 Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+                 Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                    List.map (fun (lbl, optModType) -> Doc.group (
-                     Doc.concat [
+                     Doc.concat [|
                        Doc.text lbl;
                        match optModType with
                        | None -> Doc.nil
-                       | Some modType -> Doc.concat [
+                       | Some modType -> Doc.concat [|
                            Doc.text ": ";
                            printOutModuleTypeDoc modType;
-                         ]
-                     ]
+                         |]
+                     |]
                    )) args
                  )
-               ]
+               |]
              );
              Doc.trailingComma;
              Doc.softLine;
              Doc.rparen;
-           ]
+           |]
          )
        in
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            argsDoc;
            Doc.text " => ";
            printOutModuleTypeDoc returnModType
-         ]
+         |]
        )
      | Omty_signature [] -> Doc.nil
      | Omty_signature signature ->
        Doc.breakableGroup ~forceBreak:true (
-         Doc.concat [
+         Doc.concat [|
            Doc.lbrace;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.line;
                printOutSignatureDoc signature;
-             ]
+             |]
            );
            Doc.softLine;
            Doc.rbrace;
-         ]
+         |]
        )
      | Omty_alias _ident -> Doc.nil
 
@@ -822,26 +822,26 @@ let printPolyVarIdent txt =
      | [] -> Doc.nil
      | params ->
        Doc.group(
-         Doc.concat [
+         Doc.concat [|
            Doc.lessThan;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (List.map
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (List.map
                  (fun ty -> Doc.text (if ty = "_" then ty else "'" ^ ty))
                  params
 
                )
-             ]
+             |]
            );
            Doc.softLine;
            Doc.greaterThan;
-         ]
+         |]
        )
 
      in
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.text "type ";
          printIdentLike ~allowUident:false outExt.oext_type_name;
          typeParams;
@@ -853,7 +853,7 @@ let printPolyVarIdent txt =
            Doc.nil;
          printOutConstructorDoc
            (outExt.oext_name, outExt.oext_args, outExt.oext_ret_type)
-       ]
+       |]
      )
 
    and printOutTypeExtensionDoc (typeExtension : Outcometree.out_type_extension) =
@@ -861,26 +861,26 @@ let printPolyVarIdent txt =
      | [] -> Doc.nil
      | params ->
        Doc.group(
-         Doc.concat [
+         Doc.concat [|
            Doc.lessThan;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (List.map
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (List.map
                  (fun ty -> Doc.text (if ty = "_" then ty else "'" ^ ty))
                  params
 
                )
-             ]
+             |]
            );
            Doc.softLine;
            Doc.greaterThan;
-         ]
+         |]
        )
 
      in
      Doc.group (
-       Doc.concat [
+       Doc.concat [|
          Doc.text "type ";
          printIdentLike ~allowUident:false typeExtension.otyext_name;
          typeParams;
@@ -890,7 +890,7 @@ let printPolyVarIdent txt =
          else
            Doc.nil;
          printOutConstructorsDoc typeExtension.otyext_constructors;
-       ]
+       |]
      )
 
    let printOutSigItem fmt outSigItem =
@@ -928,39 +928,39 @@ let printPolyVarIdent txt =
      match outValue with
      | Oval_array outValues ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.lbracket;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printOutValueDoc outValues
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.rbracket;
-         ]
+         |]
        )
      | Oval_char c -> Doc.text ("'" ^ (Char.escaped c) ^ "'")
      | Oval_constr (outIdent, outValues) ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            printOutIdentDoc outIdent;
            Doc.lparen;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printOutValueDoc outValues
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.rparen;
-         ]
+         |]
        )
      | Oval_ellipsis -> Doc.text "..."
      | Oval_int i -> Doc.text (Format.sprintf "%i" i)
@@ -970,20 +970,20 @@ let printPolyVarIdent txt =
      | Oval_float f -> Doc.text (floatRepres f)
      | Oval_list outValues ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.text "list[";
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printOutValueDoc outValues
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.rbracket;
-         ]
+         |]
        )
      | Oval_printer fn ->
        let fmt = Format.str_formatter in
@@ -992,47 +992,47 @@ let printPolyVarIdent txt =
        Doc.text str
      | Oval_record rows ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.lparen;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map (fun (outIdent, outValue) -> Doc.group (
-                     Doc.concat [
+                     Doc.concat [|
                        printOutIdentDoc outIdent;
                        Doc.text ": ";
                        printOutValueDoc outValue;
-                     ]
+                     |]
                    )
                  ) rows
                );
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.rparen;
-         ]
+         |]
        )
      | Oval_string (txt, _sizeToPrint, _kind) ->
        Doc.text (escapeStringContents txt)
      | Oval_stuff txt -> Doc.text txt
      | Oval_tuple outValues ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.lparen;
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
                  List.map printOutValueDoc outValues
                )
-             ]
+             |]
            );
            Doc.trailingComma;
            Doc.softLine;
            Doc.rparen;
-         ]
+         |]
        )
      (* Not supported by NapkinScript *)
      | Oval_variant _ -> Doc.nil
@@ -1046,11 +1046,11 @@ let printPolyVarIdent txt =
      | _ ->
        Doc.group (
          Doc.indent(
-           Doc.concat [
+           Doc.concat [|
              Doc.text "Exception:";
              Doc.line;
              printOutValueDoc outValue;
-           ]
+           |]
          )
        )
 
@@ -1087,11 +1087,11 @@ let printPolyVarIdent txt =
            printOutSigItemDoc sigItem
          | Some outValue ->
            Doc.group (
-             Doc.concat [
+             Doc.concat [|
                printOutSigItemDoc sigItem;
                Doc.text " = ";
                printOutValueDoc outValue;
-             ]
+             |]
            )
         in
         loop signature (doc::acc)
@@ -1104,17 +1104,17 @@ let printPolyVarIdent txt =
      match outPhrase with
      | Ophr_eval (outValue, outType) ->
        Doc.group (
-         Doc.concat [
+         Doc.concat [|
            Doc.text "- : ";
            printOutTypeDoc outType;
            Doc.text " =";
            Doc.indent (
-             Doc.concat [
+             Doc.concat [|
                Doc.line;
                printOutValueDoc outValue;
-             ]
+             |]
            )
-         ]
+         |]
        )
      | Ophr_signature [] -> Doc.nil
      | Ophr_signature signature -> printOutPhraseSignature signature

--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -138,7 +138,7 @@ let printPolyVarIdent txt =
      | attrs ->
        Doc.concat [|
          Doc.group (
-           Doc.join ~sep:Doc.line (List.map printOutAttributeDoc attrs)
+           Doc.join ~sep:Doc.line (Res_array.mapList printOutAttributeDoc attrs)
          );
          Doc.line;
        |]
@@ -196,7 +196,7 @@ let printPolyVarIdent txt =
                Doc.concat [|
                  Doc.space;
                  Doc.join ~sep:Doc.space (
-                   List.map (fun lbl -> printIdentLike ~allowUident:true lbl) tags
+                   Res_array.mapList (fun lbl -> printIdentLike ~allowUident:true lbl) tags
                  )
                |]
              )
@@ -272,7 +272,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printOutTypeDoc args
+                 Res_array.mapList printOutTypeDoc args
                )
              |]
            );
@@ -295,7 +295,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printOutTypeDoc tupleArgs
+                 Res_array.mapList printOutTypeDoc tupleArgs
                )
              |]
            );
@@ -308,7 +308,7 @@ let printPolyVarIdent txt =
        Doc.group (
          Doc.concat [|
            Doc.join ~sep:Doc.space (
-             List.map (fun var -> Doc.text ("'" ^ var)) vars
+             Res_array.mapList (fun var -> Doc.text ("'" ^ var)) vars
            );
            Doc.dot;
            Doc.space;
@@ -323,7 +323,7 @@ let printPolyVarIdent txt =
    and printOutArrowType ~uncurried typ =
      let (typArgs, typ) = collectArrowArgs typ [] in
      let args = Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-       List.map (fun (lbl, typ) ->
+       Res_array.mapList (fun (lbl, typ) ->
          if lbl = "" then
            printOutTypeDoc typ
          else
@@ -374,7 +374,7 @@ let printPolyVarIdent txt =
          * [< | #T([< u2]) & ([< u2]) & ([< u1])]  --> no ampersand
          * [< | #S & ([< u2]) & ([< u2]) & ([< u1])] --> ampersand
          *)
-         List.mapi (fun i (name, ampersand, types) ->
+         Res_array.mapListi (fun i (name, ampersand, types) ->
            let needsParens = match types with
            | [(Outcometree.Otyp_tuple _)] -> false
            | _ -> true
@@ -396,7 +396,7 @@ let printPolyVarIdent txt =
                      Doc.indent (
                        Doc.concat [|
                          Doc.join ~sep:(Doc.concat [|Doc.text " &"; Doc.line|])
-                          (List.map (fun typ ->
+                          (Res_array.mapList (fun typ ->
                             let outTypeDoc = printOutTypeDoc typ in
                             if needsParens then
                               Doc.concat [|Doc.lparen; outTypeDoc; Doc.rparen|]
@@ -426,7 +426,7 @@ let printPolyVarIdent txt =
            Doc.concat [|
              Doc.softLine;
              Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-               List.map (fun (lbl, outType) -> Doc.group (
+               Res_array.mapList (fun (lbl, outType) -> Doc.group (
                  Doc.concat [|
                    Doc.text ("\"" ^ lbl ^ "\": ");
                    printOutTypeDoc outType;
@@ -448,7 +448,7 @@ let printPolyVarIdent txt =
          Doc.concat [|
            Doc.line;
            Doc.join ~sep:Doc.line (
-             List.mapi (fun i constructor ->
+             Res_array.mapListi (fun i constructor ->
                Doc.concat [|
                  if i > 0 then Doc.text "| " else Doc.ifBreaks (Doc.text "| ") Doc.nil;
                  printOutConstructorDoc constructor;
@@ -492,7 +492,7 @@ let printPolyVarIdent txt =
                Doc.concat [|
                  Doc.softLine;
                  Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                   List.map printOutTypeDoc args
+                   Res_array.mapList printOutTypeDoc args
                  )
                |]
              );
@@ -527,7 +527,7 @@ let printPolyVarIdent txt =
          Doc.concat [|
            Doc.softLine;
            Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-             List.map printRecordDeclRowDoc rows
+             Res_array.mapList printRecordDeclRowDoc rows
            )
          |]
        );
@@ -572,7 +572,7 @@ let printPolyVarIdent txt =
                  Doc.text " =";
                  Doc.line;
                  Doc.group (
-                   Doc.join ~sep:Doc.line (List.map (fun prim -> Doc.text ("\"" ^ prim ^ "\"")) primitives)
+                   Doc.join ~sep:Doc.line (Res_array.mapList (fun prim -> Doc.text ("\"" ^ prim ^ "\"")) primitives)
                  )
                |]
              )
@@ -644,7 +644,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printTypeParameterDoc outTypeDecl.otype_params
+                 Res_array.mapList printTypeParameterDoc outTypeDecl.otype_params
                )
              |]
            );
@@ -683,7 +683,7 @@ let printPolyVarIdent txt =
          Doc.indent (
            Doc.concat [|
              Doc.hardLine;
-             Doc.join ~sep:Doc.line (List.map (fun (typ1, typ2) ->
+             Doc.join ~sep:Doc.line (Res_array.mapList (fun (typ1, typ2) ->
                Doc.group (
                  Doc.concat [|
                    Doc.text "constraint ";
@@ -735,7 +735,7 @@ let printPolyVarIdent txt =
                Doc.concat [|
                  Doc.softLine;
                  Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                   List.map (fun (lbl, optModType) -> Doc.group (
+                   Res_array.mapList (fun (lbl, optModType) -> Doc.group (
                      Doc.concat [|
                        Doc.text lbl;
                        match optModType with
@@ -814,7 +814,7 @@ let printPolyVarIdent txt =
      | [doc] -> doc
      | docs ->
        Doc.breakableGroup ~forceBreak:true (
-         Doc.join ~sep:Doc.line docs
+         Doc.join ~sep:Doc.line (docs |> Array.of_list)
        )
 
    and printOutExtensionConstructorDoc (outExt : Outcometree.out_extension_constructor) =
@@ -827,7 +827,7 @@ let printPolyVarIdent txt =
            Doc.indent (
              Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (List.map
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (Res_array.mapList
                  (fun ty -> Doc.text (if ty = "_" then ty else "'" ^ ty))
                  params
 
@@ -866,10 +866,9 @@ let printPolyVarIdent txt =
            Doc.indent (
              Doc.concat [|
                Doc.softLine;
-               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (List.map
+               Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (Res_array.mapList
                  (fun ty -> Doc.text (if ty = "_" then ty else "'" ^ ty))
                  params
-
                )
              |]
            );
@@ -934,7 +933,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printOutValueDoc outValues
+                 Res_array.mapList printOutValueDoc outValues
                )
              |]
            );
@@ -953,7 +952,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printOutValueDoc outValues
+                 Res_array.mapList printOutValueDoc outValues
                )
              |]
            );
@@ -976,7 +975,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printOutValueDoc outValues
+                 Res_array.mapList printOutValueDoc outValues
                )
              |]
            );
@@ -998,7 +997,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map (fun (outIdent, outValue) -> Doc.group (
+                 Res_array.mapList (fun (outIdent, outValue) -> Doc.group (
                      Doc.concat [|
                        printOutIdentDoc outIdent;
                        Doc.text ": ";
@@ -1025,7 +1024,7 @@ let printPolyVarIdent txt =
              Doc.concat [|
                Doc.softLine;
                Doc.join ~sep:(Doc.concat [|Doc.comma; Doc.line|]) (
-                 List.map printOutValueDoc outValues
+                 Res_array.mapList printOutValueDoc outValues
                )
              |]
            );
@@ -1097,7 +1096,7 @@ let printPolyVarIdent txt =
         loop signature (doc::acc)
       in
       Doc.breakableGroup ~forceBreak:true (
-        Doc.join ~sep:Doc.line (loop signature [])
+        Doc.join ~sep:Doc.line (loop signature [] |> Array.of_list)
       )
 
    let printOutPhraseDoc (outPhrase : Outcometree.out_phrase) =

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -1931,7 +1931,7 @@ and printValueBinding ~recFlag vb cmtTbl i =
    * Multiple pipes chained together lend themselves more towards the last layout.
    *)
   if ParsetreeViewer.isSinglePipeExpr vb.pvb_expr then
-    Doc.customLayout [
+    Doc.customLayout [|
       Doc.group (
         Doc.concat [|
           attrs;
@@ -1956,7 +1956,7 @@ and printValueBinding ~recFlag vb cmtTbl i =
           )
         |]
       );
-    ]
+    |]
   else
     let shouldIndent =
       match optBraces with
@@ -4097,10 +4097,10 @@ and printArgumentsWithCallbackInFirstPosition ~uncurried args cmtTbl =
   if Doc.willBreak printedArgs then
     breakAllArgs
   else
-    Doc.customLayout [
+    Doc.customLayout [|
       fitsOnOneLine;
       breakAllArgs;
-    ]
+    |]
 
 and printArgumentsWithCallbackInLastPosition ~uncurried args cmtTbl =
   (* Because the same subtree gets printed twice, we need to copy the cmtTbl.
@@ -4196,11 +4196,11 @@ and printArgumentsWithCallbackInLastPosition ~uncurried args cmtTbl =
   if Doc.willBreak printedArgs then
     breakAllArgs
   else
-    Doc.customLayout [
+    Doc.customLayout [|
       fitsOnOneLine;
       arugmentsFitOnOneLine;
       breakAllArgs;
-    ]
+    |]
 
 and printArguments ~uncurried (args : (Asttypes.arg_label * Parsetree.expression) list) cmtTbl =
   match args with


### PR DESCRIPTION
Excuse the commit messages. Just a toy.

This tries to allocate as few lists as possible.

Benchmark shows that everything allocates less (kinda obvious if you think about it), but the perf isn't necessarily better for now, mostly because the printer algorithm uses little pieces of lists (now arrays) again and again. So the saving of array isn't that big.

However, if/when we convert more things to array, like comments, maybe this'll shine more.

