### PR TITLE
Parse poly variant pattern with one unit arg correct.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1520,6 +1520,11 @@ and parseVariantPatternArgs p ident startPos attrs =
       p ~grammar:Grammar.PatternList ~closing:Rparen ~f:parseConstrainedPatternRegion in
   let args =
     match patterns with
+    | [] ->
+      let loc = mkLoc lparen p.prevEndPos in
+      Some (
+        Ast_helper.Pat.construct ~loc (Location.mkloc (Longident.Lident "()") loc) None
+      )
     | [{ppat_desc = Ppat_tuple _} as pat] as patterns ->
       if p.mode = ParseForTypeChecker then
         (* #ident(1, 2) for type-checker *)

--- a/tests/parsing/recovery/pattern/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/recovery/pattern/__snapshots__/parse.spec.js.snap
@@ -30,7 +30,8 @@ exports[`polyvariant.js 1`] = `
 ";;match x with
   | \`Rgb (r, g, b) -> ()
   | \`Rgb (r, g, Color (a, b)) -> ()
-  | \`Rgb (r, g, 1::2::[]) -> ()"
+  | \`Rgb (r, g, 1::2::[]) -> ()
+;;match x with | \`a () -> () | \`a () -> ()"
 `;
 
 exports[`record.js 1`] = `";;match x with | { a; b = { x; y } } -> () | { x; y } -> () | { a; b } -> ()"`;

--- a/tests/parsing/recovery/pattern/polyvariant.js
+++ b/tests/parsing/recovery/pattern/polyvariant.js
@@ -3,3 +3,8 @@ switch x {
 | #Rgb(r, g, Color(a, b => ()
 | #Rgb(r, g, list{1, 2 => ()
 }
+
+switch x {
+| #a(()) => ()
+| #a() => ()
+}

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -3485,6 +3485,9 @@ external openSync: (
     | @as(\\"ax+\\") #Append_read_fail_if_exists
   ],
 ) => unit = \\"openSync\\"
+
+let x = #a()
+let x = #a()
 "
 `;
 

--- a/tests/printer/expr/polyvariant.js
+++ b/tests/printer/expr/polyvariant.js
@@ -132,3 +132,6 @@ external openSync: (
     | @as("ax+") #Append_read_fail_if_exists
   ],
 ) => unit = "openSync"
+
+let x = #a(())
+let x = #a()

--- a/tests/printer/pattern/__snapshots__/render.spec.js.snap
+++ b/tests/printer/pattern/__snapshots__/render.spec.js.snap
@@ -459,5 +459,10 @@ let cmp = (selectedChoice, value) =>
   | #space10 => x
   | _ => false
   }
+
+switch x {
+| #a() => ()
+| #a() => ()
+}
 "
 `;

--- a/tests/printer/pattern/variant.res
+++ b/tests/printer/pattern/variant.res
@@ -33,3 +33,8 @@ let cmp = (selectedChoice, value) =>
   | #space10 => x
   | _ => false
   }
+
+switch x {
+| #a(()) => ()
+| #a() => ()
+}


### PR DESCRIPTION
`#a()` and `#a(())` should be parsed as the same ast node.
Previously the former would result into a tuple of size 0.

Fixes https://github.com/rescript-lang/syntax/issues/331