### PR TITLE
Fix printing of JSX in binary expressions.

### DIFF
--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -453,13 +453,13 @@ let shouldInlineRhsBinaryExpr rhs = match rhs.pexp_desc with
 
 let filterPrinteableAttributes attrs =
   List.filter (fun attr -> match attr with
-    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet"}, _) -> false
+    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet" | "JSX"}, _) -> false
     | _ -> true
   ) attrs
 
 let partitionPrinteableAttributes attrs =
   List.partition (fun attr -> match attr with
-    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet"}, _) -> false
+    | ({Location.txt="bs" | "ns.ternary" | "ns.iflet" | "JSX"}, _) -> false
     | _ -> true
   ) attrs
 

--- a/tests/printer/expr/binary.res
+++ b/tests/printer/expr/binary.res
@@ -388,3 +388,15 @@ React.useEffect4(
   },
   (context.library, context.account, context.chainId, dispatch),
 )
+
+@react.component
+let make = (~keycap) =>
+  <Kbd keycap="Ctrl" /> +
+  <Kbd keycap="Shift" /> +
+  <Kbd keycap />
+
+
+<Kbd keycap="Cmd" /> +
+<Kbd keycap="Option" /> +
+<Kbd keycap="Shift" /> +
+<Kbd keycap />

--- a/tests/printer/expr/expected/binary.res.txt
+++ b/tests/printer/expr/expected/binary.res.txt
@@ -511,3 +511,8 @@ React.useEffect4(() => {
   | _ => None
   }
 }, (context.library, context.account, context.chainId, dispatch))
+
+@react.component
+let make = (~keycap) => <Kbd keycap="Ctrl" /> + <Kbd keycap="Shift" /> + <Kbd keycap />
+
+<Kbd keycap="Cmd" /> + <Kbd keycap="Option" /> + <Kbd keycap="Shift" /> + <Kbd keycap />


### PR DESCRIPTION
The following snippet:
```
<Kbd keycap="Ctrl" /> + <Kbd keycap="Shift" /> + <Kbd keycap />
```
would print in the non-sugared JSX form.

Nested binary expressions should print JSX correctly.

Fixes https://github.com/rescript-lang/syntax/issues/373