### PR TITLE
Fix regression in template literal string scanning.

### DIFF
--- a/src/res_scanner.ml
+++ b/src/res_scanner.ml
@@ -472,7 +472,7 @@ let scanTemplateLiteralToken scanner =
         in
         Token.TemplatePart contents
       | _ ->
-        next2 scanner;
+        next scanner;
         scan())
     | '\\' ->
       (match peek scanner with

--- a/tests/parsing/grammar/expressions/es6template.res
+++ b/tests/parsing/grammar/expressions/es6template.res
@@ -45,3 +45,10 @@ let s = json`null`
 
 let x = `foo\`bar\$\\foo`
 let x = `foo\`bar\$\\foo${a} \` ${b} \` xx`
+
+let thisIsFine = `$something`
+let thisIsAlsoFine = `fine\$`
+let isThisFine = `shouldBeFine$`
+
+`$${dollarAmountInt}`
+`\$${dollarAmountInt}`

--- a/tests/parsing/grammar/expressions/expected/es6template.res.txt
+++ b/tests/parsing/grammar/expressions/expected/es6template.res.txt
@@ -37,3 +37,8 @@ let s = {js|$dollar without $braces $interpolation|js}
 let s = {json|null|json}
 let x = {js|foo`bar$\foo|js}
 let x = ((({js|foo`bar$\foo|js} ^ a) ^ {js| ` |js}) ^ b) ^ {js| ` xx|js}
+let thisIsFine = {js|$something|js}
+let thisIsAlsoFine = {js|fine$|js}
+let isThisFine = {js|shouldBeFine$|js}
+;;{js|$|js} ^ dollarAmountInt
+;;{js|$|js} ^ dollarAmountInt


### PR DESCRIPTION
The scanner underwent extensive refactoring, it appears that something fishy was introduced in d20c137d
Upon encountering a `$` character, the routine that scans template literal tokens, shouldn't consume two characters.

Example:
```rescript
`$${dollarAmountInt}`
```
Seeing a `$` doens't imply that the next character (here also a `$`) should be consumed.