### PR TITLE
not display external garbage

### DIFF
--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -598,7 +598,10 @@ let printPolyVarIdent txt =
                  Doc.text " =";
                  Doc.line;
                  Doc.group (
-                   Doc.join ~sep:Doc.line (List.map (fun prim -> Doc.text ("\"" ^ prim ^ "\"")) primitives)
+                   Doc.join ~sep:Doc.line (List.map (fun prim -> 
+                       let prim = if prim <> "" && prim.[0] = '\132' then "#rescript-external" else prim in 
+                       (* not display those garbage '\132' is a magic number for marshal *)
+                       Doc.text ("\"" ^ prim ^ "\"")) primitives)
                  )
                ]
              )


### PR DESCRIPTION
```
jscomp$../darwin/bsc.exe test/debug_tmp.cmi 
external f: int => int = "xx" "����
��A@�"xx@@@"
jscomp$../darwin/bsc.exe test/debug_tmp.cmi 
external f: int => int = "xx" "#rescript-external"
```
Those characters are scaring