### PR TITLE
Revert "jsx: allow locally abstract types and type constraints on @react.component definitions (#487)"

### DIFF
--- a/src/reactjs_jsx_ppx_v3.ml
+++ b/src/reactjs_jsx_ppx_v3.ml
@@ -93,10 +93,9 @@ let otherAttrsPure (loc, _) = loc.txt <> "react.component"
 let hasAttrOnBinding { pvb_attributes } = find_opt hasAttr pvb_attributes <> None
 
 (* Finds the name of the variable the binding is assigned to, otherwise raises Invalid_argument *)
-let rec getFnName binding =
+let getFnName binding =
   match binding with
-  | { ppat_desc = Ppat_var { txt } } -> txt
-  | { ppat_desc = Ppat_constraint (pat, _) } -> getFnName pat
+  | { pvb_pat = { ppat_desc = Ppat_var { txt } } } -> txt
   | _ -> raise (Invalid_argument "react.component calls cannot be destructured.")
   [@@raises Invalid_argument]
 
@@ -488,7 +487,7 @@ let jsxMapper () =
             let bindingLoc = binding.pvb_loc in
             let bindingPatLoc = binding.pvb_pat.ppat_loc in
             let binding = { binding with pvb_pat = { binding.pvb_pat with ppat_loc = emptyLoc }; pvb_loc = emptyLoc } in
-            let fnName = getFnName binding.pvb_pat in
+            let fnName = getFnName binding in
             let internalFnName = fnName ^ "$Internal" in
             let fullModuleName = makeModuleName fileName !nestedModules fnName in
             let modifiedBindingOld binding =
@@ -506,10 +505,6 @@ let jsxMapper () =
                 | { pexp_desc = Pexp_apply (_wrapperExpression, [ (Nolabel, innerFunctionExpression) ]) } ->
                     spelunkForFunExpression innerFunctionExpression
                 | { pexp_desc = Pexp_sequence (_wrapperExpression, innerFunctionExpression) } ->
-                    spelunkForFunExpression innerFunctionExpression
-                | { pexp_desc = Pexp_newtype (_label, innerFunctionExpression) } ->
-                    spelunkForFunExpression innerFunctionExpression
-                | { pexp_desc = Pexp_constraint (innerFunctionExpression, _typ) } ->
                     spelunkForFunExpression innerFunctionExpression
                 | _ ->
                     raise

--- a/tests/ppx/react/expected/newtype.res.txt
+++ b/tests/ppx/react/expected/newtype.res.txt
@@ -1,6 +1,0 @@
-@obj external makeProps: (~a: a, ~b: 'b, ~key: string=?, unit) => {"a": a, "b": 'b} = ""
-let make = (type a, ~a: a, ~b, _) => ReactDOMRe.createDOMElementVariadic("div", [])
-let make = {
-  let \"Newtype" = (\"Props": {"a": a, "b": 'b}) => make(~b=\"Props"["b"], ~a=\"Props"["a"])
-  \"Newtype"
-}

--- a/tests/ppx/react/expected/typeConstraint.res.txt
+++ b/tests/ppx/react/expected/typeConstraint.res.txt
@@ -1,8 +1,0 @@
-@obj external makeProps: (~a: 'a, ~b: 'b, ~key: string=?, unit) => {"a": 'a, "b": 'b} = ""
-let make:
-  type a. (~a: a, ~b: a, a) => React.element =
-  (~a, ~b, _) => ReactDOMRe.createDOMElementVariadic("div", [])
-let make = {
-  let \"TypeConstraint" = (\"Props": {"a": 'a, "b": 'b}) => make(~b=\"Props"["b"], ~a=\"Props"["a"])
-  \"TypeConstraint"
-}

--- a/tests/ppx/react/newtype.res
+++ b/tests/ppx/react/newtype.res
@@ -1,2 +1,0 @@
-@react.component
-let make = (type a, ~a: a, ~b, _) => <div />

--- a/tests/ppx/react/typeConstraint.res
+++ b/tests/ppx/react/typeConstraint.res
@@ -1,2 +1,0 @@
-@react.component
-let make: type a. (~a: a, ~b: a, a) => React.element = (~a, ~b, _) => <div />


### PR DESCRIPTION
This reverts commit fab78d4bb48780d4a478037dbf69c3954df75b7e.

See https://github.com/rescript-lang/syntax/pull/487#discussion_r867451571