### PR TITLE
Printer: auto-pun record fields

### DIFF
--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4826,8 +4826,7 @@ and printRecordRow (lbl, expr) cmtTbl punningAllowed =
     match expr.pexp_desc with
     | Pexp_ident({txt = Lident key; loc = keyLoc}) when (
       punningAllowed &&
-      Longident.last lbl.txt = key &&
-      lbl.loc.loc_start.pos_cnum == keyLoc.loc_start.pos_cnum
+      Longident.last lbl.txt = key
     ) ->
       (* print punned field *)
       printLidentPath lbl cmtTbl;

--- a/tests/conversion/reason/expected/bracedJsx.res.txt
+++ b/tests/conversion/reason/expected/bracedJsx.res.txt
@@ -91,7 +91,7 @@ let make = () => {
           ],
         ),
       }
-    | SetValue(input) => {...state, input: input}
+    | SetValue(input) => {...state, input}
     }
   , {history: [], input: ""})
 

--- a/tests/conversion/reason/expected/braces.res.txt
+++ b/tests/conversion/reason/expected/braces.res.txt
@@ -20,5 +20,5 @@ let getDailyNewCases = x =>
   | Pair({prevRecord, record}) =>
     let confirmed = record.confirmed - prevRecord.confirmed
     let deaths = record.deaths - prevRecord.deaths
-    {confirmed: confirmed, deaths: deaths}
+    {confirmed, deaths}
   }

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -45,9 +45,9 @@ let r = {a} // actually not a record, just an expression in braces
 let r = {a, b}
 let r = {a, b, c: 42}
 let r = {A.a, b}
-let r = {A.a: a, b}
-let r = {a: a, b}
-let r = {a, b: b}
+let r = {A.a, b}
+let r = {a, b}
+let r = {a, b}
 
 // Punning + comments
 let r = {

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -42,6 +42,8 @@ let user = {name: {(ceo.name: string)}}
 
 // Punning
 let r = {a} // actually not a record, just an expression in braces
+let r = {a: a} // single-element record, not punned
+let r = {A.a: a} // single-element record, not punned
 let r = {a, b}
 let r = {a, b, c: 42}
 let r = {A.a, b}

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -32,6 +32,8 @@ let user = {name: {(ceo.name: string)}}
 
 // Punning
 let r = {a} // actually not a record, just an expression in braces
+let r = {a: a} // single-element record, not punned
+let r = {A.a: a} // single-element record, not punned
 let r = {a, b}
 let r = {a, b, c: 42}
 let r = {A.a, b}


### PR DESCRIPTION
In #480, I already prevented the printer from expanding `{a, b} to {a: a, b: b}`.

At the time, I refrained from making it collapse `{a: a, b: b}` to `{a, b}` like it used to be the case in Reason.
But I think it would actually be the better behavior to always print record fields as punned when possible.

Now that the next release is going to be a major version (10.0), it would IMHO be fine to make that change.