### PR TITLE
Reanalyze failure should not prevent running tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,17 @@ bootstrap: build
 bench: build
 	dune exec -- bench
 
-test: reanalyze
+test:
 	dune exec -- testrunner
 	dune exec -- bash ./scripts/test.sh
+	make reanalyze
+	bash ./scripts/testok.sh
 
-roundtrip-test: reanalyze
+roundtrip-test:
 	dune exec -- testrunner
 	ROUNDTRIP_TEST=1 dune exec -- bash ./scripts/test.sh
+	make reanalyze
+	bash ./scripts/testok.sh
 
 reanalyze: build
 	reanalyze.exe -set-exit-code -all-cmt _build/default -suppress testrunner,compiler-libs-406 -exclude-paths compiler-libs-406 

--- a/scripts/testok.sh
+++ b/scripts/testok.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+successGreen='\033[0;32m'
+reset='\033[0m'
+
+printf "${successGreen}✅ All Tests Passed${reset}\n"


### PR DESCRIPTION
Now running reanalyze only after the normal tests.
Since introducing the exit code, the dev experience has been too strict, where even introducing an unused variable would prevent tests from running.

This also prints all tests passed at the end.