### PR TITLE
Update package-lock to new v2 lockfile format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,27 @@
 {
   "name": "rescript-syntax",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "rescript-syntax",
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "reanalyze": "^2.17.0"
+      }
+    },
+    "node_modules/reanalyze": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/reanalyze/-/reanalyze-2.17.0.tgz",
+      "integrity": "sha512-6OzrmtmaGvweIvGnpJKkFvWXSRoMvMdgTX9BtLewV1gR20uerEONGjqgHaLoO0AF7hmyJpKY+C+ft+o4lHS3JQ==",
+      "dev": true,
+      "bin": {
+        "reanalyze": "reanalyze.exe"
+      }
+    }
+  },
   "dependencies": {
     "reanalyze": {
       "version": "2.17.0",


### PR DESCRIPTION
Node v16 comes with npm 8 that is based on the new v2 lockfile format.