### PR TITLE
Remove "to" and "downto" as keywords.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3148,8 +3148,8 @@ and parseForRest hasOpeningParen pattern startPos p =
   Parser.expect In p;
   let e1 = parseExpr p in
   let direction = match p.Parser.token with
-  | To -> Asttypes.Upto
-  | Downto -> Asttypes.Downto
+  | Lident "to" -> Asttypes.Upto
+  | Lident "downto" -> Asttypes.Downto
   | token ->
     Parser.err p (Diagnostics.unexpected token p.breadcrumbs);
     Asttypes.Upto

--- a/src/res_token.ml
+++ b/src/res_token.ml
@@ -44,7 +44,7 @@ type t =
   | Lazy
   | Tilde
   | Question
-  | If | Else | For | In | To | Downto | While | Switch
+  | If | Else | For | In | While | Switch
   | When
   | EqualGreater | MinusGreater
   | External
@@ -131,8 +131,6 @@ let toString = function
   | Else -> "else"
   | For -> "for"
   | In -> "in"
-  | To -> "to"
-  | Downto -> "downto"
   | While -> "while"
   | Switch -> "switch"
   | When -> "when"
@@ -168,7 +166,6 @@ let keywordTable = function
 | "as" -> As
 | "assert" -> Assert
 | "constraint" -> Constraint
-| "downto" -> Downto
 | "else" -> Else
 | "exception" -> Exception
 | "export" -> Export
@@ -189,7 +186,6 @@ let keywordTable = function
 | "private" -> Private
 | "rec" -> Rec
 | "switch" -> Switch
-| "to" -> To
 | "true" -> True
 | "try" -> Try
 | "type" -> Typ
@@ -200,10 +196,10 @@ let keywordTable = function
 [@@raises Not_found]
 
 let isKeyword = function
-  | And | As | Assert | Constraint | Downto | Else | Exception | Export
+  | And | As | Assert | Constraint | Else | Exception | Export
   | External | False | For | If | Import | In | Include | Land | Lazy
   | Let | List | Lor | Module | Mutable | Of | Open | Private | Rec
-  | Switch | To | True | Try | Typ | When | While | With -> true
+  | Switch | True | Try | Typ | When | While | With -> true
   | _ -> false
 
 let lookupKeyword str =

--- a/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
@@ -247,19 +247,19 @@ let [%rescript.patternhole ] = 3
   Syntax error!
   parsing/errors/structure/letBindingPatternKeyword.js:1:5-8  
   1 │ let open = 1
-  2 │ let to = 3
+  2 │ let for = 3
   3 │ 
   
   \`open\` is a reserved keyword. Keywords need to be escaped: \\\\\\"open\\"
 
 
   Syntax error!
-  parsing/errors/structure/letBindingPatternKeyword.js:2:5-6  
+  parsing/errors/structure/letBindingPatternKeyword.js:2:5-7  
   1 │ let open = 1
-  2 │ let to = 3
+  2 │ let for = 3
   3 │ 
   
-  \`to\` is a reserved keyword. Keywords need to be escaped: \\\\\\"to\\"
+  \`for\` is a reserved keyword. Keywords need to be escaped: \\\\\\"for\\"
 
 
 ========================================================"

--- a/tests/parsing/errors/structure/letBindingPatternKeyword.js
+++ b/tests/parsing/errors/structure/letBindingPatternKeyword.js
@@ -1,2 +1,2 @@
 let open = 1
-let to = 3
+let for = 3

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -211,7 +211,7 @@ exports[`typeParams.js 1`] = `
 "=====Parsetree==========================================
 type nonrec 'a node = {
   _value: 'a Js.Nullable.value }
-type nonrec ('from, 'to) derivedNode =
+type nonrec ('from, 'for) derivedNode =
   {
   mutable value: 'to_ ;
   updateF: 'from -> 'to_ }
@@ -240,14 +240,14 @@ type nonrec ('from, 'foo) derivedNode =
 
 
   Syntax error!
-  parsing/errors/typeDef/typeParams.js:5:26-27  
+  parsing/errors/typeDef/typeParams.js:5:26-28  
   3 │ }
   4 │ 
-  5 │ type derivedNode<'from, 'to> = {
+  5 │ type derivedNode<'from, 'for> = {
   6 │   mutable value: 'to_,
   7 │   updateF: 'from => 'to_,
   
-  \`to\` is a reserved keyword. Keywords need to be escaped: \\\\\\"to\\"
+  \`for\` is a reserved keyword. Keywords need to be escaped: \\\\\\"for\\"
 
 
   Syntax error!

--- a/tests/parsing/errors/typeDef/typeParams.js
+++ b/tests/parsing/errors/typeDef/typeParams.js
@@ -2,7 +2,7 @@ type node('a) = {
   _value: Js.Nullable.value<'a>
 }
 
-type derivedNode<'from, 'to> = {
+type derivedNode<'from, 'for> = {
   mutable value: 'to_,
   updateF: 'from => 'to_,
 }


### PR DESCRIPTION
 "to" is a commonly use identifier in interop scenarios. to/downto take a lot of expensive grammar real estate at a very high price. Since this is a handrolled parser, we can drop them as a keyword and parse them straight as identifier.