### PR TITLE
Fix printing of trailing comments on variant constructor without bar.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -4662,7 +4662,7 @@ and parseTypeEquationOrConstrDecl p =
       | _ -> (Some typ, Asttypes.Public, Parsetree.Ptype_abstract)
       end
     | _ ->
-      let uidentEndPos = p.endPos in
+      let uidentEndPos = p.prevEndPos in
       let (args, res) = parseConstrDeclArgs p in
       let first = Some (
         let uidentLoc = mkLoc uidentStartPos uidentEndPos in

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -1757,8 +1757,8 @@ type color =
   | /* before Blue */ Blue /* after Blue */: /* before gadt */ color /* after gadt */
 
 type color =
-  /* before constr */ | Rgb(
-      /* after constructor */ /* before red */ red,
+  /* before constr */ | Rgb /* after constructor */(
+      /* before red */ red,
       green,
       blue,
     )

--- a/tests/printer/comments/expected/typeDefinition.res.txt
+++ b/tests/printer/comments/expected/typeDefinition.res.txt
@@ -37,7 +37,7 @@ type color =
   | /* before Red */ Red /* after Red */: /* before gadt */ color /* after gadt */
   | /* before Blue */ Blue /* after Blue */: /* before gadt */ color /* after gadt */
 
-type color = /* before constr */ Rgb(/* after constructor */ /* before red */ red, green, blue)
+type color = /* before constr */ Rgb /* after constructor */(/* before red */ red, green, blue)
 
 type color =
   | /* before constr */ Rgb /* after constructor */(


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/362

The wrong end location was parsed for the `Rgb` constructor in:
```rescript
type color = /* before constr */ Rgb/*after constructor */( /* before red */ red, green, blue)
```
resulting in the comment `/* after constructor */` being moved inside the arguments