### PR TITLE
Fix location of foo["abc']

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1974,7 +1974,7 @@ and parseBracketAccess p expr startPos =
     let rbracket = p.prevEndPos in
     let e =
       let identLoc = mkLoc stringStart stringEnd in
-      let loc = mkLoc lbracket rbracket in
+      let loc = mkLoc startPos rbracket in
       Ast_helper.Exp.send ~loc expr (Location.mkloc s identLoc)
     in
     let e = parsePrimaryExpr ~operand:e p in


### PR DESCRIPTION
The location of `foo["abc"]` should be the whole thing, and not only `["abc"]`

Example compilation error:
```
  129 │ someObj["age"] +. 0.
               ~~~~~~~

  This has type: int
  Somewhere wanted: float
```