### PR TITLE
Remove `{path as p}` record pattern sugar for `{path: p}`

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1380,15 +1380,7 @@ and parseRecordPatternField p =
       ~loc:label.loc
       (Location.mkloc (Longident.last label.txt) label.loc)
   in
-  match p.token with
-  | As -> (* {bar as baz} -> {bar: baz} *)
-    Parser.next p;
-    let (name, loc) = parseLident p in
-    let var = Location.mkloc name loc in
-    let newNameOfLabel = Ast_helper.Pat.var ~loc var in
-    (label, newNameOfLabel)
-  | _ ->
-    (label, pattern)
+  (label, pattern)
 
  (* TODO: there are better representations than PatField|Underscore ? *)
 and parseRecordPatternItem p =

--- a/tests/parsing/grammar/pattern/record.res
+++ b/tests/parsing/grammar/pattern/record.res
@@ -2,16 +2,16 @@ let {a} = x
 let {a} as p = x
 let {a,} = x // trailing comma
 let {a, b} = x
-let {a as p1, b as p2} = x
+let {a: p1, b: p2} = x
 let {a, b,} = x // trailing comma
 let {ReasonReact.state} = x
 let {ReasonReact.state: state as prevState} = x
-let {ReasonReact.state as theState} = x 
+let {ReasonReact.state: theState} = x 
 let {a: u} = x
 let {a: (u: int)} = x
 let {a: (u as p: int)} = x
 let {a: {x, y}} = x
-let {a: {x as p1, y as p2}} = x
+let {a: {x: p1, y: p2}} = x
 let {a, _ } = x
 let {a, _, } = x
 let ({a} : myRecord) = x
@@ -24,12 +24,12 @@ switch x {
 | {a, b,} => () // trailing comma
 | {ReasonReact.state} => ()
 | {ReasonReact.state: state as prevState} => ()
-| {ReasonReact.state as theState} => ()
+| {ReasonReact.state: theState} => ()
 | {a: u} => ()
 | {a: (u: int)} => ()
 | {a: (u as p: int) as p2} as p3 => ()
 | {a: {x, y}} => ()
-| {a: {x as p1, y as p2} as p3} => ()
+| {a: {x: p1, y: p2} as p3} => ()
 | {a, _ } => ()
 | {a, _, } => ()
 | ({a} : myRecord) => () 
@@ -42,12 +42,12 @@ let f = ({a, b}) => ()
 let f = ({a, b,}) => () // trailing comma
 let f = ({ReasonReact.state}) => () 
 let f = ({ReasonReact.state: state as prevState}) => () 
-let f = ({ReasonReact.state as theState}) => () 
+let f = ({ReasonReact.state: theState}) => () 
 let f = ({a: u}) => ()
 let f = ({a: (u: int)}) => ()
 let f = ({a: (u as x: int) as r}) => ()
 let f = ({a: {x, y}}) => () 
-let f = ({a: {x as r, y as r2}}) => () 
+let f = ({a: {x: r, y: r2}}) => () 
 let f = ({a, _ }) => () 
 let f = ({a, _,}) => () 
 let f = ({a}: myRecord) => () 
@@ -69,9 +69,9 @@ for (({ReasonReact.state}) in 0 to 10) { () }
 for {ReasonReact.state: state as prevState} in 0 to 10 { () }
 for ({ReasonReact.state: state as prevState} in 0 to 10) { () }
 for (({ReasonReact.state: state as prevState}) in 0 to 10) { () }
-for {ReasonReact.state as theState} in 0 to 10 { () }
-for ({ReasonReact.state as theState} in 0 to 10) { () }
-for (({ReasonReact.state as theState}) in 0 to 10) { () }
+for {ReasonReact.state: theState} in 0 to 10 { () }
+for ({ReasonReact.state: theState} in 0 to 10) { () }
+for (({ReasonReact.state: theState}) in 0 to 10) { () }
 for {a: u} in 0 to 10 { () }
 for (({a: u}) in 0 to 10) { () }
 for ({a: u} in 0 to 10) { () }
@@ -80,7 +80,7 @@ for {a: (u as sp: int) as p} in 0 to 10 { () }
 for (({a: (u: int)}) in 0 to 10) { () }
 for ({a: (u: int)} in 0 to 10) { () }
 for {a: {x, y}} in 0 to 10 { () }
-for {a: {x as p1, y as p2} as p3} in 0 to 10 { () }
+for {a: {x: p1, y: p2} as p3} in 0 to 10 { () }
 for (({a: {x, y}}) in 0 to 10) { () }
 for (({a: {x, y}} as p) as p2 in 0 to 10) { () }
 for ({a: {x, y}} in 0 to 10) { () }

--- a/tests/printer/expr/fun.res
+++ b/tests/printer/expr/fun.res
@@ -205,7 +205,7 @@ let add = ([a, b]): array<intWithSuperLongName, stringWithSuperLongName, intWith
 let add = ([superLongParameterName, bsuperLongParameterName, superLongParameterName, superLongParameterName]): array<intWithSuperLongName, stringWithSuperLongName, intWithSuperLongName, intWithSuperLongName>  => a + b
 
 let add = ({x: superLongParameterName, y: superLongParameterName, z: superLongParameterName}) => x + y + z
-let add = ({x as superLongParameterName, y as superLongParameterName, z as superLongParameterName}) => x + y + z
+let add = ({x: superLongParameterName, y: superLongParameterName, z: superLongParameterName}) => x + y + z
 let add = ({x: x as superLongParameterName, y: y as superLongParameterName, z: z as superLongParameterName}) => x + y + z
 
 

--- a/tests/printer/pattern/record.res
+++ b/tests/printer/pattern/record.res
@@ -9,7 +9,7 @@ let {x: xCoord, y: yCoord, _} = 1
 let {xxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzzzzzzzzz } = 1
 let {xxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzzzzzzzzz, _ } = 1
 
-let {x as y} = z
+let {x: y} = z
 let {x: x as y} = z
 
 let get_age3 = ({age: (age2: int), name: _}) => age2


### PR DESCRIPTION
`{path as p}` formats to `{path: p`}, which is the right syntax. The as syntax is unnecessarily confusing sugar.