### PR TITLE
Fragment ghost

### DIFF
--- a/cli/reactjs_jsx_ppx_v3.ml
+++ b/cli/reactjs_jsx_ppx_v3.ml
@@ -873,6 +873,7 @@ let jsxMapper () =
         (* no JSX attribute *)
         | [], _ -> default_mapper.expr mapper expression
         | _, nonJSXAttributes ->
+            let loc = {loc with loc_ghost= true} in
             let fragment = Exp.ident ~loc { loc; txt = Ldot (Lident "ReasonReact", "fragment") } in
             let childrenExpr = transformChildrenIfList ~loc ~mapper listItems in
             let args =


### PR DESCRIPTION
Location of ReasonReact.fragment should be ghost.
See: https://github.com/rescript-lang/syntax/issues/519
https://github.com/rescript-lang/rescript-vscode/pull/449