### PR TITLE
Add tests for template literal with backslashes

### DIFF
--- a/tests/printer/expr/expected/templateLiteral.res.txt
+++ b/tests/printer/expr/expected/templateLiteral.res.txt
@@ -9,6 +9,10 @@ let s = `multi
 string
 `
 
+let s = `a \ b`
+let s = `a \\ b`
+let s = `a \\\ b`
+
 let s = `${foo}`
 
 let s = `before${foo}`

--- a/tests/printer/expr/templateLiteral.res
+++ b/tests/printer/expr/templateLiteral.res
@@ -9,6 +9,10 @@ let s = `multi
 string
 `
 
+let s = `a \ b`
+let s = `a \\ b`
+let s = `a \\\ b`
+
 let s = `${foo}`
 
 let s = `before${foo}`


### PR DESCRIPTION
with regard to #429, the bug in `res_printer` has been addressed at some point I guess?