### PR TITLE
Fix parsing punned record fields with module name

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -493,6 +493,12 @@ let hexValue ch =
   | 'A'..'F' -> (Char.code ch) + 32 - (Char.code 'a') + 10
   | _ -> 16 (* larger than any legal value *)
 
+(* Transform A.a into a. For use with punned record fields as in {A.a, b}. *)
+let removeModuleNameFromPunnedFieldValue exp =
+  match exp.Parsetree.pexp_desc with
+  | Pexp_ident pathIdent -> {exp with pexp_desc = Pexp_ident { pathIdent with txt = Lident (Longident.last pathIdent.txt) }} 
+  | _ -> exp
+
 let parseStringLiteral s =
   let len = String.length s in
   let b = Buffer.create (String.length s) in
@@ -2710,11 +2716,6 @@ and parseJsxChildren p =
     Parser.next p;
     (true, [parsePrimaryExpr ~operand:(parseAtomicExpr p) ~noCall:true p])
   | _ -> (false, loop p [])
-
-and removeModuleNameFromPunnedFieldValue exp =
-  match exp.Parsetree.pexp_desc with
-  | Pexp_ident pathIdent -> {exp with pexp_desc = Pexp_ident { pathIdent with txt = Lident (Longident.last pathIdent.txt) }} 
-  | _ -> exp
 
 and parseBracedOrRecordExpr  p =
   let startPos = p.Parser.startPos in

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2777,18 +2777,19 @@ and parseBracedOrRecordExpr  p =
       end
     end
   | Uident _ | Lident _ ->
+    let startToken = p.token in
     let valueOrConstructor = parseValueOrConstructor p in
     begin match valueOrConstructor.pexp_desc with
     | Pexp_ident pathIdent ->
       let identEndPos = p.prevEndPos in
       begin match p.Parser.token with
       | Comma ->
-        let valueOrConstructor = match p.token with
+        Parser.next p;
+        let valueOrConstructor = match startToken with
         | Uident _ -> removeModuleNameFromPunnedFieldValue(valueOrConstructor)
         | _ -> valueOrConstructor
         in
-        Parser.next p;    
-        let expr = parseRecordExpr ~startPos [(pathIdent, removeModuleNameFromPunnedFieldValue valueOrConstructor)] p in
+        let expr = parseRecordExpr ~startPos [(pathIdent, valueOrConstructor)] p in
         Parser.expect Rbrace p;
         expr
       | Colon ->
@@ -2947,10 +2948,9 @@ and parseRecordRow p =
     Parser.next p;
   | _ -> ()
   in
-  let startToken = p.Parser.token
-  in
-  match startToken with
+  match p.Parser.token with
   | Lident _ | Uident _ ->
+    let startToken = p.token in
     let field = parseValuePath p in
     begin match p.Parser.token with
     | Colon ->
@@ -2958,8 +2958,7 @@ and parseRecordRow p =
       let fieldExpr = parseExpr p in
       Some (field, fieldExpr)
     | _ ->
-      let value = Ast_helper.Exp.ident ~loc:field.loc field
-      in
+      let value = Ast_helper.Exp.ident ~loc:field.loc field in
       let value = match startToken with
       | Uident _ -> removeModuleNameFromPunnedFieldValue(value)
       | _ -> value

--- a/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -2,8 +2,8 @@ let r = { a = expr }
 let r = { a = expr }
 let r = { Parsetree.pexp_attributes = [||]; Parsetree.loc = loc }
 let r = { a; b; c }
-let r = { Parsetree.pexp_attributes; Parsetree.loc }
-let r = { Parsetree.pexp_attributes; Parsetree.loc }
+let r = { Parsetree.pexp_attributes = pexp_attributes; Parsetree.loc = loc }
+let r = { Parsetree.pexp_attributes = pexp_attributes; Parsetree.loc = loc }
 let r = { a = (expr : int); b = (x : string) }
 let r = { expr with pexp_attributes = [||] }
 let r = { expr with pexp_attributes = [||]; pexp_loc = loc }

--- a/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -2,6 +2,8 @@ let r = { a = expr }
 let r = { a = expr }
 let r = { Parsetree.pexp_attributes = [||]; Parsetree.loc = loc }
 let r = { a; b; c }
+let r = { A.a = a; b }
+let r = { A.a = a; b; C.c = c }
 let r = { Parsetree.pexp_attributes = pexp_attributes; Parsetree.loc = loc }
 let r = { Parsetree.pexp_attributes = pexp_attributes; Parsetree.loc = loc }
 let r = { a = (expr : int); b = (x : string) }

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -5,6 +5,8 @@ let r = {Parsetree.pexp_attributes: [], Parsetree.loc: loc}
 
 // punning
 let r = {a, b, c} 
+let r = {A.a, b}
+let r = {A.a, b, C.c}
 
 let r = {Parsetree.pexp_attributes, Parsetree.loc}
 // trailing comma


### PR DESCRIPTION
This fixes https://github.com/rescript-lang/rescript-compiler/issues/5362.

I.e.

```rescript
{A.a, b}
```

is now correctly parsed to match the AST for

```rescript
{A.a: a, b: b}
```

and not for

```rescript
{A.a: A.a, b: b}
```