### PR TITLE
Remove res_io.readStdin

### DIFF
--- a/src/res_driver.ml
+++ b/src/res_driver.ml
@@ -35,7 +35,7 @@ type printEngine = {
 }
 
 let setup ~filename ~forPrinter () =
-  let src = if filename = "" then IO.readStdin () else IO.readFile ~filename in
+  let src = IO.readFile ~filename in
   let mode = if forPrinter then Res_parser.Default
     else ParseForTypeChecker
   in

--- a/src/res_driver_reason_binary.ml
+++ b/src/res_driver_reason_binary.ml
@@ -11,10 +11,7 @@ let isReasonDocComment (comment: Res_comment.t) =
 let extractConcreteSyntax filename =
   let commentData = ref [] in
   let stringData = ref [] in
-  let src =
-    if String.length filename > 0 then IO.readFile ~filename
-    else IO.readStdin ()
-  in
+  let src = IO.readFile ~filename in
   let scanner = Res_scanner.make src ~filename in
 
   let rec next prevEndPos scanner =

--- a/src/res_io.ml
+++ b/src/res_io.ml
@@ -7,25 +7,6 @@ let readFile ~filename =
   close_in_noerr chan;
   content
 
-
-(* random chunk size: 2^15, TODO: why do we guess randomly? *)
-let chunkSize = 32768
-
-let readStdin () =
-  let buffer = Buffer.create chunkSize in
-  let chunk = (Bytes.create [@doesNotRaise]) chunkSize in
-  let rec loop () =
-    let len = try input stdin chunk 0 chunkSize with Invalid_argument _ -> 0 in
-    if len == 0 then (
-      close_in_noerr stdin;
-      Buffer.contents buffer
-    ) else (
-      Buffer.add_subbytes buffer chunk 0 len;
-      loop ()
-    )
-  in
-  loop ()
-
 let writeFile ~filename ~contents:txt =
   let chan = open_out_bin filename in
   output_string chan txt;

--- a/src/res_io.mli
+++ b/src/res_io.mli
@@ -3,8 +3,5 @@
 (* reads the contents of "filename" into a string *)
 val readFile: filename: string -> string
 
-(* read the contents of stdin into a string*)
-val readStdin: unit -> string
-
 (* writes "content" into file with name "filename" *)
 val writeFile: filename: string -> contents: string -> unit

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -127,27 +127,23 @@ function parseReasonFileToNapkin(filename, width = 100) {
     .stdout.toString("utf8");
 }
 
-function parseNapkinStdinToSexp(src, isInterface) {
-  let args = ["-parse", "res", "-print", "sexp"];
+function parseNapkinToSexp(src, isInterface) {
+  let args = ["-parse", "res", "-print", "sexp", src];
   if (isInterface) {
     args.push("-interface");
   }
   return cp
-    .spawnSync(parser, args, {
-      input: src,
-    })
+    .spawnSync(parser, args)
     .stdout.toString("utf8");
 }
 
-function parseNapkinStdinToNapkin(src, isInterface, width = 100) {
-  let args = ["-parse", "res", "-print", "res", "-width", width];
+function parseNapkinToNapkin(src, isInterface, width = 100) {
+  let args = ["-parse", "res", "-print", "res", "-width", width, src];
   if (isInterface) {
     args.push("-interface");
   }
   return cp
-    .spawnSync(parser, args, {
-      input: src,
-    })
+    .spawnSync(parser, args)
     .stdout.toString("utf8");
 }
 
@@ -230,10 +226,16 @@ Make sure the test input is syntactically valid.`;
       if (process.env.ROUNDTRIP_TEST && ppx === "") {
         let intf = isInterface(filename);
         let sexpAst = parseFileToSexp(filename);
-        let result2 = parseNapkinStdinToNapkin(result, intf, 80);
-        let resultSexpAst = parseNapkinStdinToSexp(result, intf);
+
+        let napkinOutput = filename + '.napkin';
+        fs.writeFileSync(napkinOutput, result);
+
+        let result2 = parseNapkinToNapkin(napkinOutput, intf, 80);
+        let resultSexpAst = parseNapkinToSexp(napkinOutput, intf);
         expect(sexpAst).toEqual(resultSexpAst);
         expect(result).toEqual(result2);
+
+        fs.unlinkSync(napkinOutput);
       }
     });
   });
@@ -304,10 +306,16 @@ global.idemPotency = (dirname) => {
         let intf = isInterface(filename);
         let napkin = parseToNapkin(filename);
         let sexpAst = parseFileToSexp(filename);
-        let napkinSexpAst = parseNapkinStdinToSexp(napkin, intf);
-        let napkin2 = parseNapkinStdinToNapkin(napkin, intf);
+
+        let napkinOutput = filename + '.napkin';
+        fs.writeFileSync(napkinOutput, parseToNapkin(filename));
+
+        let napkinSexpAst = parseNapkinToSexp(napkinOutput, intf);
+        let napkin2 = parseNapkinToNapkin(napkinOutput, intf);
         expect(sexpAst).toEqual(napkinSexpAst);
         expect(napkin).toEqual(napkin2);
+
+        fs.unlinkSync(napkinOutput);
       });
     });
   });


### PR DESCRIPTION
#288

Though IO overhead was added for tests, I think it's negligible.
Besides, this also fixes an issue that roundtrip-test always hangs on my local machine.
I'm not sure what causes jest to run indefinitely, but now it's gone.

(before - neverending)
<img width="449" alt="before" src="https://user-images.githubusercontent.com/243097/110210436-0e6b9f00-7ed5-11eb-9ca4-96e732bad958.png">

(after)
<img width="409" alt="after" src="https://user-images.githubusercontent.com/243097/110210447-1e837e80-7ed5-11eb-9405-63d383711abb.png">
