### PR TITLE
Update object method parsing and printer for ReScript 9

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1955,9 +1955,7 @@ and parseBracketAccess p expr startPos =
     let e =
       let identLoc = mkLoc stringStart stringEnd in
       let loc = mkLoc lbracket rbracket in
-      Ast_helper.Exp.apply ~loc
-      (Ast_helper.Exp.ident ~loc (Location.mkloc (Longident.Lident "##") loc))
-      [Nolabel, expr; Nolabel, (Ast_helper.Exp.ident ~loc:identLoc (Location.mkloc (Longident.Lident s) identLoc))]
+      Ast_helper.Exp.send ~loc expr (Location.mkloc s identLoc)
     in
     let e = parsePrimaryExpr ~operand:e p in
     let equalStart = p.startPos in

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3137,8 +3137,26 @@ and printExpression (e : Parsetree.expression) cmtTbl =
       Doc.concat [Doc.text ": "; printTypExpr typ1 cmtTbl]
     in
     Doc.concat [Doc.lparen; docExpr; ofType; Doc.text " :> "; docTyp; Doc.rparen]
-  | Pexp_send _ ->
-    Doc.text "Pexp_send not impemented in printer"
+  | Pexp_send (parentExpr, label) ->
+    let parentDoc =
+      let doc = printExpressionWithComments parentExpr cmtTbl in
+      match Parens.unaryExprOperand parentExpr with
+      | Parens.Parenthesized -> addParens doc
+      | Braced braces  -> printBraces doc parentExpr braces
+      | Nothing -> doc
+    in
+    let member =
+      let memberDoc = printComments (Doc.text label.txt) cmtTbl label.loc in
+      Doc.concat [Doc.text "\""; memberDoc; Doc.text "\""]
+    in
+    Doc.group (
+      Doc.concat [
+        parentDoc;
+        Doc.lbracket;
+        member;
+        Doc.rbracket;
+      ]
+    )
   | Pexp_new _ ->
     Doc.text "Pexp_new not impemented in printer"
   | Pexp_setinstvar _ ->

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1285,6 +1285,17 @@ type propField<'a> = Js.nullable<{..} as 'a>
 type propField<'a> = {\\"a\\": b}
 type propField<'a> = {..\\"a\\": b}
 type propField<'a> = {\\"a\\": {\\"b\\": c}}
+
+user[\\"address\\"]
+user[\\"address\\"][\\"street\\"]
+user[\\"address\\"][\\"street\\"][\\"log\\"]
+
+user[\\"address\\"] = \\"Avenue 1\\"
+user[\\"address\\"][\\"street\\"] = \\"Avenue\\"
+user[\\"address\\"][\\"street\\"][\\"number\\"] = \\"1\\"
+
+school[\\"print\\"](direction[\\"name\\"], studentHead[\\"name\\"])
+city[\\"getSchool\\"]()[\\"print\\"](direction[\\"name\\"], studentHead[\\"name\\"])
 "
 `;
 

--- a/tests/conversion/reason/expected/jsObject.re.txt
+++ b/tests/conversion/reason/expected/jsObject.re.txt
@@ -13,3 +13,14 @@ type propField<'a> = Js.nullable<{..} as 'a>
 type propField<'a> = {"a": b}
 type propField<'a> = {.."a": b}
 type propField<'a> = {"a": {"b": c}}
+
+user["address"]
+user["address"]["street"]
+user["address"]["street"]["log"]
+
+user["address"] = "Avenue 1"
+user["address"]["street"] = "Avenue"
+user["address"]["street"]["number"] = "1"
+
+school["print"](direction["name"], studentHead["name"])
+city["getSchool"]()["print"](direction["name"], studentHead["name"])

--- a/tests/conversion/reason/jsObject.re
+++ b/tests/conversion/reason/jsObject.re
@@ -13,3 +13,15 @@ type propField('a) = Js.nullable(Js.t({..} as 'a))
 type propField('a) = {. "a": b}
 type propField('a) = {.. "a": b}
 type propField('a) = Js.t(Js.t({. "a": Js.t({. "b": c})}))
+
+user##address;
+user##address##street;
+user##address##street##log;
+
+user##address #= "Avenue 1";
+user##address##street #= "Avenue" ;
+user##address##street##number #= "1";
+
+school##print(direction##name, studentHead##name);
+(city##getSchool())##print(direction##name, studentHead##name);
+

--- a/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`breadcrumbs170.res 1`] = `
 "=====Parsetree==========================================
 let l = (Some [1; 2; 3]) |> Obj.magic
-module M = struct ;;match l with | None -> [] | Some l -> l ## prop end
+module M = struct ;;match l with | None -> [] | Some l -> l#prop end
 ;;from
 ;;now
 ;;on

--- a/tests/parsing/errors/other/expected/breadcrumbs170.res.txt
+++ b/tests/parsing/errors/other/expected/breadcrumbs170.res.txt
@@ -11,7 +11,7 @@
   I'm not sure what to parse here when looking at "}".
 
 let l = (Some [1; 2; 3]) |> Obj.magic
-module M = struct ;;match l with | None -> [] | Some l -> l ## prop end
+module M = struct ;;match l with | None -> [] | Some l -> l#prop end
 ;;from
 ;;now
 ;;on

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -778,10 +778,10 @@ let icon =
   [@JSX ])
 let _ =
   ((MessengerSharedPhotosAlbumViewPhotoReact.createElement
-      ?ref:((if (foo ## bar) == baz
+      ?ref:((if foo#bar == baz
              then Some (foooooooooooooooooooooooo setRefChild)
              else None)[@ns.namedArgLoc ][@ns.ternary ])
-      ~key:((node ## legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
+      ~key:((node#legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
 let _ = ((Foo.createElement ~bar:((bar)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
@@ -792,7 +792,7 @@ let _ =
   [@JSX ])
 let x = ((div ~children:[] ())[@JSX ])
 let _ = ((div ~asd:((1)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
-;;(foo ## bar) #= ((bar ~children:[] ())[@JSX ])
+;;foo#bar #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 let x = [|((div ~children:[] ())[@JSX ])|]
@@ -1078,12 +1078,11 @@ let _ =
                 [@ns.braces ])] ())
   [@JSX ])
 let _ =
-  ((View.createElement ~style:((styles ## backgroundImageWrapper)
+  ((View.createElement ~style:((styles#backgroundImageWrapper)
       [@ns.namedArgLoc ])
       ~children:[(((let uri = \\"/images/header-background.png\\" in
                     ((Image.createElement ~resizeMode:((Contain)
-                        [@ns.namedArgLoc ])
-                        ~style:((styles ## backgroundImage)
+                        [@ns.namedArgLoc ]) ~style:((styles#backgroundImage)
                         [@ns.namedArgLoc ]) ~uri:((uri)[@ns.namedArgLoc ])
                         ~children:[] ())
                       [@JSX ])))
@@ -1215,13 +1214,13 @@ let x = (arr.((x : int))).((y : int))
     [@ns.namedArgLoc ]) ~b:((bArg)[@ns.namedArgLoc ]) ?c:((c)
     [@ns.namedArgLoc ]) ?d:((expr)[@ns.namedArgLoc ])
 ;;f ~a:(((x : int))[@ns.namedArgLoc ]) ?b:(((y : int))[@ns.namedArgLoc ])
-;;connection ## platformId
-;;((connection ## left) ## account) ## accountName
-;;(john ## age) #= 99
-;;((john ## son) ## age) #= ((steve ## age) - 5)
-;;(dict ## 
-) #= abc
-;;(dict ## \\") #= (dict2 ## \\")"
+;;connection#platformId
+;;((connection#left)#account)#accountName
+;;john#age #= 99
+;;(john#son)#age #= (steve#age - 5)
+;;dict#
+ #= abc
+;;dict#\\" #= dict2#\\""
 `;
 
 exports[`record.res 1`] = `

--- a/tests/parsing/grammar/expressions/expected/jsx.res.txt
+++ b/tests/parsing/grammar/expressions/expected/jsx.res.txt
@@ -220,10 +220,10 @@ let icon =
   [@JSX ])
 let _ =
   ((MessengerSharedPhotosAlbumViewPhotoReact.createElement
-      ?ref:((if (foo ## bar) == baz
+      ?ref:((if foo#bar == baz
              then Some (foooooooooooooooooooooooo setRefChild)
              else None)[@ns.namedArgLoc ][@ns.ternary ])
-      ~key:((node ## legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
+      ~key:((node#legacy_attachment_id)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
 let _ = ((Foo.createElement ~bar:((bar)[@ns.namedArgLoc ]) ~children:[] ())
   [@JSX ])
@@ -234,7 +234,7 @@ let _ =
   [@JSX ])
 let x = ((div ~children:[] ())[@JSX ])
 let _ = ((div ~asd:((1)[@ns.namedArgLoc ]) ~children:[] ())[@JSX ])
-;;(foo ## bar) #= ((bar ~children:[] ())[@JSX ])
+;;foo#bar #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 ;;foo #= ((bar ~children:[] ())[@JSX ])
 let x = [|((div ~children:[] ())[@JSX ])|]
@@ -520,12 +520,11 @@ let _ =
                 [@ns.braces ])] ())
   [@JSX ])
 let _ =
-  ((View.createElement ~style:((styles ## backgroundImageWrapper)
+  ((View.createElement ~style:((styles#backgroundImageWrapper)
       [@ns.namedArgLoc ])
       ~children:[(((let uri = "/images/header-background.png" in
                     ((Image.createElement ~resizeMode:((Contain)
-                        [@ns.namedArgLoc ])
-                        ~style:((styles ## backgroundImage)
+                        [@ns.namedArgLoc ]) ~style:((styles#backgroundImage)
                         [@ns.namedArgLoc ]) ~uri:((uri)[@ns.namedArgLoc ])
                         ~children:[] ())
                       [@JSX ])))

--- a/tests/parsing/grammar/expressions/expected/primary.res.txt
+++ b/tests/parsing/grammar/expressions/expected/primary.res.txt
@@ -27,10 +27,10 @@ let x = (arr.((x : int))).((y : int))
     [@ns.namedArgLoc ]) ~b:((bArg)[@ns.namedArgLoc ]) ?c:((c)
     [@ns.namedArgLoc ]) ?d:((expr)[@ns.namedArgLoc ])
 ;;f ~a:(((x : int))[@ns.namedArgLoc ]) ?b:(((y : int))[@ns.namedArgLoc ])
-;;connection ## platformId
-;;((connection ## left) ## account) ## accountName
-;;(john ## age) #= 99
-;;((john ## son) ## age) #= ((steve ## age) - 5)
-;;(dict ## 
-) #= abc
-;;(dict ## ") #= (dict2 ## ")
+;;connection#platformId
+;;((connection#left)#account)#accountName
+;;john#age #= 99
+;;(john#son)#age #= (steve#age - 5)
+;;dict#
+ #= abc
+;;dict#" #= dict2#"


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/311

`obj["say"]` was currently parsed as `obj##say` (Pexp_apply with ##)
We now parse this straight into `obj#say`(Pexp_send)