### PR TITLE
Fix printing of parens in binary expressions with attributes

### DIFF
--- a/src/res_parens.ml
+++ b/src/res_parens.ml
@@ -126,6 +126,11 @@ type kind = Parenthesized | Braced of Location.t | Nothing
             Pexp_lazy _
           | Pexp_assert _
         } when isLhs -> Parenthesized
+      | {Parsetree.pexp_attributes = (_::_) as attrs} ->
+        begin match ParsetreeViewer.filterPrinteableAttributes attrs with
+        | [] -> Nothing
+        | _ -> Parenthesized
+        end
       | _ -> Nothing
       end
 

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -453,7 +453,7 @@ let shouldInlineRhsBinaryExpr rhs = match rhs.pexp_desc with
 
 let filterPrinteableAttributes attrs =
   List.filter (fun attr -> match attr with
-    | ({Location.txt="bs" | "res.template" | "ns.ternary" | "ns.iflet" | "JSX"}, _) -> false
+    | ({Location.txt="bs" | "res.template" | "ns.ternary" | "ns.braces" | "ns.iflet" | "JSX"}, _) -> false
     | _ -> true
   ) attrs
 

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3494,7 +3494,10 @@ and printBinaryExpression (expr : Parsetree.expression) cmtTbl =
               let printeableAttrs =
                 ParsetreeViewer.filterPrinteableAttributes right.pexp_attributes
               in
-              Doc.concat [printAttributes printeableAttrs cmtTbl; doc]
+              let doc = Doc.concat [printAttributes printeableAttrs cmtTbl; doc] in
+              match printeableAttrs with
+              | [] -> doc
+              | _ -> addParens doc
             in
             let doc = Doc.concat [
               leftPrinted;
@@ -4827,7 +4830,7 @@ and printRecordRow (lbl, expr) cmtTbl punningAllowed =
   let doc = Doc.group (
     match expr.pexp_desc with
     | Pexp_ident({txt = Lident key; loc = keyLoc}) when (
-      punningAllowed && 
+      punningAllowed &&
       Longident.last lbl.txt = key &&
       lbl.loc.loc_start.pos_cnum == keyLoc.loc_start.pos_cnum
     ) ->

--- a/tests/conversion/reason/expected/fastPipe.res.txt
+++ b/tests/conversion/reason/expected/fastPipe.res.txt
@@ -5,7 +5,7 @@ Element.querySelectorAll(selector, element)
 ->Array.keepMap(Element.ofNode)
 ->Array.getBy(node => node->Element.textContent === content)
 
-let x = @attr (@attr2 a->f(b)->c(d))
+let x = @attr ((@attr2 a)->f(b)->c(d))
 
 5->doStuff(3, _, 7)
 

--- a/tests/printer/expr/binary.res
+++ b/tests/printer/expr/binary.res
@@ -400,3 +400,8 @@ let make = (~keycap) =>
 <Kbd keycap="Option" /> +
 <Kbd keycap="Shift" /> +
 <Kbd keycap />
+
+// rescript-lang/syntax/issues/499
+(@doesNotRaise [])->Belt.Array.getExn(0)
+@doesNotRaise
+[]->Belt.Array.getExn(0)

--- a/tests/printer/expr/expected/binary.res.txt
+++ b/tests/printer/expr/expected/binary.res.txt
@@ -1,6 +1,6 @@
 let x = a + b
 let x = @attr (a + b)
-let x = @attr (@attr a + @attr b)
+let x = @attr ((@attr a) + (@attr b))
 let x = a && b + c
 let x = (a && b) + c
 let x = (a && b) || c
@@ -182,13 +182,13 @@ let x = a && (b || c) && d
 let x = a && b + c
 let x = a && b + c && d
 
-let x = a && @attr b && c
-let x = @attr a && @attr b && @attr c
+let x = a && (@attr b) && c
+let x = (@attr a) && (@attr b) && (@attr c)
 let x = a && @attr (b && c)
-let x = a && @attr (b && c) && @attr (d && e)
+let x = a && (@attr (b && c)) && @attr (d && e)
 
 let x = a && @attr (x |> f(g))
-let x = a && @attr (x |> f(g)) && @attr (y |> f(h))
+let x = a && (@attr (x |> f(g))) && @attr (y |> f(h))
 
 let x = a && a.b
 let x = a && x.y && g.h
@@ -516,3 +516,8 @@ React.useEffect4(() => {
 let make = (~keycap) => <Kbd keycap="Ctrl" /> + <Kbd keycap="Shift" /> + <Kbd keycap />
 
 <Kbd keycap="Cmd" /> + <Kbd keycap="Option" /> + <Kbd keycap="Shift" /> + <Kbd keycap />
+
+// rescript-lang/syntax/issues/499
+(@doesNotRaise [])->Belt.Array.getExn(0)
+@doesNotRaise
+[]->Belt.Array.getExn(0)


### PR DESCRIPTION
Parens should be printed:
```rescript
(@doesNotRaise [])->Belt.Array.getExn(0)
```

Fixes https://github.com/rescript-lang/syntax/issues/499