### PR TITLE
Try to switch to ocaml/setup-ocaml@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
-    - name: Cache OCaml's opam
-      uses: actions/cache@v2.1.5
-      with:
-        path: ~/.opam
-        key: macos-latest-ocaml-4.06.1
+    # - name: Cache OCaml's opam
+      # uses: actions/cache@v2.1.5
+      # with:
+        # path: ~/.opam
+        # key: macos-latest-ocaml-4.06.1
 
     - name: Use OCaml
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v1
       with:
         ocaml-version: 4.06.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
-    # - name: Cache OCaml's opam
-      # uses: actions/cache@v2.1.5
-      # with:
-        # path: ~/.opam
-        # key: macos-latest-ocaml-4.06.1
+    - name: Cache OCaml's opam
+      uses: actions/cache@v2.1.5
+      with:
+        path: ~/.opam
+        key: macos-latest-ocaml-4.06.1
 
     - name: Use OCaml
-      uses: ocaml/setup-ocaml@v1
+      uses: ocaml/setup-ocaml@v1.1.13
       with:
         ocaml-version: 4.06.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         key: macos-latest-ocaml-4.06.1
 
     - name: Use OCaml
-      uses: ocaml/setup-ocaml@v1
+      uses: ocaml/setup-ocaml@v2
       with:
         ocaml-version: 4.06.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
+    - run: rm -rf ~/.opam
+
     - name: Cache OCaml's opam
       uses: actions/cache@v2.1.5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
-    - run: rm -rf ~/.opam
-
-    - name: Cache OCaml's opam
-      uses: actions/cache@v2.1.5
-      with:
-        path: ~/.opam
-        key: macos-latest-ocaml-4.06.1
+    # - name: Cache OCaml's opam
+      # uses: actions/cache@v2.1.5
+      # with:
+        # path: ~/.opam
+        # key: macos-latest-ocaml-4.06.1
 
     - name: Use OCaml
       uses: ocaml/setup-ocaml@v1.1.13
@@ -32,5 +30,7 @@ jobs:
         node-version: 14.4.0
 
     - run: npm ci
+
+    - run: opam --version
 
     - run: eval $(opam env) && make roundtrip-test


### PR DESCRIPTION
There's an error on GH actions:
```
Refusing write access to /Users/runner/.opam, which is more recent than this version of opam (2.1 > 2.0), aborting.
```
Switching to `ocaml/setup-ocaml@v2` might fix it