### PR TITLE
Cleanup: get rid of lib dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ _build
 
 # Merlin
 .merlin
+
+# Output dir for bootstrap script
+bootstrap/

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,1 +1,0 @@
-We store a few dev-time binaries here.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,6 +1,9 @@
 #!/bin/zsh
 
 # pack and parse the whole codebase using the compiler itself. Kind of a test
-ocaml unix.cma ./scripts/bspack.ml -bs-main Res_cli -I cli -I src -o ./lib/rescript.ml
-rescript ./lib/rescript.ml > ./lib/rescript.res
-ocamlopt.opt -w a -pp "rescript -print binary" -O2 -o rescript -I +compiler-libs ocamlcommon.cmxa -I lib -impl ./lib/rescript.res
+rm -rf ./bootstrap
+mkdir ./bootstrap
+
+ocaml unix.cma ./scripts/bspack.ml -bs-main Res_cli -I cli -I src -o ./bootstrap/rescript.ml
+rescript ./bootstrap/rescript.ml > ./bootstrap/rescript.res
+ocamlopt.opt -w a -pp "rescript -print binary" -O2 -o rescript -I +compiler-libs ocamlcommon.cmxa -I lib -impl ./bootstrap/rescript.res


### PR DESCRIPTION
Currently there is a `lib` dir in the repo containing only a `README.md` saying

> We store a few dev-time binaries here.

In the pre-dune setup, the `lib` dir was actually used to store `rescript.exe` etc. Now the only place it is still used is by `scripts/bootstrap.sh`. Also, invoking `scripts/bootstrap.sh` produces an uncommitted change.

I have therefore removed the `lib` dir / its README and changed the bootstrap script to use a new, git-ignored dir `bootstrap` that it creates on demand.