### PR TITLE
Fix parsing of arrow type with objects in constructor declaration args

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -4396,7 +4396,11 @@ and parseConstrDeclArgs p =
             ) in
             Parser.expect Rbrace p;
             let loc = mkLoc startPos p.prevEndPos in
-            let typ = Ast_helper.Typ.object_ ~loc ~attrs:[] fields closedFlag in
+            let typ =
+              Ast_helper.Typ.object_ ~loc ~attrs:[] fields closedFlag
+              |> parseTypeAlias p
+            in
+            let typ = parseArrowTypeRest ~es6Arrow:true ~startPos typ p in
             Parser.optional p Comma |> ignore;
             let moreArgs =
               parseCommaDelimitedRegion

--- a/tests/parsing/grammar/typedefinition/constructorDeclaration.res
+++ b/tests/parsing/grammar/typedefinition/constructorDeclaration.res
@@ -86,3 +86,8 @@ type node <_, 'value> =
       updateF: 'value => 'value,
       mutable updatedTime: float,
     }): node<derived, 'value>
+
+type delta = Compute({"blocked_ids": unit} => unit)
+type queryDelta =
+  | Compute({"blocked_ids": unit} => unit)
+  | Compute({"blocked_ids": unit} => unit, {"allowed_ids": unit} => unit)

--- a/tests/parsing/grammar/typedefinition/expected/constructorDeclaration.res.txt
+++ b/tests/parsing/grammar/typedefinition/expected/constructorDeclaration.res.txt
@@ -85,3 +85,9 @@ type nonrec (_, 'value) node =
   root: (root, 'value) node ;
   updateF: 'value -> 'value ;
   mutable updatedTime: float } -> (derived, 'value) node 
+type nonrec delta =
+  | Compute of (< blocked_ids: unit   >  -> unit) 
+type nonrec queryDelta =
+  | Compute of (< blocked_ids: unit   >  -> unit) 
+  | Compute of (< blocked_ids: unit   >  -> unit) *
+  (< allowed_ids: unit   >  -> unit) 


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/409

The parser should parse `type queryDelta = Compute({"blocked_ids": unit} => unit)` without parens surrounding the object type-expr `{"blocked_ids": unit}`. The parens are optional in this case. In other places like `{"blocked_ids": unit} => unit`, this was already the case.