### PR TITLE
Fix problem with string in braces introduced in #494

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2772,7 +2772,8 @@ and parseBracedOrRecordExpr  p =
       Parser.expect Rbrace p;
       expr
     | _ ->
-      let constant = Ast_helper.Exp.constant ~loc:field.loc (Parsetree.Pconst_string(s, Some("js"))) in
+      let tag = if p.mode = ParseForTypeChecker then Some "js" else None in
+      let constant = Ast_helper.Exp.constant ~loc:field.loc (Parsetree.Pconst_string(s, tag)) in
       let a = parsePrimaryExpr ~operand:constant p in
       let e = parseBinaryExpr ~a p 1 in
       let e = parseTernaryExpr e p in

--- a/tests/printer/expr/expected/switch.res.txt
+++ b/tests/printer/expr/expected/switch.res.txt
@@ -21,3 +21,7 @@ let x =
   switch x {
   | Universe => ()
   }
+
+switch count {
+| 1 => "one"
+}

--- a/tests/printer/expr/switch.res
+++ b/tests/printer/expr/switch.res
@@ -19,3 +19,7 @@ let rec updateSum = (node, ~delta) =>
 let x = @attr switch x {
 | Universe => ()
 }
+
+switch count {
+| 1 => { "one" }
+}


### PR DESCRIPTION
I forgot to check for the mode which broke the roundtrip test for the added test case.