### PR TITLE
resdoc: add support for .ml and .res files

### DIFF
--- a/.depend
+++ b/.depend
@@ -72,8 +72,8 @@ src/res_scanner.cmx : src/res_token.cmx src/res_diagnostics.cmx \
     src/res_comment.cmx src/res_character_codes.cmx src/res_scanner.cmi
 src/res_scanner.cmi : src/res_token.cmx src/res_diagnostics.cmi
 src/res_token.cmx : src/res_comment.cmx src/res_character_codes.cmx
-src/resdoc_cli.cmx : src/res_printer.cmx src/res_doc.cmx \
-    src/res_comments_table.cmx
+src/resdoc_cli.cmx : src/res_printer.cmx src/res_driver_ml_parser.cmx \
+    src/res_driver.cmx src/res_doc.cmx src/res_comments_table.cmx
 tests/napkin_test.cmx : src/res_token.cmx src/res_parser.cmx \
     src/res_outcome_printer.cmx src/res_multi_printer.cmx src/res_io.cmx \
     src/res_driver.cmx tests/res_diff.cmx

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -369,13 +369,9 @@ let extractDocItem_type_declarations (tdecls: Parsetree.type_declaration list) s
     | item :: _ -> Some item
     | _ -> None)
 
-let rec extractSignatureDocItem (signatureItem: Parsetree.signature_item) : DocItem.t option =
-  match signatureItem.psig_desc with
-  | Psig_value value_description -> extractDocItem_value_description value_description (Signature.fromSignatureItem signatureItem)
-  | Psig_type (_, tdecls) -> extractDocItem_type_declarations tdecls (Signature.fromSignatureItem signatureItem)
-  | Psig_typext _ -> None (* TODO verify *)
-  | Psig_exception _ -> None (* TODO verify *)
-  | Psig_module { pmd_attributes; pmd_name; pmd_type } ->
+let rec extractDocItem_module_declaration (module_declaration: Parsetree.module_declaration) signature = 
+  match module_declaration with
+  | { pmd_attributes; pmd_name; pmd_type } ->
     (match pmd_type.pmty_desc with
      | Pmty_signature signature ->
        let items = Util.filter_map extractSignatureDocItem signature in
@@ -387,7 +383,6 @@ let rec extractSignatureDocItem (signatureItem: Parsetree.signature_item) : DocI
        Some (DocItem.Doc_module {name=pmd_name.txt; items; docstring; })
      | Pmty_alias {txt = Ldot _} ->
        (*print_endline str;*)
-       let signature = Signature.fromSignatureItem signatureItem in 
        let docstring =
          match extractDocstring pmd_attributes with
          | Some docstring -> docstring
@@ -396,6 +391,13 @@ let rec extractSignatureDocItem (signatureItem: Parsetree.signature_item) : DocI
        Some (DocItem.Doc_module_alias {name=pmd_name.txt; docstring; signature})
      | _ -> None
     )
+and extractSignatureDocItem (signatureItem: Parsetree.signature_item) : DocItem.t option =
+  match signatureItem.psig_desc with
+  | Psig_value value_description -> extractDocItem_value_description value_description (Signature.fromSignatureItem signatureItem)
+  | Psig_type (_, tdecls) -> extractDocItem_type_declarations tdecls (Signature.fromSignatureItem signatureItem)
+  | Psig_typext _ -> None (* TODO verify *)
+  | Psig_exception _ -> None (* TODO verify *)
+  | Psig_module module_declaration -> extractDocItem_module_declaration module_declaration (Signature.fromSignatureItem signatureItem)
   | Psig_recmodule _ -> None (* TODO verify *)
   | Psig_modtype _ -> None (* TODO verify *)
   | Psig_open _ -> None (* TODO verify *)
@@ -411,12 +413,12 @@ let (* rec *) extractStructureDocItem (structureItem: Parsetree.structure_item) 
 (*| Pstr_value of Asttypes.rec_flag * Parsetree.value_binding list *)
   | Pstr_primitive value_description -> extractDocItem_value_description value_description (Signature.fromStructureItem structureItem)
   | Pstr_type (_, tdecls) -> extractDocItem_type_declarations tdecls (Signature.fromStructureItem structureItem)
-(*| Pstr_typext of Parsetree.type_extension *)
-(*| Pstr_exception of Parsetree.extension_constructor *)
+  | Pstr_typext _ -> None (* TODO verify *)
+  | Pstr_exception _ -> None (* TODO verify *)
 (*| Pstr_module of Parsetree.module_binding *)
-(*| Pstr_recmodule of Parsetree.module_binding list *)
-(*| Pstr_modtype of Parsetree.module_type_declaration *)
-(*| Pstr_open of Parsetree.open_description *)
+  | Pstr_recmodule _ -> None (* TODO verify *)
+  | Pstr_modtype _ -> None (* TODO verify *)
+  | Pstr_open _ -> None (* TODO verify *)
 (*| Pstr_class of Parsetree.class_declaration list *)
 (*| Pstr_class_type of Parsetree.class_type_declaration list *)
 (*| Pstr_include of Parsetree.include_declaration *)

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -320,6 +320,27 @@ module ExtractDocStrings = struct
         default_iterator.value_description iterator value_description;
       end;
 
+      value_binding = begin fun iterator value_binding ->
+        begin match value_binding with
+        | {pvb_attributes; pvb_pat; _ } ->
+          let signature = List.hd !signature_stack in
+          let docstring = match from_attributes pvb_attributes with
+            | Some docstring -> docstring
+            | None -> ""
+          in
+          begin match pvb_pat.ppat_desc with
+          | Ppat_constraint({ ppat_desc = Ppat_var(name); _ }, _) ->
+            DocItem.Doc_value({
+              signature;
+              name = name.txt;
+              docstring;
+            }) |> generate
+          | _ -> ()
+          end;
+        end;
+        default_iterator.value_binding iterator value_binding;
+      end;
+
       type_declaration = begin fun iterator type_declaration ->
         let signature = List.hd !signature_stack in
         let docstring = match from_attributes type_declaration.ptype_attributes with

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -431,7 +431,7 @@ let extract_file filename =
   json |> Json.stringifyPretty ~indent:0 |> print_endline
 
 let usage cmd = begin
-  Printf.eprintf "Usage: %s -file <input.(ml|mli|resi)>\n" cmd;
+  Printf.eprintf "Usage: %s -file <input.(res|resi|ml|mli)>\n" cmd;
   exit 1
 end
 

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -371,9 +371,10 @@ let extractDocItem_type_declarations (tdecls: Parsetree.type_declaration list) s
 
 let rec extractSignatureDocItem (signatureItem: Parsetree.signature_item) : DocItem.t option =
   match signatureItem.psig_desc with
-  | Psig_attribute attribute -> extractDocItem_attribute attribute
   | Psig_value value_description -> extractDocItem_value_description value_description (Signature.fromSignatureItem signatureItem)
   | Psig_type (_, tdecls) -> extractDocItem_type_declarations tdecls (Signature.fromSignatureItem signatureItem)
+  | Psig_typext _ -> None (* TODO verify *)
+  | Psig_exception _ -> None (* TODO verify *)
   | Psig_module { pmd_attributes; pmd_name; pmd_type } ->
     (match pmd_type.pmty_desc with
      | Pmty_signature signature ->
@@ -395,7 +396,14 @@ let rec extractSignatureDocItem (signatureItem: Parsetree.signature_item) : DocI
        Some (DocItem.Doc_module_alias {name=pmd_name.txt; docstring; signature})
      | _ -> None
     )
-  | _ -> None
+  | Psig_recmodule _ -> None (* TODO verify *)
+  | Psig_modtype _ -> None (* TODO verify *)
+  | Psig_open _ -> None (* TODO verify *)
+  | Psig_include _ -> None (* TODO verify *)
+  | Psig_class _ -> None (* TODO verify *)
+  | Psig_class_type _ -> None (* TODO verify *)
+  | Psig_attribute attribute -> extractDocItem_attribute attribute
+  | Psig_extension _ -> None (* TODO verify *)
 
 let (* rec *) extractStructureDocItem (structureItem: Parsetree.structure_item) : DocItem.t option =
   match structureItem.pstr_desc with

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -418,10 +418,18 @@ let extract_file filename =
   let parseResult = backend.parseInterface ~forPrinter:false ~filename in
   extract_signature_docs ~filename parseResult.parsetree
 
-let () =   
-  for i = 0 to Array.length Sys.argv - 1 do 
-    if Sys.argv.(i) = "-file" && i + 1 < Array.length Sys.argv then begin 
-      extract_file Sys.argv.(i+1);
+let usage cmd = begin
+  Printf.eprintf "Usage: %s -file <input.(ml|mli|resi)>\n" cmd;
+  exit 1
+end
+
+let () = match Sys.argv with
+  | [| _; "-file"; input_file |] -> begin
+    try
+      extract_file input_file;
       exit 0
+    with Syntaxerr.Error err ->
+      fprintf Format.err_formatter "@[%a@]@." Syntaxerr.report_error err;
+      exit 1
     end
-  done     
+  | _ -> usage Sys.argv.(0)

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -251,6 +251,7 @@ module Signature = struct
   let from_signature_item item =
     Res_printer.printSignatureItem (DropDocAttributes.signature_item item) cmtTable |> Res_doc.toString ~width:80
 
+  (* TODO: this prints the entire structure; it should extract the signature *)
   let from_structure_item item =
     Res_printer.printStructure [DropDocAttributes.structure_item item] cmtTable |> Res_doc.toString ~width:80
 end
@@ -327,12 +328,13 @@ module ExtractDocStrings = struct
         in
         begin match type_declaration.ptype_kind with
         | Ptype_variant cdecls ->
-          let constructorDocs = Util.filter_map (fun { Parsetree.pcd_attributes; pcd_name } ->
-              (match from_attributes pcd_attributes with
-                | Some docstring ->
-                  Some (pcd_name.txt, docstring)
-                | None -> None)
-            ) cdecls
+          let constructorDocs = Util.filter_map 
+            begin fun { Parsetree.pcd_attributes; pcd_name } ->
+              match from_attributes pcd_attributes with
+              | Some docstring -> Some (pcd_name.txt, docstring)
+              | None -> None
+            end
+            cdecls
           in
           DocItem.Doc_variant {signature; constructorDocs; docstring} |> generate
         | Ptype_record labelDecls ->

--- a/src/resdoc_cli.ml
+++ b/src/resdoc_cli.ml
@@ -329,6 +329,13 @@ module ExtractDocStrings = struct
             | None -> ""
           in
           begin match pvb_pat.ppat_desc with
+          | Ppat_var(name) ->
+            (* Example: let add = (a, b) => a + b *)
+            DocItem.Doc_value({
+              signature;
+              name = name.txt;
+              docstring;
+            }) |> generate
           | Ppat_constraint({ ppat_desc = Ppat_var(name); _ }, _) ->
             DocItem.Doc_value({
               signature;


### PR DESCRIPTION
Building on the [experimental-docgen](https://github.com/rescript-lang/syntax/tree/experimental-docgen) branch.

Fixes rescript-association/rescript-lang.org#359