### PR TITLE
Handle windows CRLF correct.

### DIFF
--- a/.depend
+++ b/.depend
@@ -72,4 +72,4 @@ src/res_scanner.cmi : src/res_token.cmx src/res_diagnostics.cmi
 src/res_token.cmx : src/res_comment.cmx
 tests/res_test.cmx : src/res_token.cmx src/res_parser.cmx \
     src/res_outcome_printer.cmx src/res_multi_printer.cmx src/res_io.cmx \
-    src/res_driver.cmx
+    src/res_driver.cmx src/res_core.cmx

--- a/src/res_scanner.ml
+++ b/src/res_scanner.ml
@@ -96,26 +96,15 @@ let _printDebug ~startPos ~endPos scanner token =
 [@@live]
 
 let next scanner =
-  let nextOffset =
-    let nextPos = scanner.offset + 1 in
-    match scanner.ch with
-    | '\n' ->
-      scanner.lineOffset <- nextPos;
-      scanner.lnum <- scanner.lnum + 1;
-      nextPos
-    | '\r' ->
-      scanner.lineOffset <- nextPos;
-      scanner.lnum <- scanner.lnum + 1;
-      (* windows users might use CRLF as line break. \r followed by \n should be considered one line break, not two *)
-      if nextPos < String.length scanner.src then (
-        match String.unsafe_get scanner.src nextPos with
-        | '\n' -> nextPos + 1
-        | _ -> nextPos
-      ) else (
-        nextPos
-      )
-    | _ -> nextPos
-  in
+  let nextOffset = scanner.offset + 1 in
+  (match scanner.ch with
+  | '\n' ->
+    scanner.lineOffset <- nextOffset;
+    scanner.lnum <- scanner.lnum + 1;
+    (* What about CRLF (\r + \n) on windows?
+     * \r\n will always be terminated by a \n
+     * -> we can just bump the line count on \n *)
+  | _ -> ());
   if nextOffset < String.length scanner.src then (
     scanner.offset <- nextOffset;
     scanner.ch <- String.unsafe_get scanner.src scanner.offset;

--- a/tests/res_test.ml
+++ b/tests/res_test.ml
@@ -147,8 +147,32 @@ module ParserApiTest = struct
     assert (parser.token = Res_token.Let);
     print_endline "✅ Parser make: initializes parser and checking offsets"
 
+  let unixLf () =
+    let src = "let x = 1\nlet y = 2\nlet z = 3" in
+    let parser = Res_parser.make src "test.res" in
+    (match Res_core.parseImplementation parser with
+    | [x; y; z] ->
+      assert (x.pstr_loc.loc_start.pos_lnum = 1);
+      assert (y.pstr_loc.loc_start.pos_lnum = 2);
+      assert (z.pstr_loc.loc_start.pos_lnum = 3)
+    | _ -> assert false);
+    print_endline "✅ Parser handles LF correct"
+
+  let windowsCrlf () =
+    let src = "let x = 1\r\nlet y = 2\r\nlet z = 3" in
+    let parser = Res_parser.make src "test.res" in
+    (match Res_core.parseImplementation parser with
+    | [x; y; z] ->
+      assert (x.pstr_loc.loc_start.pos_lnum = 1);
+      assert (y.pstr_loc.loc_start.pos_lnum = 2);
+      assert (z.pstr_loc.loc_start.pos_lnum = 3)
+    | _ -> assert false);
+    print_endline "✅ Parser handles CRLF correct"
+
   let run () =
     makeDefault();
+    unixLf();
+    windowsCrlf()
 
 end
 


### PR DESCRIPTION
`\r\n` should be picked up as one line break, not two.