### PR TITLE
Fix redundant space in outcome printing of constructors.

### DIFF
--- a/src/res_outcome_printer.ml
+++ b/src/res_outcome_printer.ml
@@ -506,7 +506,7 @@ let printPolyVarIdent txt =
      Doc.group (
        Doc.indent (
          Doc.concat [
-           Doc.line;
+           Doc.softLine;
            Doc.join ~sep:Doc.line (
              List.mapi (fun i constructor ->
                Doc.concat [

--- a/tests/oprint/expected/oprint.resi.txt
+++ b/tests/oprint/expected/oprint.resi.txt
@@ -16,7 +16,7 @@ module Diff: {
   let string: (string, string) => bool
 }
 module Diff2 = Diff
-type rec tree<'value> =  Nil | Node(tree<'value>, 'value, tree<'value>)
+type rec tree<'value> = Nil | Node(tree<'value>, 'value, tree<'value>)
 type intTree = tree<int>
 type rec tree2<'value> =
   | Niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiil2
@@ -36,16 +36,16 @@ type rec tree4<'value> =
       riiiiiiiiiiiiiiiiiiiiiiight: tree3<'value>,
     })
 type color = ..
-type color +=  Blue
-type color +=  Red | Green
+type color += Blue
+type color += Red | Green
 type color +=
   | Blaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaack
   | Oraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaange
   | Reeeeeeeeeeeeeeeeeeeed
 module Expr: {
   type attr = ..
-  type attr += private  Str(string)
-  type attr +=  Int(int) | Float(float)
+  type attr += private Str(string)
+  type attr += Int(int) | Float(float)
 }
 module User: {
   type t = {name: string, age: int}
@@ -449,7 +449,7 @@ module type DEVICE = {
 }
 let devices: Hashtbl.t<string, module(DEVICE)>
 module rec A: {
-  type t =  Leaf(string) | Node(ASet.t)
+  type t = Leaf(string) | Node(ASet.t)
   let compare: (t, t) => int
 }
 and ASet: {
@@ -493,3 +493,4 @@ and ASet: {
 }
 type emptyObject = {.}
 let f: (~x: 'a=?, ~y: 'b) => option<'a>
+type call = CleanStart

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -336,3 +336,5 @@ and ASet: Set.S with type elt = A.t = Set.Make(A)
 type emptyObject = {.}
 
 let f = (~x=?, ~y as _) => x
+
+type call = CleanStart


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/451.

`type call =  CleanStart` should be printed as `type call = CleanStart`. Notice the correct space after `=`.