### PR TITLE
Fix printing of trailing comments on constructor part of Ppat_construct.

### DIFF
--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -1656,7 +1656,11 @@ and walkExprArgument (_argLabel, expr) t comments =
     | Ppat_construct (constr, Some pat) ->
       let (leading, trailing) = partitionLeadingTrailing comments constr.loc in
       attach t.leading constr.loc leading;
-      let (leading, inside, trailing) = partitionByLoc trailing pat.ppat_loc in
+      let (afterConstructor, rest) =
+        partitionAdjacentTrailing constr.loc trailing
+      in
+      attach t.trailing constr.loc afterConstructor;
+      let (leading, inside, trailing) = partitionByLoc rest pat.ppat_loc in
       attach t.leading pat.ppat_loc leading;
       walkPattern pat t inside;
       attach t.trailing pat.ppat_loc trailing

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2164,7 +2164,7 @@ and printPattern (p : Parsetree.pattern) cmtTbl =
       ])
     )
   | Ppat_construct(constrName, constructorArgs) ->
-    let constrName = printLongident constrName.txt in
+    let constrName = printLongidentLocation constrName cmtTbl in
     let argsDoc = match constructorArgs with
     | None -> Doc.nil
     | Some({ppat_loc; ppat_desc = Ppat_construct ({txt = Longident.Lident "()"}, _)}) ->

--- a/tests/printer/comments/expected/pattern.res.txt
+++ b/tests/printer/comments/expected/pattern.res.txt
@@ -28,11 +28,16 @@ let Black(// singleLineComment
 
 let module(/* c0 */ X /* c1 */: /* c2 */ X_int /* c3 */) /* c4 */ = x
 
-let /* before */ Rgb(
+let /* before */ Rgb /* after constr */(
   /* red */ r /* red2 */,
   /* green */ g /* green2 */,
   /* blue */ b /* blue2 */,
 ) /* after */ = color
+
+switch a {
+| Constr /* after constr */
+| Constr /* after constr */(a, _) => a
+}
 
 let () = ()
 let [/* inside */] = []

--- a/tests/printer/comments/pattern.res
+++ b/tests/printer/comments/pattern.res
@@ -31,6 +31,11 @@ let module(/* c0 */ X /* c1 */ : /* c2 */ X_int /* c3 */) /* c4 */ = x
 
 let /* before */ Rgb /* after constr */ (/* red */ r /* red2 */, /* green */ g/* green2 */, /* blue */ b /* blue2 */) /* after */ = color
 
+switch a {
+| Constr /* after constr */ 
+| Constr /* after constr */ (a, _) => a
+}
+
 let () = ()
 let [/* inside */] = []
 let list{/* inside */} = list{}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/374

These comments should print correct:
```rescript
switch a {
| Constr /* after constr */
| Constr /* after constr */ (a, _) => a
}
```