### PR TITLE
Implement printing of `Otyp_module` in outcome printer.

### DIFF
--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -343,8 +343,34 @@ let printPolyVarIdent txt =
        )
      | Otyp_arrow _ as typ ->
        printOutArrowType ~uncurried:false typ
-     | Otyp_module (_modName, _stringList, _outTypes) ->
-         Doc.nil
+     | Otyp_module (modName, stringList, outTypes) ->
+      let packageTypeDoc = match (stringList, outTypes) with
+      | [], [] -> Doc.nil
+      | labels, types ->
+        let i = ref 0 in
+        let package = Doc.join ~sep:Doc.line (List.map2 (fun lbl typ ->
+          Doc.concat [
+            Doc.text (if i.contents > 0 then "and " else "with ");
+            Doc.text lbl;
+            Doc.text " = ";
+            printOutTypeDoc typ;
+          ]
+        ) labels types)
+        in
+        Doc.indent (
+          Doc.concat [
+            Doc.line;
+            package
+          ]
+        )
+      in
+       Doc.concat [
+         Doc.text "module";
+         Doc.lparen;
+         Doc.text modName;
+         packageTypeDoc;
+         Doc.rparen;
+       ]
 
    and printOutArrowType ~uncurried typ =
      let (typArgs, typ) = collectArrowArgs typ [] in
@@ -598,8 +624,8 @@ let printPolyVarIdent txt =
                  Doc.text " =";
                  Doc.line;
                  Doc.group (
-                   Doc.join ~sep:Doc.line (List.map (fun prim -> 
-                       let prim = if prim <> "" && (prim.[0] [@doesNotRaise]) = '\132' then "#rescript-external" else prim in 
+                   Doc.join ~sep:Doc.line (List.map (fun prim ->
+                       let prim = if prim <> "" && (prim.[0] [@doesNotRaise]) = '\132' then "#rescript-external" else prim in
                        (* not display those garbage '\132' is a magic number for marshal *)
                        Doc.text ("\"" ^ prim ^ "\"")) primitives)
                  )

--- a/tests/oprint/expected/oprint.res.txt
+++ b/tests/oprint/expected/oprint.res.txt
@@ -441,3 +441,10 @@ type dotdotObjectCoordinate<'a> = 'a
 type permissions = [#644 | #777]
 type numericPolyVarWithPayload = [#1(string) | #2(int, string)]
 let numericPolyVarMatch: [> #1(string) | #2(int, string)]
+let sort: (module(Set.S with elt = 'a), list<'a>) => list<'a>
+let make_set: (('a, 'a) => int) => module(Set.S with elt = 'a)
+type picture = string
+module type DEVICE = {
+  let draw: picture => unit
+}
+let devices: Hashtbl.t<string, module(DEVICE)>

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -294,3 +294,22 @@ type permissions = [
    | #777 => #1("payload")
    | #644 => #2(42, "test")
  }
+
+let sort = (type s, module(Set: Set.S with type elt = s), l) =>
+  Set.elements(List.fold_right(Set.add, l, Set.empty))
+
+let make_set = (type s, cmp) => {
+  module S = Set.Make({
+    type t = s
+    let compare = cmp
+  })
+  module(S: Set.S with type elt = s)
+}
+
+type picture = string
+
+module type DEVICE = {
+  let draw: picture => unit
+}
+
+let devices: Hashtbl.t<string, module(DEVICE)> = Hashtbl.create(17)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/398