### PR TITLE
Revert "Turn on standard warnings in dune config."

### DIFF
--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -4,7 +4,7 @@
  (enabled_if
   (= %{system} macosx))
  (flags
-  (-open Syntax -open Compilerlibs406 -w +26+27+32+33+39))
+  (-open Syntax -open Compilerlibs406))
  (foreign_stubs
   (language c)
   (names mac_osx_time))

--- a/cli/dune
+++ b/cli/dune
@@ -2,5 +2,5 @@
  (name res_cli)
  (public_name rescript)
  (flags
-  (-open Syntax -open Compilerlibs406 -w -d  -w +26+27+32+33+39))
+  (-open Syntax -open Compilerlibs406 -w -d))
  (libraries syntax compilerlibs406))

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (library
  (name syntax)
  (flags
-  (-open Compilerlibs406 -w +26+27+32+33+39))
+  (-open Compilerlibs406))
  (libraries compilerlibs406))

--- a/tests/dune
+++ b/tests/dune
@@ -2,5 +2,5 @@
  (name res_test)
  (public_name tests)
  (flags
-  (-open Syntax -open Compilerlibs406 -w +26+27+32+33+39))
+  (-open Syntax -open Compilerlibs406))
  (libraries syntax compilerlibs406))


### PR DESCRIPTION
This reverts commit d28656e2efd7270c3323e223b36acd40d5a3ed29.

Standard warnings are already defined globally in https://github.com/rescript-lang/syntax/blob/master/dune.