### PR TITLE
Update object method parsing and printer for ReScript 9

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3766,7 +3766,7 @@ and parseAtomicTypExpr ~attrs p =
     let loc = mkLoc startPos p.prevEndPos in
     Ast_helper.Typ.extension ~attrs ~loc extension
   | Lbrace ->
-    parseRecordOrBsObjectType ~attrs p
+    parseRecordOrObjectType ~attrs p
   | token ->
     Parser.err p (Diagnostics.unexpected token p.breadcrumbs);
     begin match skipTokensAndMaybeRetry p ~isStartOfGrammar:Grammar.isAtomicTypExprStart with
@@ -3825,7 +3825,7 @@ and parsePackageConstraint p =
     Some (typeConstr, typ)
   | _ -> None
 
-and parseRecordOrBsObjectType ~attrs p =
+and parseRecordOrObjectType ~attrs p =
   (* for inline record in constructor *)
   let startPos = p.Parser.startPos in
   Parser.expect Lbrace p;
@@ -4641,7 +4641,7 @@ and parseTypeEquationOrConstrDecl p =
     (* TODO: is this a good idea? *)
     (None, Asttypes.Public, Parsetree.Ptype_abstract)
 
-and parseRecordOrBsObjectDecl p =
+and parseRecordOrObjectDecl p =
   let startPos = p.Parser.startPos in
   Parser.expect Lbrace p;
   match p.Parser.token with
@@ -4777,7 +4777,7 @@ and parsePrivateEqOrRepr p =
   Parser.expect Private p;
   match p.Parser.token with
   | Lbrace ->
-    let (manifest, _ ,kind) = parseRecordOrBsObjectDecl p in
+    let (manifest, _ ,kind) = parseRecordOrObjectDecl p in
     (manifest, Asttypes.Private, kind)
   | Uident _ ->
     let (manifest, _, kind) = parseTypeEquationOrConstrDecl p in
@@ -4979,7 +4979,7 @@ and parseTypeEquationAndRepresentation p =
     | Uident _ ->
       parseTypeEquationOrConstrDecl p
     | Lbrace ->
-      parseRecordOrBsObjectDecl p
+      parseRecordOrObjectDecl p
     | Private ->
       parsePrivateEqOrRepr p
     | Bar | DotDot ->

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -121,6 +121,9 @@ Solution: directly use `concat`."
 
   let forbiddenInlineRecordDeclaration =
     "An inline record type declaration is only allowed in a variant constructor's declaration"
+
+  let ambiguousRecordSpread =
+    "The … spread is only supported for record value update and object type declaration."
 end
 
 
@@ -4280,7 +4283,13 @@ and parseConstrDeclArgs p =
         (* start of object type spreading, e.g. `User({...a, "u": int})` *)
         Parser.next p;
         let typ = parseTypExpr p in
-        Parser.expect Comma p;
+        let () = match p.token with
+        | Rbrace ->
+          Parser.err ~startPos:dotdotdotStart ~endPos:dotdotdotEnd p
+            (Diagnostics.message ErrorMessages.ambiguousRecordSpread);
+          Parser.next p;
+        | _ -> Parser.expect Comma p
+        in
         let () = match p.token with
         | Lident _ ->
           Parser.err ~startPos:dotdotdotStart ~endPos:dotdotdotEnd p
@@ -4694,7 +4703,13 @@ and parseRecordOrObjectDecl p =
     (* start of object type spreading, e.g. `type u = {...a, "u": int}` *)
     Parser.next p;
     let typ = parseTypExpr p in
-    Parser.expect Comma p;
+    let () = match p.token with
+    | Rbrace ->
+      Parser.err ~startPos:dotdotdotStart ~endPos:dotdotdotEnd p
+        (Diagnostics.message ErrorMessages.ambiguousRecordSpread);
+      Parser.next p;
+    | _ -> Parser.expect Comma p
+    in
     let () = match p.token with
     | Lident _ ->
       Parser.err ~startPos:dotdotdotStart ~endPos:dotdotdotEnd p

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1955,9 +1955,7 @@ and parseBracketAccess p expr startPos =
     let e =
       let identLoc = mkLoc stringStart stringEnd in
       let loc = mkLoc lbracket rbracket in
-      Ast_helper.Exp.apply ~loc
-      (Ast_helper.Exp.ident ~loc (Location.mkloc (Longident.Lident "##") loc))
-      [Nolabel, expr; Nolabel, (Ast_helper.Exp.ident ~loc:identLoc (Location.mkloc (Longident.Lident s) identLoc))]
+      Ast_helper.Exp.send ~loc expr (Location.mkloc s identLoc)
     in
     let e = parsePrimaryExpr ~operand:e p in
     let equalStart = p.startPos in

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -211,7 +211,7 @@ let isParameterStart = function
 
 (* TODO: overparse Uident ? *)
 let isStringFieldDeclStart = function
-  | Token.String _ | Lident _ | At -> true
+  | Token.String _ | Lident _ | At | DotDotDot -> true
   | _ -> false
 
 (* TODO: overparse Uident ? *)

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -1712,7 +1712,14 @@ and printObject ~inline fields openFlag cmtTbl =
       Doc.lbrace;
       (match openFlag with
       | Asttypes.Closed -> Doc.nil
-      | Open -> Doc.dotdot);
+      | Open ->
+        begin match fields with
+        (* handle `type t = {.. ...objType, "x": int}`
+         * .. and ... should have a space in between *)
+        | (Oinherit _)::_ -> Doc.text ".. "
+        | _ -> Doc.dotdot
+        end
+      );
       Doc.indent (
         Doc.concat [
           Doc.softLine;

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3137,8 +3137,26 @@ and printExpression (e : Parsetree.expression) cmtTbl =
       Doc.concat [Doc.text ": "; printTypExpr typ1 cmtTbl]
     in
     Doc.concat [Doc.lparen; docExpr; ofType; Doc.text " :> "; docTyp; Doc.rparen]
-  | Pexp_send _ ->
-    Doc.text "Pexp_send not impemented in printer"
+  | Pexp_send (parentExpr, label) ->
+    let parentDoc =
+      let doc = printExpressionWithComments parentExpr cmtTbl in
+      match Parens.unaryExprOperand parentExpr with
+      | Parens.Parenthesized -> addParens doc
+      | Braced braces  -> printBraces doc parentExpr braces
+      | Nothing -> doc
+    in
+    let member =
+      let memberDoc = printComments (Doc.text label.txt) cmtTbl label.loc in
+      Doc.concat [Doc.text "\""; memberDoc; Doc.text "\""]
+    in
+    Doc.group (
+      Doc.concat [
+        parentDoc;
+        Doc.lbracket;
+        member;
+        Doc.rbracket;
+      ]
+    )
   | Pexp_new _ ->
     Doc.text "Pexp_new not impemented in printer"
   | Pexp_setinstvar _ ->

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -1761,7 +1761,11 @@ and printObjectField (field : Parsetree.object_field) cmtTbl =
     ] in
     let cmtLoc = {labelLoc.loc with loc_end = typ.ptyp_loc.loc_end} in
     printComments doc cmtTbl cmtLoc
-  | _ -> Doc.nil
+  | Oinherit typexpr ->
+    Doc.concat [
+      Doc.dotdotdot;
+      printTypExpr typexpr cmtTbl
+    ]
 
 (* es6 arrow type arg
  * type t = (~foo: string, ~bar: float=?, unit) => unit

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1430,6 +1430,14 @@ let make = (
 "
 `;
 
+exports[`object.ml 1`] = `
+"type hi = {\\"z\\": int}
+type u<'a> = {.. ...hi, \\"x\\": int, \\"y\\": int} as 'a
+type u1<'a> = {.. ...hi} as 'a
+type u2<'a> = {.. ...hi, ...hi, \\"y\\": int, ...hi} as 'a
+"
+`;
+
 exports[`openPattern.re 1`] = `
 "let {T.a: a} = a()
 let [Color.Blue] = a()

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1285,6 +1285,17 @@ type propField<'a> = Js.nullable<{..} as 'a>
 type propField<'a> = {\\"a\\": b}
 type propField<'a> = {..\\"a\\": b}
 type propField<'a> = {\\"a\\": {\\"b\\": c}}
+
+user[\\"address\\"]
+user[\\"address\\"][\\"street\\"]
+user[\\"address\\"][\\"street\\"][\\"log\\"]
+
+user[\\"address\\"] = \\"Avenue 1\\"
+user[\\"address\\"][\\"street\\"] = \\"Avenue\\"
+user[\\"address\\"][\\"street\\"][\\"number\\"] = \\"1\\"
+
+school[\\"print\\"](direction[\\"name\\"], studentHead[\\"name\\"])
+city[\\"getSchool\\"]()[\\"print\\"](direction[\\"name\\"], studentHead[\\"name\\"])
 "
 `;
 

--- a/tests/conversion/reason/expected/object.ml.txt
+++ b/tests/conversion/reason/expected/object.ml.txt
@@ -1,0 +1,4 @@
+type hi = {"z": int}
+type u<'a> = {.. ...hi, "x": int, "y": int} as 'a
+type u1<'a> = {.. ...hi} as 'a
+type u2<'a> = {.. ...hi, ...hi, "y": int, ...hi} as 'a

--- a/tests/conversion/reason/jsObject.re
+++ b/tests/conversion/reason/jsObject.re
@@ -13,3 +13,15 @@ type propField('a) = Js.nullable(Js.t({..} as 'a))
 type propField('a) = {. "a": b}
 type propField('a) = {.. "a": b}
 type propField('a) = Js.t(Js.t({. "a": Js.t({. "b": c})}))
+
+user##address;
+user##address##street;
+user##address##street##log;
+
+user##address #= "Avenue 1";
+user##address##street #= "Avenue" ;
+user##address##street##number #= "1";
+
+school##print(direction##name, studentHead##name);
+(city##getSchool())##print(direction##name, studentHead##name);
+

--- a/tests/conversion/reason/object.ml
+++ b/tests/conversion/reason/object.ml
@@ -1,0 +1,4 @@
+type hi = < z : int >
+type 'a u = < hi ; x : int ; y : int; .. >  as 'a
+type 'a u1 = < hi; .. > as 'a
+type 'a u2 = < hi ; hi; y : int ; hi; .. >  as 'a

--- a/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
@@ -166,6 +166,9 @@ let record = { x with y }
 let { x; y } = myRecord
 let myList = x :: y
 let x::y = myList
+type nonrec t = < a  > 
+type nonrec t =
+  | Foo of < a  >  
 =====Errors=============================================
 
   Syntax error!
@@ -216,13 +219,35 @@ Solution: you need to pull out each field you want explicitly.
 
   Syntax error!
   parsing/errors/other/spread.res:8:13-22
-  6 │ 
-  7 │ let myList = list{...x, ...y}
-  8 │ let list{...x, ...y} = myList
-  9 │ 
+   6 │ 
+   7 │ let myList = list{...x, ...y}
+   8 │ let list{...x, ...y} = myList
+   9 │ 
+  10 │ type t = {...a}
 
   List pattern matches only supports one \`...\` spread, at the end.
 Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list[s]; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
+
+
+  Syntax error!
+  parsing/errors/other/spread.res:10:11-13
+   8 │ let list{...x, ...y} = myList
+   9 │ 
+  10 │ type t = {...a}
+  11 │ type t = Foo({...a})
+  12 │ 
+
+  The … spread is only supported for record value update and object type declaration.
+
+
+  Syntax error!
+  parsing/errors/other/spread.res:11:15-17
+   9 │ 
+  10 │ type t = {...a}
+  11 │ type t = Foo({...a})
+  12 │ 
+
+  The … spread is only supported for record value update and object type declaration.
 
 
 ========================================================"

--- a/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`breadcrumbs170.res 1`] = `
 "=====Parsetree==========================================
 let l = (Some [1; 2; 3]) |> Obj.magic
-module M = struct ;;match l with | None -> [] | Some l -> l ## prop end
+module M = struct ;;match l with | None -> [] | Some l -> l#prop end
 ;;from
 ;;now
 ;;on
@@ -169,6 +169,7 @@ let x::y = myList
 type nonrec t = < a  > 
 type nonrec t =
   | Foo of < a  >  
+type nonrec t = (foo, < x  > ) option
 =====Errors=============================================
 
   Syntax error!
@@ -235,9 +236,9 @@ Explanation: a list spread at the tail is efficient, but a spread in the middle 
    9 │ 
   10 │ type t = {...a}
   11 │ type t = Foo({...a})
-  12 │ 
+  12 │ type t = option<foo, {...x}>
 
-  The … spread is only supported for record value update and object type declaration.
+  You're using a ... spread without extra fields. This is the same type.
 
 
   Syntax error!
@@ -245,9 +246,20 @@ Explanation: a list spread at the tail is efficient, but a spread in the middle 
    9 │ 
   10 │ type t = {...a}
   11 │ type t = Foo({...a})
-  12 │ 
+  12 │ type t = option<foo, {...x}>
+  13 │ 
 
-  The … spread is only supported for record value update and object type declaration.
+  You're using a ... spread without extra fields. This is the same type.
+
+
+  Syntax error!
+  parsing/errors/other/spread.res:12:23-26
+  10 │ type t = {...a}
+  11 │ type t = Foo({...a})
+  12 │ type t = option<foo, {...x}>
+  13 │ 
+
+  You're using a ... spread without extra fields. This is the same type.
 
 
 ========================================================"

--- a/tests/parsing/errors/other/expected/breadcrumbs170.res.txt
+++ b/tests/parsing/errors/other/expected/breadcrumbs170.res.txt
@@ -11,7 +11,7 @@
   I'm not sure what to parse here when looking at "}".
 
 let l = (Some [1; 2; 3]) |> Obj.magic
-module M = struct ;;match l with | None -> [] | Some l -> l ## prop end
+module M = struct ;;match l with | None -> [] | Some l -> l#prop end
 ;;from
 ;;now
 ;;on

--- a/tests/parsing/errors/other/expected/spread.res.txt
+++ b/tests/parsing/errors/other/expected/spread.res.txt
@@ -52,13 +52,49 @@ Solution: you need to pull out each field you want explicitly.
   Syntax error!
   tests/parsing/errors/other/spread.res:8:13-22
 
-  6 │ 
-  7 │ let myList = list{...x, ...y}
-  8 │ let list{...x, ...y} = myList
-  9 │ 
+   6 │ 
+   7 │ let myList = list{...x, ...y}
+   8 │ let list{...x, ...y} = myList
+   9 │ 
+  10 │ type t = {...a}
 
   List pattern matches only supports one `...` spread, at the end.
 Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list[s]; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
+
+
+  Syntax error!
+  tests/parsing/errors/other/spread.res:10:11-13
+
+   8 │ let list{...x, ...y} = myList
+   9 │ 
+  10 │ type t = {...a}
+  11 │ type t = Foo({...a})
+  12 │ type t = option<foo, {...x}>
+
+  You're using a ... spread without extra fields. This is the same type.
+
+
+  Syntax error!
+  tests/parsing/errors/other/spread.res:11:15-17
+
+   9 │ 
+  10 │ type t = {...a}
+  11 │ type t = Foo({...a})
+  12 │ type t = option<foo, {...x}>
+  13 │ 
+
+  You're using a ... spread without extra fields. This is the same type.
+
+
+  Syntax error!
+  tests/parsing/errors/other/spread.res:12:23-26
+
+  10 │ type t = {...a}
+  11 │ type t = Foo({...a})
+  12 │ type t = option<foo, {...x}>
+  13 │ 
+
+  You're using a ... spread without extra fields. This is the same type.
 
 let arr = [|x;y|]
 let [|arr;_|] = [|1;2;3|]
@@ -66,3 +102,7 @@ let record = { x with y }
 let { x; y } = myRecord
 let myList = x :: y
 let x::y = myList
+type nonrec t = < a  > 
+type nonrec t =
+  | Foo of < a  >  
+type nonrec t = (foo, < x  > ) option

--- a/tests/parsing/errors/other/spread.res
+++ b/tests/parsing/errors/other/spread.res
@@ -6,3 +6,6 @@ let {...x, ...y} = myRecord
 
 let myList = list{...x, ...y}
 let list{...x, ...y} = myList
+
+type t = {...a}
+type t = Foo({...a})

--- a/tests/parsing/errors/other/spread.res
+++ b/tests/parsing/errors/other/spread.res
@@ -9,3 +9,4 @@ let list{...x, ...y} = myList
 
 type t = {...a}
 type t = Foo({...a})
+type t = option<foo, {...x}>

--- a/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
@@ -222,6 +222,71 @@ external printName : name:((unit)[@ns.namedArgLoc ]) -> unit = \\"printName\\"
 ========================================================"
 `;
 
+exports[`objectSpread.res 1`] = `
+"=====Parsetree==========================================
+type nonrec u = < a ;u: int   > 
+type nonrec u = private < a ;u: int   > 
+type nonrec x =
+  | Type of < a ;u: int   >  
+type nonrec u = < a ;u: int  ;v: int   > 
+let f (x : < a: int  ;b: int   > ) = ()
+=====Errors=============================================
+
+  Syntax error!
+  parsing/errors/typexpr/objectSpread.res:1:11-13
+  1 │ type u = {...a, u: int}
+  2 │ 
+  3 │ type u = private {...a, u: int}
+
+  A record type declaration doesn't support the ... spread. Only an object (with quoted field names) does.
+
+
+  Syntax error!
+  parsing/errors/typexpr/objectSpread.res:3:19-21
+  1 │ type u = {...a, u: int}
+  2 │ 
+  3 │ type u = private {...a, u: int}
+  4 │ 
+  5 │ type x = Type({...a, u: int})
+
+  A record type declaration doesn't support the ... spread. Only an object (with quoted field names) does.
+
+
+  Syntax error!
+  parsing/errors/typexpr/objectSpread.res:5:16-18
+  3 │ type u = private {...a, u: int}
+  4 │ 
+  5 │ type x = Type({...a, u: int})
+  6 │ 
+  7 │ type u = {...a, \\"u\\": int, v: int}
+
+  A record type declaration doesn't support the ... spread. Only an object (with quoted field names) does.
+
+
+  Syntax error!
+  parsing/errors/typexpr/objectSpread.res:7:27
+  5 │ type x = Type({...a, u: int})
+  6 │ 
+  7 │ type u = {...a, \\"u\\": int, v: int}
+  8 │ 
+  9 │ let f = (x: {a: int, b: int}) => ()
+
+  An object type declaration needs quoted field names. Did you mean \\"v\\"?
+
+
+  Syntax error!
+  parsing/errors/typexpr/objectSpread.res:9:14
+   7 │ type u = {...a, \\"u\\": int, v: int}
+   8 │ 
+   9 │ let f = (x: {a: int, b: int}) => ()
+  10 │ 
+
+  An inline record type declaration is only allowed in a variant constructor's declaration
+
+
+========================================================"
+`;
+
 exports[`typeConstructorArgs.res 1`] = `
 "=====Parsetree==========================================
 type nonrec 'a node = {

--- a/tests/parsing/errors/typexpr/expected/objectSpread.res.txt
+++ b/tests/parsing/errors/typexpr/expected/objectSpread.res.txt
@@ -1,0 +1,63 @@
+
+  Syntax error!
+  tests/parsing/errors/typexpr/objectSpread.res:1:11-13
+
+  1 │ type u = {...a, u: int}
+  2 │ 
+  3 │ type u = private {...a, u: int}
+
+  A record type declaration doesn't support the ... spread. Only an object (with quoted field names) does.
+
+
+  Syntax error!
+  tests/parsing/errors/typexpr/objectSpread.res:3:19-21
+
+  1 │ type u = {...a, u: int}
+  2 │ 
+  3 │ type u = private {...a, u: int}
+  4 │ 
+  5 │ type x = Type({...a, u: int})
+
+  A record type declaration doesn't support the ... spread. Only an object (with quoted field names) does.
+
+
+  Syntax error!
+  tests/parsing/errors/typexpr/objectSpread.res:5:16-18
+
+  3 │ type u = private {...a, u: int}
+  4 │ 
+  5 │ type x = Type({...a, u: int})
+  6 │ 
+  7 │ type u = {...a, "u": int, v: int}
+
+  A record type declaration doesn't support the ... spread. Only an object (with quoted field names) does.
+
+
+  Syntax error!
+  tests/parsing/errors/typexpr/objectSpread.res:7:27
+
+  5 │ type x = Type({...a, u: int})
+  6 │ 
+  7 │ type u = {...a, "u": int, v: int}
+  8 │ 
+  9 │ let f = (x: {a: int, b: int}) => ()
+
+  An object type declaration needs quoted field names. Did you mean "v"?
+
+
+  Syntax error!
+  tests/parsing/errors/typexpr/objectSpread.res:9:14
+
+   7 │ type u = {...a, "u": int, v: int}
+   8 │ 
+   9 │ let f = (x: {a: int, b: int}) => ()
+  10 │ 
+
+  An inline record type declaration is only allowed in a variant constructor's declaration
+
+type nonrec u = < a ;u: int   > 
+type nonrec u = private < a ;u: int   > 
+type nonrec x =
+  | Type of < a ;u: int   >  
+type nonrec u = < a ;u: int  ;v: int   > 
+let f (x : < a: int  ;b: int   > ) = ()

--- a/tests/parsing/errors/typexpr/objectSpread.res
+++ b/tests/parsing/errors/typexpr/objectSpread.res
@@ -1,0 +1,9 @@
+type u = {...a, u: int}
+
+type u = private {...a, u: int}
+
+type x = Type({...a, u: int})
+
+type u = {...a, "u": int, v: int}
+
+let f = (x: {a: int, b: int}) => ()

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -778,10 +778,10 @@ let icon =
   [@JSX ])
 let _ =
   ((MessengerSharedPhotosAlbumViewPhotoReact.createElement
-      ?ref:((if (foo ## bar) == baz
+      ?ref:((if foo#bar == baz
              then Some (foooooooooooooooooooooooo setRefChild)
              else None)[@ns.namedArgLoc ][@ns.ternary ])
-      ~key:((node ## legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
+      ~key:((node#legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
 let _ = ((Foo.createElement ~bar:((bar)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
@@ -792,7 +792,7 @@ let _ =
   [@JSX ])
 let x = ((div ~children:[] ())[@JSX ])
 let _ = ((div ~asd:((1)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
-;;(foo ## bar) #= ((bar ~children:[] ())[@JSX ])
+;;foo#bar #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 let x = [|((div ~children:[] ())[@JSX ])|]
@@ -1078,12 +1078,11 @@ let _ =
                 [@ns.braces ])] ())
   [@JSX ])
 let _ =
-  ((View.createElement ~style:((styles ## backgroundImageWrapper)
+  ((View.createElement ~style:((styles#backgroundImageWrapper)
       [@ns.namedArgLoc ])
       ~children:[(((let uri = \\"/images/header-background.png\\" in
                     ((Image.createElement ~resizeMode:((Contain)
-                        [@ns.namedArgLoc ])
-                        ~style:((styles ## backgroundImage)
+                        [@ns.namedArgLoc ]) ~style:((styles#backgroundImage)
                         [@ns.namedArgLoc ]) ~uri:((uri)[@ns.namedArgLoc ])
                         ~children:[] ())
                       [@JSX ])))
@@ -1215,13 +1214,13 @@ let x = (arr.((x : int))).((y : int))
     [@ns.namedArgLoc ]) ~b:((bArg)[@ns.namedArgLoc ]) ?c:((c)
     [@ns.namedArgLoc ]) ?d:((expr)[@ns.namedArgLoc ])
 ;;f ~a:(((x : int))[@ns.namedArgLoc ]) ?b:(((y : int))[@ns.namedArgLoc ])
-;;connection ## platformId
-;;((connection ## left) ## account) ## accountName
-;;(john ## age) #= 99
-;;((john ## son) ## age) #= ((steve ## age) - 5)
-;;(dict ## 
-) #= abc
-;;(dict ## \\") #= (dict2 ## \\")"
+;;connection#platformId
+;;((connection#left)#account)#accountName
+;;john#age #= 99
+;;(john#son)#age #= (steve#age - 5)
+;;dict#
+ #= abc
+;;dict#\\" #= dict2#\\""
 `;
 
 exports[`record.res 1`] = `

--- a/tests/parsing/grammar/expressions/expected/jsx.res.txt
+++ b/tests/parsing/grammar/expressions/expected/jsx.res.txt
@@ -220,10 +220,10 @@ let icon =
   [@JSX ])
 let _ =
   ((MessengerSharedPhotosAlbumViewPhotoReact.createElement
-      ?ref:((if (foo ## bar) == baz
+      ?ref:((if foo#bar == baz
              then Some (foooooooooooooooooooooooo setRefChild)
              else None)[@ns.namedArgLoc ][@ns.ternary ])
-      ~key:((node ## legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
+      ~key:((node#legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
 let _ = ((Foo.createElement ~bar:((bar)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
@@ -234,7 +234,7 @@ let _ =
   [@JSX ])
 let x = ((div ~children:[] ())[@JSX ])
 let _ = ((div ~asd:((1)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
-;;(foo ## bar) #= ((bar ~children:[] ())[@JSX ])
+;;foo#bar #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 let x = [|((div ~children:[] ())[@JSX ])|]
@@ -520,12 +520,11 @@ let _ =
                 [@ns.braces ])] ())
   [@JSX ])
 let _ =
-  ((View.createElement ~style:((styles ## backgroundImageWrapper)
+  ((View.createElement ~style:((styles#backgroundImageWrapper)
       [@ns.namedArgLoc ])
       ~children:[(((let uri = "/images/header-background.png" in
                     ((Image.createElement ~resizeMode:((Contain)
-                        [@ns.namedArgLoc ])
-                        ~style:((styles ## backgroundImage)
+                        [@ns.namedArgLoc ]) ~style:((styles#backgroundImage)
                         [@ns.namedArgLoc ]) ~uri:((uri)[@ns.namedArgLoc ])
                         ~children:[] ())
                       [@JSX ])))

--- a/tests/parsing/grammar/expressions/expected/primary.res.txt
+++ b/tests/parsing/grammar/expressions/expected/primary.res.txt
@@ -27,10 +27,10 @@ let x = (arr.((x : int))).((y : int))
     [@ns.namedArgLoc ]) ~b:((bArg)[@ns.namedArgLoc ]) ?c:((c)
     [@ns.namedArgLoc ]) ?d:((expr)[@ns.namedArgLoc ])
 ;;f ~a:(((x : int))[@ns.namedArgLoc ]) ?b:(((y : int))[@ns.namedArgLoc ])
-;;connection ## platformId
-;;((connection ## left) ## account) ## accountName
-;;(john ## age) #= 99
-;;((john ## son) ## age) #= ((steve ## age) - 5)
-;;(dict ## 
-) #= abc
-;;(dict ## ") #= (dict2 ## ")
+;;connection#platformId
+;;((connection#left)#account)#accountName
+;;john#age #= 99
+;;(john#son)#age #= (steve#age - 5)
+;;dict#
+ #= abc
+;;dict#" #= dict2#"

--- a/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
@@ -119,6 +119,13 @@ type nonrec t = (module Console) ref
 let (devices : (string, (module DEVICE)) Hastbl.t) = Hashtbl.creat 17"
 `;
 
+exports[`objectTypeSpreading.res 1`] = `
+"type nonrec a = < x: int   > 
+type nonrec u = < a ;u: int   > 
+type nonrec v = < v: int  ;a  > 
+type nonrec w = < j: int  ;a ;k: int  ;v  > "
+`;
+
 exports[`parenthesized.res 1`] = `"type nonrec t = ((a:((int)[@ns.namedArgLoc ]) -> unit)[@attr ])"`;
 
 exports[`poly.res 1`] = `

--- a/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
@@ -123,7 +123,42 @@ exports[`objectTypeSpreading.res 1`] = `
 "type nonrec a = < x: int   > 
 type nonrec u = < a ;u: int   > 
 type nonrec v = < v: int  ;a  > 
-type nonrec w = < j: int  ;a ;k: int  ;v  > "
+type nonrec w = < j: int  ;a ;k: int  ;v  > 
+type nonrec t = < a ;u: int   >  as 'a
+type nonrec t = < a ;u: int   >  -> unit
+type nonrec t = (< a ;u: int   >  as 'a) -> unit
+type nonrec t = < a ;u: int   >  -> < a ;v: int   >  -> unit
+type nonrec user = < name: string   > 
+let (steve : < user ;age: int   > ) = [%obj { name = \\"Steve\\"; age = 30 }]
+let steve = ([%obj { name = \\"Steve\\"; age = 30 }] : < user ;age: int   > )
+let steve = ((([%obj { name = \\"Steve\\"; age = 30 }] : < user ;age: int   > ))
+  [@ns.braces ])
+let printFullUser (steve : < user ;age: int   > ) = Js.log steve
+let printFullUser ~user:(((user : < user ;age: int   > ))[@ns.namedArgLoc ]) 
+  = Js.log steve
+let printFullUser ~user:(((user : < user ;age: int   > ))[@ns.namedArgLoc ]) 
+  = Js.log steve
+let printFullUser ?user:(((user)[@ns.namedArgLoc ])=
+  (steve : < user ;age: int   > ))  = Js.log steve
+external steve : < user ;age: int   >  = \\"steve\\"[@@val ]
+let makeCeoOf30yearsOld name =
+  ([%obj { name; age = 30 }] : < user ;age: int   > )
+type nonrec optionalUser = < user ;age: int   >  option
+type nonrec optionalTupleUser =
+  (< user ;age: int   >  * < user ;age: int   > ) option
+type nonrec constrUser =
+  (< user ;age: int   > , < user ;age: int   > ) myTypeConstructor
+type nonrec taggedUser =
+  | User of < user ;age: int   >  
+  | Ceo of < user ;age: int  ;direction: bool   >  *
+  < salary ;taxFraud: bool   >  
+type nonrec polyTaggedUser = [ \`User of < user ;age: int   >  ]
+type nonrec polyTaggedUser2 =
+  [ \`User of < user ;age: int   >  
+  | \`Ceo of
+      (< user ;age: int  ;direction: bool   >  *
+        < salary ;taxFraud: bool   > )
+      ]"
 `;
 
 exports[`parenthesized.res 1`] = `"type nonrec t = ((a:((int)[@ns.namedArgLoc ]) -> unit)[@attr ])"`;

--- a/tests/parsing/grammar/typexpr/expected/objectTypeSpreading.res.txt
+++ b/tests/parsing/grammar/typexpr/expected/objectTypeSpreading.res.txt
@@ -1,0 +1,39 @@
+type nonrec a = < x: int   > 
+type nonrec u = < a ;u: int   > 
+type nonrec v = < v: int  ;a  > 
+type nonrec w = < j: int  ;a ;k: int  ;v  > 
+type nonrec t = < a ;u: int   >  as 'a
+type nonrec t = < a ;u: int   >  -> unit
+type nonrec t = (< a ;u: int   >  as 'a) -> unit
+type nonrec t = < a ;u: int   >  -> < a ;v: int   >  -> unit
+type nonrec user = < name: string   > 
+let (steve : < user ;age: int   > ) = [%obj { name = "Steve"; age = 30 }]
+let steve = ([%obj { name = "Steve"; age = 30 }] : < user ;age: int   > )
+let steve = ((([%obj { name = "Steve"; age = 30 }] : < user ;age: int   > ))
+  [@ns.braces ])
+let printFullUser (steve : < user ;age: int   > ) = Js.log steve
+let printFullUser ~user:(((user : < user ;age: int   > ))[@ns.namedArgLoc ]) 
+  = Js.log steve
+let printFullUser ~user:(((user : < user ;age: int   > ))[@ns.namedArgLoc ]) 
+  = Js.log steve
+let printFullUser ?user:(((user)[@ns.namedArgLoc ])=
+  (steve : < user ;age: int   > ))  = Js.log steve
+external steve : < user ;age: int   >  = "steve"[@@val ]
+let makeCeoOf30yearsOld name =
+  ([%obj { name; age = 30 }] : < user ;age: int   > )
+type nonrec optionalUser = < user ;age: int   >  option
+type nonrec optionalTupleUser =
+  (< user ;age: int   >  * < user ;age: int   > ) option
+type nonrec constrUser =
+  (< user ;age: int   > , < user ;age: int   > ) myTypeConstructor
+type nonrec taggedUser =
+  | User of < user ;age: int   >  
+  | Ceo of < user ;age: int  ;direction: bool   >  *
+  < salary ;taxFraud: bool   >  
+type nonrec polyTaggedUser = [ `User of < user ;age: int   >  ]
+type nonrec polyTaggedUser2 =
+  [ `User of < user ;age: int   >  
+  | `Ceo of
+      (< user ;age: int  ;direction: bool   >  *
+        < salary ;taxFraud: bool   > )
+      ]

--- a/tests/parsing/grammar/typexpr/objectTypeSpreading.res
+++ b/tests/parsing/grammar/typexpr/objectTypeSpreading.res
@@ -2,3 +2,39 @@ type a = {"x": int}
 type u = {...a, "u": int}
 type v = {"v": int, ...a}
 type w = {"j": int, ...a, "k": int, ...v}
+
+
+type t = {...a, "u": int} as 'a 
+type t = {...a, "u": int} => unit
+type t = {...a, "u": int} as 'a => unit
+type t = ({...a, "u": int}, {...a, "v": int}) => unit
+
+type user = {"name": string} 
+
+let steve: {...user, "age": int} = {"name": "Steve", "age": 30}
+let steve = ({"name": "Steve", "age": 30}: {...user, "age": int})
+let steve = {({"name": "Steve", "age": 30}: {...user, "age": int})}
+
+let printFullUser = (steve: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user = steve : {...user, "age": int}) => Js.log(steve)
+
+@val
+external steve: {...user, "age": int} = "steve"
+
+let makeCeoOf30yearsOld = (name) : {...user, "age": int} => {"name": name, "age": 30}
+
+type optionalUser = option<{...user, "age": int}>
+type optionalTupleUser = option<({...user, "age": int}, {...user, "age": int})>
+type constrUser = myTypeConstructor<{...user, "age": int}, {...user, "age": int}>
+
+type taggedUser =
+  | User({...user, "age": int})
+  | Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool}) 
+
+type polyTaggedUser = [ #User({...user, "age": int}) ]
+type polyTaggedUser2 = [ 
+  | #User({...user, "age": int}) 
+  | #Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool}) 
+]

--- a/tests/parsing/grammar/typexpr/objectTypeSpreading.res
+++ b/tests/parsing/grammar/typexpr/objectTypeSpreading.res
@@ -1,0 +1,4 @@
+type a = {"x": int}
+type u = {...a, "u": int}
+type v = {"v": int, ...a}
+type w = {"j": int, ...a, "k": int, ...v}

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -409,6 +409,14 @@ let devices: @attr Hastbl.t<string, module(DEVICE)> = xyz
 "
 `;
 
+exports[`objectTypeSpreading.res 1`] = `
+"type a = {\\"x\\": int}
+type u = {...a, \\"u\\": int}
+type v = {\\"v\\": int, ...a}
+type w = {\\"j\\": int, ...a, \\"k\\": int, ...v}
+"
+`;
+
 exports[`polyTyp.res 1`] = `
 "external getLogger: unit => {
   \\"log\\": 'a => unit,

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -414,6 +414,48 @@ exports[`objectTypeSpreading.res 1`] = `
 type u = {...a, \\"u\\": int}
 type v = {\\"v\\": int, ...a}
 type w = {\\"j\\": int, ...a, \\"k\\": int, ...v}
+
+type t = {...a, \\"u\\": int} as 'a
+type t = {...a, \\"u\\": int} => unit
+type t = ({...a, \\"u\\": int} as 'a) => unit
+type t = ({...a, \\"u\\": int}, {...a, \\"v\\": int}) => unit
+
+type user = {\\"name\\": string}
+
+let steve: {...user, \\"age\\": int} = {\\"name\\": \\"Steve\\", \\"age\\": 30}
+let steve = ({\\"name\\": \\"Steve\\", \\"age\\": 30}: {...user, \\"age\\": int})
+let steve = {({\\"name\\": \\"Steve\\", \\"age\\": 30}: {...user, \\"age\\": int})}
+
+let printFullUser = (steve: {...user, \\"age\\": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, \\"age\\": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, \\"age\\": int}) => Js.log(steve)
+let printFullUser = (~user=steve: {...user, \\"age\\": int}) => Js.log(steve)
+
+@val
+external steve: {...user, \\"age\\": int} = \\"steve\\"
+
+let makeCeoOf30yearsOld = (name): {...user, \\"age\\": int} =>
+  {\\"name\\": name, \\"age\\": 30}
+
+type optionalUser = option<{...user, \\"age\\": int}>
+type optionalTupleUser = option<({...user, \\"age\\": int}, {...user, \\"age\\": int})>
+type constrUser = myTypeConstructor<
+  {...user, \\"age\\": int},
+  {...user, \\"age\\": int},
+>
+
+type taggedUser =
+  | User({...user, \\"age\\": int})
+  | Ceo({...user, \\"age\\": int, \\"direction\\": bool}, {...salary, \\"taxFraud\\": bool})
+
+type polyTaggedUser = [#User({...user, \\"age\\": int})]
+type polyTaggedUser2 = [
+  | #User({...user, \\"age\\": int})
+  | #Ceo(
+    {...user, \\"age\\": int, \\"direction\\": bool},
+    {...salary, \\"taxFraud\\": bool},
+  )
+]
 "
 `;
 

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -456,6 +456,21 @@ type polyTaggedUser2 = [
     {...salary, \\"taxFraud\\": bool},
   )
 ]
+
+// notice .. and ..., they should have a space
+type u<'a> = {.. ...hi} as 'a
+type u<'a> = {..
+  ...hi,
+  \\"superLongFieldName\\": string,
+  \\"superLongFieldName22222222222\\": int,
+} as 'a
+type u<'a> = {..
+  ...hi,
+  \\"superLongFieldName\\": string,
+  ...hi,
+  \\"superLongFieldName22222222222\\": int,
+  ...hi,
+} as 'a
 "
 `;
 

--- a/tests/printer/typexpr/expected/objectTypeSpreading.res.txt
+++ b/tests/printer/typexpr/expected/objectTypeSpreading.res.txt
@@ -1,0 +1,50 @@
+type a = {"x": int}
+type u = {...a, "u": int}
+type v = {"v": int, ...a}
+type w = {"j": int, ...a, "k": int, ...v}
+
+type t = {...a, "u": int} as 'a
+type t = {...a, "u": int} => unit
+type t = ({...a, "u": int} as 'a) => unit
+type t = ({...a, "u": int}, {...a, "v": int}) => unit
+
+type user = {"name": string}
+
+let steve: {...user, "age": int} = {"name": "Steve", "age": 30}
+let steve = ({"name": "Steve", "age": 30}: {...user, "age": int})
+let steve = {({"name": "Steve", "age": 30}: {...user, "age": int})}
+
+let printFullUser = (steve: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user=steve: {...user, "age": int}) => Js.log(steve)
+
+@val
+external steve: {...user, "age": int} = "steve"
+
+let makeCeoOf30yearsOld = (name): {...user, "age": int} => {"name": name, "age": 30}
+
+type optionalUser = option<{...user, "age": int}>
+type optionalTupleUser = option<({...user, "age": int}, {...user, "age": int})>
+type constrUser = myTypeConstructor<{...user, "age": int}, {...user, "age": int}>
+
+type taggedUser =
+  | User({...user, "age": int})
+  | Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool})
+
+type polyTaggedUser = [#User({...user, "age": int})]
+type polyTaggedUser2 = [
+  | #User({...user, "age": int})
+  | #Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool})
+]
+
+// notice .. and ..., they should have a space
+type u<'a> = {.. ...hi} as 'a
+type u<'a> = {.. ...hi, "superLongFieldName": string, "superLongFieldName22222222222": int} as 'a
+type u<'a> = {..
+  ...hi,
+  "superLongFieldName": string,
+  ...hi,
+  "superLongFieldName22222222222": int,
+  ...hi,
+} as 'a

--- a/tests/printer/typexpr/objectTypeSpreading.res
+++ b/tests/printer/typexpr/objectTypeSpreading.res
@@ -2,3 +2,39 @@ type a = {"x": int}
 type u = {...a, "u": int}
 type v = {"v": int, ...a}
 type w = {"j": int, ...a, "k": int, ...v}
+
+
+type t = {...a, "u": int} as 'a 
+type t = {...a, "u": int} => unit
+type t = {...a, "u": int} as 'a => unit
+type t = ({...a, "u": int}, {...a, "v": int}) => unit
+
+type user = {"name": string} 
+
+let steve: {...user, "age": int} = {"name": "Steve", "age": 30}
+let steve = ({"name": "Steve", "age": 30}: {...user, "age": int})
+let steve = {({"name": "Steve", "age": 30}: {...user, "age": int})}
+
+let printFullUser = (steve: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user: {...user, "age": int}) => Js.log(steve)
+let printFullUser = (~user = steve : {...user, "age": int}) => Js.log(steve)
+
+@val
+external steve: {...user, "age": int} = "steve"
+
+let makeCeoOf30yearsOld = (name) : {...user, "age": int} => {"name": name, "age": 30}
+
+type optionalUser = option<{...user, "age": int}>
+type optionalTupleUser = option<({...user, "age": int}, {...user, "age": int})>
+type constrUser = myTypeConstructor<{...user, "age": int}, {...user, "age": int}>
+
+type taggedUser =
+  | User({...user, "age": int})
+  | Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool}) 
+
+type polyTaggedUser = [ #User({...user, "age": int}) ]
+type polyTaggedUser2 = [ 
+  | #User({...user, "age": int}) 
+  | #Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool}) 
+]

--- a/tests/printer/typexpr/objectTypeSpreading.res
+++ b/tests/printer/typexpr/objectTypeSpreading.res
@@ -38,3 +38,8 @@ type polyTaggedUser2 = [
   | #User({...user, "age": int}) 
   | #Ceo({...user, "age": int, "direction": bool}, {...salary, "taxFraud": bool}) 
 ]
+
+// notice .. and ..., they should have a space
+type u<'a> = {.. ...hi} as 'a
+type u<'a> = {.. ...hi, "superLongFieldName": string, "superLongFieldName22222222222": int} as 'a
+type u<'a> = {.. ...hi, "superLongFieldName": string, ...hi, "superLongFieldName22222222222": int, ...hi} as 'a

--- a/tests/printer/typexpr/objectTypeSpreading.res
+++ b/tests/printer/typexpr/objectTypeSpreading.res
@@ -1,0 +1,4 @@
+type a = {"x": int}
+type u = {...a, "u": int}
+type v = {"v": int, ...a}
+type w = {"j": int, ...a, "k": int, ...v}


### PR DESCRIPTION
Fixes #311

`obj["say"]` was currently parsed as `obj##say` (Pexp_apply with ##)
We now parse this straight into `obj#say`(Pexp_send)