### PR TITLE
Expose Res_outcome_printer.printOutTypeDoc / printOutSigItemDoc

### DIFF
--- a/.depend
+++ b/.depend
@@ -49,7 +49,7 @@ src/res_multi_printer.cmx : src/res_printer.cmx src/res_io.cmx \
 src/res_multi_printer.cmi :
 src/res_outcome_printer.cmx : src/res_token.cmx src/res_doc.cmx \
     src/res_outcome_printer.cmi
-src/res_outcome_printer.cmi :
+src/res_outcome_printer.cmi : src/res_doc.cmi
 src/res_parens.cmx : src/res_parsetree_viewer.cmx src/res_parens.cmi
 src/res_parens.cmi :
 src/res_parser.cmx : src/res_token.cmx src/res_scanner.cmx \

--- a/src/res_outcome_printer.mli
+++ b/src/res_outcome_printer.mli
@@ -10,3 +10,7 @@
 val parenthesized_ident : string -> bool [@@live]
 
 val setup : unit lazy_t [@@live]
+
+(* Needed for e.g. the playground to print typedtree data *)
+val printOutTypeDoc : Outcometree.out_type -> Res_doc.t [@@live]
+val printOutSigItemDoc : Outcometree.out_sig_item -> Res_doc.t [@@live]


### PR DESCRIPTION
This particular APIs are needed to be able to print typedtree data
in the playground bundle. We need that to show type hint tooltips.