### PR TITLE
Regenerate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,11 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/reanalyze/-/reanalyze-2.15.0.tgz",
       "integrity": "sha512-FUN/pqgTKs5i+kzi9Mje5deahZHKniOQDyig5UseozDiK81eW77A4iRyN+3UsnontG6K6mAdUcXCU9NpEqZFug==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "reanalyze": "reanalyze.exe"
+      }
     }
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #388

Somehow a stale package-lock.json was incrementally generated during a6841172ea5daa719114a97917c1cd6563616533, without the needed `hasInstallScript` field.

CI still worked because CI was on an older npm which required regenerating the lockfile fresh.

Lessons:
- Be fast enough to generate something fresh please.
- Go was right. No lockfiles.
