### PR TITLE
Don't parse Int token with suffices as hash ident for poly variants

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -124,6 +124,9 @@ Solution: directly use `concat`."
 
   let sameTypeSpread =
     "You're using a ... spread without extra fields. This is the same type."
+
+  let polyVarIntWithSuffix number =
+    "A numeric polymorphic variant cannot be followed by a letter. Did you mean `#" ^ number ^ "`?"
 end
 
 
@@ -696,7 +699,12 @@ let parseHashIdent ~startPos p =
     Parser.next p;
     let text = if p.mode = ParseForTypeChecker then parseStringLiteral text else text in
     (text, mkLoc startPos p.prevEndPos)
-  | Int {i; suffix = None} ->
+  | Int {i; suffix} ->
+    let () = match suffix with
+    | Some _ ->
+      Parser.err p (Diagnostics.message (ErrorMessages.polyVarIntWithSuffix i))
+    | None -> ()
+    in
     Parser.next p;
     (i, mkLoc startPos p.prevEndPos)
   | _ ->
@@ -1202,7 +1210,12 @@ let rec parsePattern ?(alias=true) ?(or_=true) p =
         Parser.next p;
         let text = if p.mode = ParseForTypeChecker then parseStringLiteral text else text in
         (text, mkLoc startPos p.prevEndPos)
-      | Int {i; suffix = None} ->
+      | Int {i; suffix} ->
+        let () = match suffix with
+        | Some _ ->
+          Parser.err p (Diagnostics.message (ErrorMessages.polyVarIntWithSuffix i))
+        | None -> ()
+        in
         Parser.next p;
         (i, mkLoc startPos p.prevEndPos)
       | _ ->

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -77,7 +77,7 @@ Explanation: since records have a known, fixed shape, a spread like `{a, ...b}` 
 Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list[a, ...bc]` efficiently creates a new item and links `bc` as its next nodes. `[...bc, a]` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.\n\
 Solution: directly use `concat`."
 
-  let variantIdent = "A polymorphic variant (e.g. #id) must start with an alphabetical letter."
+  let variantIdent = "A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)"
 
   let experimentalIfLet expr =
     let switchExpr = {expr with Parsetree.pexp_attributes = []} in
@@ -696,7 +696,7 @@ let parseHashIdent ~startPos p =
     Parser.next p;
     let text = if p.mode = ParseForTypeChecker then parseStringLiteral text else text in
     (text, mkLoc startPos p.prevEndPos)
-  | Int {i} ->
+  | Int {i; suffix = None} ->
     Parser.next p;
     (i, mkLoc startPos p.prevEndPos)
   | _ ->
@@ -1202,7 +1202,7 @@ let rec parsePattern ?(alias=true) ?(or_=true) p =
         Parser.next p;
         let text = if p.mode = ParseForTypeChecker then parseStringLiteral text else text in
         (text, mkLoc startPos p.prevEndPos)
-      | Int {i} ->
+      | Int {i; suffix = None} ->
         Parser.next p;
         (i, mkLoc startPos p.prevEndPos)
       | _ ->

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -77,7 +77,7 @@ Explanation: since records have a known, fixed shape, a spread like `{a, ...b}` 
 Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list[a, ...bc]` efficiently creates a new item and links `bc` as its next nodes. `[...bc, a]` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.\n\
 Solution: directly use `concat`."
 
-  let variantIdent = "A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)"
+  let variantIdent = "A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)"
 
   let experimentalIfLet expr =
     let switchExpr = {expr with Parsetree.pexp_attributes = []} in

--- a/tests/parsing/errors/other/expected/hashIdent.res.txt
+++ b/tests/parsing/errors/other/expected/hashIdent.res.txt
@@ -1,0 +1,37 @@
+
+  Syntax error!
+  tests/parsing/errors/other/hashIdent.res:1:9-12
+
+  1 │ let x = #10s
+  2 │ 
+  3 │ type t = [ #red | #10s ] 
+
+  A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)
+
+
+  Syntax error!
+  tests/parsing/errors/other/hashIdent.res:3:19-22
+
+  1 │ let x = #10s
+  2 │ 
+  3 │ type t = [ #red | #10s ] 
+  4 │ 
+  5 │ switch x {
+
+  A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)
+
+
+  Syntax error!
+  tests/parsing/errors/other/hashIdent.res:6:3-6
+
+  4 │ 
+  5 │ switch x {
+  6 │ | #10s => ()
+  7 │ }
+  8 │ 
+
+  A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)
+
+let x = `
+type nonrec t = [ `red  | ` ]
+;;match x with | ` -> ()

--- a/tests/parsing/errors/other/expected/hashIdent.res.txt
+++ b/tests/parsing/errors/other/expected/hashIdent.res.txt
@@ -1,16 +1,16 @@
 
   Syntax error!
-  tests/parsing/errors/other/hashIdent.res:1:9-12
+  tests/parsing/errors/other/hashIdent.res:1:10-12
 
   1 │ let x = #10s
   2 │ 
   3 │ type t = [ #red | #10s ] 
 
-  A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)
+  A numeric polymorphic variant cannot be followed by a letter. Did you mean `#10`?
 
 
   Syntax error!
-  tests/parsing/errors/other/hashIdent.res:3:19-22
+  tests/parsing/errors/other/hashIdent.res:3:20-22
 
   1 │ let x = #10s
   2 │ 
@@ -18,11 +18,11 @@
   4 │ 
   5 │ switch x {
 
-  A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)
+  A numeric polymorphic variant cannot be followed by a letter. Did you mean `#10`?
 
 
   Syntax error!
-  tests/parsing/errors/other/hashIdent.res:6:3-6
+  tests/parsing/errors/other/hashIdent.res:6:4-6
 
   4 │ 
   5 │ switch x {
@@ -30,8 +30,8 @@
   7 │ }
   8 │ 
 
-  A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)
+  A numeric polymorphic variant cannot be followed by a letter. Did you mean `#10`?
 
-let x = `
-type nonrec t = [ `red  | ` ]
-;;match x with | ` -> ()
+let x = `10
+type nonrec t = [ `red  | `10 ]
+;;match x with | `10 -> ()

--- a/tests/parsing/errors/other/expected/hashIdent.res.txt
+++ b/tests/parsing/errors/other/expected/hashIdent.res.txt
@@ -6,7 +6,7 @@
   2 │ 
   3 │ type t = [ #red | #10s ] 
 
-  A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)
+  A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)
 
 
   Syntax error!
@@ -18,7 +18,7 @@
   4 │ 
   5 │ switch x {
 
-  A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)
+  A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)
 
 
   Syntax error!
@@ -30,7 +30,7 @@
   7 │ }
   8 │ 
 
-  A polymorphic variant (e.g. #id) must start with an alphabetical letter or is a number (e.g. #742)
+  A polymorphic variant (e.g. #id) must start with an alphabetical letter or be a number (e.g. #742)
 
 let x = `
 type nonrec t = [ `red  | ` ]

--- a/tests/parsing/errors/other/hashIdent.res
+++ b/tests/parsing/errors/other/hashIdent.res
@@ -1,0 +1,7 @@
+let x = #10s
+
+type t = [ #red | #10s ] 
+
+switch x {
+| #10s => ()
+}

--- a/tests/printer/typexpr/expected/variant.res.txt
+++ b/tests/printer/typexpr/expected/variant.res.txt
@@ -112,3 +112,6 @@ type t = [
   | #1(string)
   | #2(int, string)
 ]
+
+// don't pick int with suffix as numeric polyvar
+type t = [#"10s" | #"20t"]

--- a/tests/printer/typexpr/variant.res
+++ b/tests/printer/typexpr/variant.res
@@ -106,3 +106,6 @@ type t = [
   | #1(string)
   | #2(int, string)
 ]
+
+// don't pick int with suffix as numeric polyvar
+type t = [#"10s" | #"20t" ]


### PR DESCRIPTION
`#10s` should not be accepted as a numeric polyvariant identifier.

Fixes https://github.com/rescript-lang/syntax/issues/407