### PR TITLE
Recovery when encountering errors parsing long idents.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -713,6 +713,7 @@ let parseValuePath p =
   let ident = match p.Parser.token with
   | Lident ident -> Longident.Lident ident
   | Uident ident ->
+    Parser.next p;
     if p.Parser.token = Dot then (
       Parser.expect Dot p;
       aux p (Lident ident)  


### PR DESCRIPTION
More fine grained error recovery from parsing longidents.
E.g. Foo. gives Foo._ instead of a default expression which erases info on what's parser already.

From: https://github.com/rescript-lang/rescript-vscode/pull/388