### PR TITLE
fix: prevent stripping of quotes for empty polymorphic variant

### DIFF
--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -459,7 +459,13 @@ let printPolyVarIdent txt =
         Doc.text txt;
         Doc.text"\""
       ]
-    | NormalIdent -> Doc.text txt
+    | NormalIdent -> match txt with
+      | "" -> Doc.concat [
+        Doc.text "\"";
+        Doc.text txt;
+        Doc.text"\""
+      ]
+      | _ -> Doc.text txt
 
 
 let printLident l = match l with

--- a/tests/printer/pattern/expected/variant.res.txt
+++ b/tests/printer/pattern/expected/variant.res.txt
@@ -43,3 +43,5 @@ switch numericPolyVar {
 | #42 => ()
 | #3(x, y, z) => Js.log3(x, y, z)
 }
+
+let e = #""

--- a/tests/printer/pattern/variant.res
+++ b/tests/printer/pattern/variant.res
@@ -43,3 +43,5 @@ switch numericPolyVar {
 | #42 => ()
 | #3(x, y, z) => Js.log3(x, y, z)
 }
+
+let e = #""


### PR DESCRIPTION
Fixes  https://github.com/rescript-lang/syntax/issues/472