### PR TITLE
WIP: Test cases for comments issues

### DIFF
--- a/tests/printer/comments/expected/missing.res.txt
+++ b/tests/printer/comments/expected/missing.res.txt
@@ -1,0 +1,20 @@
+// #301 Improve printing of callbacks in first arg position with comments
+11->foo(
+  x => {
+    let y = 100
+
+    x + y
+  },
+  // Do the addition.
+
+  _,
+)
+
+// #463 Cases where comments are lost converting ReasonML to ReScript
+f(_ => 1)
+g(a => 1)
+// This comment is moved down
+h((~a) =>
+  // This comment works fine
+  1
+)

--- a/tests/printer/comments/missing.res
+++ b/tests/printer/comments/missing.res
@@ -1,0 +1,18 @@
+// #301 Improve printing of callbacks in first arg position with comments
+11->foo(x => {
+  let y = 100
+
+  // Do the addition.
+  x + y
+}, _)
+
+// #463 Cases where comments are lost converting ReasonML to ReScript
+f(_
+  // This comment vanishes
+  => 1);
+g(a
+  // This comment is moved down
+  => 1);
+h((~a)
+  // This comment works fine
+  => 1);


### PR DESCRIPTION
There were quite a few issues reported with comments being moved or removed in the printer output.

I collected test cases for all of these issues into a single test file.
The current (invalid) behavior can be observed in the test output file.