### PR TITLE
Fix printing of optional labeled args in outcome arrow types.

### DIFF
--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -348,7 +348,7 @@ let printPolyVarIdent txt =
       | [], [] -> Doc.nil
       | labels, types ->
         let i = ref 0 in
-        let package = Doc.join ~sep:Doc.line (List.map2 (fun lbl typ ->
+        let package = Doc.join ~sep:Doc.line ((List.map2 [@doesNotRaise]) (fun lbl typ ->
           Doc.concat [
             Doc.text (if i.contents > 0 then "and " else "with ");
             Doc.text lbl;
@@ -376,13 +376,21 @@ let printPolyVarIdent txt =
      let (typArgs, typ) = collectArrowArgs typ [] in
      let args = Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (
        List.map (fun (lbl, typ) ->
-         if lbl = "" then
+         let lblLen = String.length lbl in
+         if lblLen = 0 then
            printOutTypeDoc typ
          else
+           let (lbl, optionalIndicator) =
+             (* the ocaml compiler hardcodes the optional label inside the string of the label in printtyp.ml *)
+             match String.unsafe_get lbl 0 with
+             | '?' -> ((String.sub [@doesNotRaise]) lbl 1 (lblLen - 1) , Doc.text "=?")
+             | _ -> (lbl, Doc.nil)
+           in
            Doc.group (
              Doc.concat [
                Doc.text ("~" ^ lbl ^ ": ");
-               printOutTypeDoc typ
+               printOutTypeDoc typ;
+               optionalIndicator
              ]
            )
        ) typArgs

--- a/tests/oprint/expected/oprint.resi.txt
+++ b/tests/oprint/expected/oprint.resi.txt
@@ -492,3 +492,4 @@ and ASet: {
   let of_list: list<elt> => t
 }
 type emptyObject = {.}
+let f: (~x: 'a=?, ~y: 'b) => option<'a>

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -334,3 +334,5 @@ module rec A: {
 and ASet: Set.S with type elt = A.t = Set.Make(A)
 
 type emptyObject = {.}
+
+let f = (~x=?, ~y as _) => x


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/445

**before**
```
(~?x: 'a, ~y: 'b) => option<'a>
```

**after**
```
(~?x: 'a, ~y: 'b) => option<'a>
```