### PR TITLE
Use node 16 for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2.1.5
       with:
-        node-version: 14.4.0
+        node-version: 16
 
     - run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
     },
     "node_modules/reanalyze": {
       "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/reanalyze/-/reanalyze-2.17.0.tgz",
       "integrity": "sha512-6OzrmtmaGvweIvGnpJKkFvWXSRoMvMdgTX9BtLewV1gR20uerEONGjqgHaLoO0AF7hmyJpKY+C+ft+o4lHS3JQ==",
       "dev": true,
+      "hasInstallScript": true,
       "bin": {
         "reanalyze": "reanalyze.exe"
       }
@@ -25,8 +25,6 @@
   "dependencies": {
     "reanalyze": {
       "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/reanalyze/-/reanalyze-2.17.0.tgz",
-      "integrity": "sha512-6OzrmtmaGvweIvGnpJKkFvWXSRoMvMdgTX9BtLewV1gR20uerEONGjqgHaLoO0AF7hmyJpKY+C+ft+o4lHS3JQ==",
       "dev": true
     }
   }


### PR DESCRIPTION
I also regenerated the package-lock.json from scratch, as the previously upgraded one was broken (it caused the reanalyze binary not to be installed).