### PR TITLE
No need to cache npm installs anymore + use npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,6 @@ jobs:
         path: ~/.opam
         key: macos-latest-ocaml-4.06.1
 
-    - name: Cache npm
-      uses: actions/cache@v2.1.5
-      with:
-        path: ~/.npm
-        key: macos-latest-node-14.4.0-${{hashFiles('package-lock.json')}}
-
     - name: Use OCaml
       uses: avsm/setup-ocaml@v1.1.10
       with:
@@ -35,6 +29,6 @@ jobs:
       with:
         node-version: 14.4.0
 
-    - run: npm install
+    - run: npm ci
 
     - run: eval $(opam env) && make roundtrip-test


### PR DESCRIPTION
We have a single dependency that's faster to install than to cache lol
Also, use npm ci, which is a subset of npm install that only reads into
the lockfile and doesn't do any user-facing adjustments.
