### PR TITLE
Fix parsing of arrow expressions in ternaries.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1576,7 +1576,7 @@ and parseTernaryExpr leftOperand p =
   | _ ->
     leftOperand
 
-and parseEs6ArrowExpression ?parameters p =
+and parseEs6ArrowExpression ?context ?parameters p =
   let startPos = p.Parser.startPos in
   Parser.leaveBreadcrumb p Grammar.Es6ArrowExpr;
   let parameters = match parameters with
@@ -1592,7 +1592,7 @@ and parseEs6ArrowExpression ?parameters p =
   in
   Parser.expect EqualGreater p;
   let body =
-    let expr = parseExpr p in
+    let expr = parseExpr ?context p in
     match returnType with
     | Some typ ->
       Ast_helper.Exp.constraint_
@@ -2108,7 +2108,7 @@ and parseOperandExpr ~context p =
     if (context != WhenExpr) &&
        isEs6ArrowExpression ~inTernary:(context=TernaryTrueBranchExpr) p
     then
-      parseEs6ArrowExpression p
+      parseEs6ArrowExpression ~context p
     else
       parseUnaryExpr p
   in

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -4037,6 +4037,9 @@ a =>
 
 let x = @attrOnTernary (truth ? true : false)
 let x = @attrOnCondition truth ? true : false
+
+x ? y => () : onChange
+let y = <input value onChange={x ? _ => () : onChange} />
 "
 `;
 

--- a/tests/printer/expr/expected/ternary.res.txt
+++ b/tests/printer/expr/expected/ternary.res.txt
@@ -259,3 +259,6 @@ a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaaaaa :
 
 let x = @attrOnTernary (truth ? true : false)
 let x = @attrOnCondition truth ? true : false
+
+x ? y => () : onChange
+let y = <input value onChange={x ? _ => () : onChange} />

--- a/tests/printer/expr/ternary.res
+++ b/tests/printer/expr/ternary.res
@@ -121,3 +121,6 @@ a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaaaaa :
 
 let x = @attrOnTernary (truth ? true : false)
 let x = @attrOnCondition truth ? true : false
+
+x ? y => () : onChange
+let y = <input value onChange={x ? _ => () : onChange} />


### PR DESCRIPTION
Arrow functions in the "ternary true branch" where picked up as nested arrows:
`x ? y => () : onChange` for the parser was `x ? y => (() : onChange => …)`

The fix is to pass the right context through.

Fixes https://github.com/rescript-lang/syntax/issues/363