### PR TITLE
Print punned fields

### DIFF
--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2807,9 +2807,9 @@ and printExpression (e : Parsetree.expression) cmtTbl =
     let forceBreak =
       e.pexp_loc.loc_start.pos_lnum < e.pexp_loc.loc_end.pos_lnum
     in
-    let punningAllowed = match spreadExpr with
-    | Some(_) -> true
-    | None -> List.length rows > 1
+    let punningAllowed = match spreadExpr, rows with
+    | (None, [_]) -> false (* disallow punning for single-element records *)
+    | _ -> true
     in
     Doc.breakableGroup ~forceBreak (
       Doc.concat([

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2807,6 +2807,10 @@ and printExpression (e : Parsetree.expression) cmtTbl =
     let forceBreak =
       e.pexp_loc.loc_start.pos_lnum < e.pexp_loc.loc_end.pos_lnum
     in
+    let punningAllowed = match spreadExpr with
+    | Some(_) -> true
+    | None -> List.length rows > 1
+    in
     Doc.breakableGroup ~forceBreak (
       Doc.concat([
         Doc.lbrace;
@@ -2815,7 +2819,7 @@ and printExpression (e : Parsetree.expression) cmtTbl =
             Doc.softLine;
             spread;
             Doc.join ~sep:(Doc.concat [Doc.text ","; Doc.line])
-              (List.map (fun row -> printRecordRow row cmtTbl) rows)
+              (List.map (fun row -> printRecordRow row cmtTbl punningAllowed) rows)
           ]
         );
         Doc.trailingComma;
@@ -4818,17 +4822,28 @@ and printDirectionFlag flag = match flag with
   | Asttypes.Downto -> Doc.text " downto "
   | Asttypes.Upto -> Doc.text " to "
 
-and printRecordRow (lbl, expr) cmtTbl =
+and printRecordRow (lbl, expr) cmtTbl punningAllowed =
   let cmtLoc = {lbl.loc with loc_end = expr.pexp_loc.loc_end} in
-  let doc = Doc.group (Doc.concat [
-    printLidentPath lbl cmtTbl;
-    Doc.text ": ";
-    (let doc = printExpressionWithComments expr cmtTbl in
-    match Parens.expr expr with
-    | Parens.Parenthesized -> addParens doc
-    | Braced braces -> printBraces doc expr braces
-    | Nothing -> doc);
-  ]) in
+  let doc = Doc.group (
+    match expr.pexp_desc with
+    | Pexp_ident({txt = Lident key; loc = keyLoc}) when (
+      punningAllowed && 
+      Longident.last lbl.txt = key &&
+      lbl.loc.loc_start.pos_cnum == keyLoc.loc_start.pos_cnum
+    ) ->
+      (* print punned field *)
+      printLidentPath lbl cmtTbl;
+    | _ ->
+      Doc.concat [
+      printLidentPath lbl cmtTbl;
+      Doc.text ": ";
+      (let doc = printExpressionWithComments expr cmtTbl in
+      match Parens.expr expr with
+      | Parens.Parenthesized -> addParens doc
+      | Braced braces -> printBraces doc expr braces
+      | Nothing -> doc);
+    ]
+  ) in
   printComments doc cmtTbl cmtLoc
 
 and printBsObjectRow (lbl, expr) cmtTbl =

--- a/tests/conversion/reason/expected/bracedJsx.re.txt
+++ b/tests/conversion/reason/expected/bracedJsx.re.txt
@@ -91,7 +91,7 @@ let make = () => {
           ],
         ),
       }
-    | SetValue(input) => {...state, input: input}
+    | SetValue(input) => {...state, input}
     }
   , {history: [], input: ""})
 

--- a/tests/conversion/reason/expected/braces.re.txt
+++ b/tests/conversion/reason/expected/braces.re.txt
@@ -20,5 +20,5 @@ let getDailyNewCases = x =>
   | Pair({prevRecord, record}) =>
     let confirmed = record.confirmed - prevRecord.confirmed
     let deaths = record.deaths - prevRecord.deaths
-    {confirmed: confirmed, deaths: deaths}
+    {confirmed, deaths}
   }

--- a/tests/printer/expr/expected/block.res.txt
+++ b/tests/printer/expr/expected/block.res.txt
@@ -60,7 +60,7 @@ React.useEffect0(() => {
     switch videoContainerRect {
     | Some(videoContainerRect) =>
       let newChapter = ({startTime: percent *. duration}: Video.chapter)
-      {a: a, b: b}->onChange
+      {a, b}->onChange
     | _ => ()
     }
   }}

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -48,3 +48,26 @@ let r = {A.a, b}
 let r = {A.a: a, b}
 let r = {a: a, b}
 let r = {a, b: b}
+
+// Punning + comments
+let r = {
+  // a
+  a,
+  // b
+  b,
+}
+let r = {
+  a, // a
+  b, // b
+}
+let r = {
+  /* a */
+  a,
+  /* b */
+  b,
+}
+let r = {
+  a /* a */,
+  b /* b */,
+}
+let r = {a /* a */, b /* b */}

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -39,3 +39,12 @@ let user = {
 }
 // braced + constrained expr
 let user = {name: {(ceo.name: string)}}
+
+// Punning
+let r = {a} // actually not a record, just an expression in braces
+let r = {a, b}
+let r = {a, b, c: 42}
+let r = {A.a, b}
+let r = {A.a: a, b}
+let r = {a: a, b}
+let r = {a, b: b}

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -28,3 +28,13 @@ let user = {name: {
 }}
 // braced + constrained expr
 let user = {name: {(ceo.name: string)}}
+
+
+// Punning
+let r = {a} // actually not a record, just an expression in braces
+let r = {a, b}
+let r = {a, b, c: 42}
+let r = {A.a, b}
+let r = {A.a: a, b}
+let r = {a: a, b}
+let r = {a, b: b}

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -38,3 +38,26 @@ let r = {A.a, b}
 let r = {A.a: a, b}
 let r = {a: a, b}
 let r = {a, b: b}
+
+// Punning + comments
+let r = {
+  // a
+  a,
+  // b
+  b,
+}
+let r = {
+  a, // a
+  b, // b
+}
+let r = {
+  /* a */
+  a,
+  /* b */
+  b,
+}
+let r = {
+  a /* a */,
+  b /* b */,
+}
+let r = {a /* a */, b /* b */}


### PR DESCRIPTION
Currently, the printer removes record field punning as discussed in #252 (for record expressions) and #47 (for record type declarations). I.e., it expands `{a, b}` to `{a: a, b: b}`.

I gather from the discussions that we want to leave the behavior for record type declarations as it is, but improve the behavior for record expressions. This PR addresses that.

To avoid breaking changes for now, the printer will keep record expressions as the user wrote them, whether punned or not. That is, `{a, b}` will remain `{a, b}` and `{a: a, b: b}` will remain `{a: a, b: b}`.