### PR TITLE
Fix Windows build and beautify + format ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           opam-pin: false
           opam-depext: false
 
-      - name: Use OCaml ${{matrix.ocaml_compiler}}
+      - name: Use OCaml ${{matrix.ocaml_compiler}} (macOS ARM)
         if: runner.name == 'macos-arm'
         uses: AbstractMachinesLab/setup-ocaml@arm-support
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,13 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  OCAML_VERSION: 4.14.0
-  
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest, macos-arm]
+        ocaml_compiler: [4.14.0]
 
     runs-on: ${{matrix.os}}
     
@@ -27,19 +25,19 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Use OCaml ${{env.OCAML_VERSION}}
+    - name: Use OCaml ${{matrix.ocaml_compiler}}
       if: runner.name != 'macos-arm'
       uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-compiler: ${{env.OCAML_VERSION}}
+        ocaml-compiler: ${{matrix.ocaml_compiler}}
         opam-pin: false
         opam-depext: false
 
-    - name: Use OCaml ${{env.OCAML_VERSION}}
+    - name: Use OCaml ${{matrix.ocaml_compiler}}
       if: runner.name == 'macos-arm'
       uses: AbstractMachinesLab/setup-ocaml@arm-support
       with:
-        ocaml-compiler: ${{env.OCAML_VERSION}}
+        ocaml-compiler: ${{matrix.ocaml_compiler}}
         opam-pin: false
         opam-depext: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Use OCaml ${{env.OCAML_VERSION}}
       if: runner.name != 'macos-arm'
-      uses: ocaml/setup-ocaml@v2.0.3
+      uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{env.OCAML_VERSION}}
         # Set default repo explicitly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -15,42 +15,42 @@ jobs:
         ocaml_compiler: [4.14.0]
 
     runs-on: ${{matrix.os}}
-    
+
     steps:
-    - name: "Windows: Set git to use LF"
-      if: runner.os == 'Windows'
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
+      - name: "Windows: Set git to use LF"
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Use OCaml ${{matrix.ocaml_compiler}}
-      if: runner.name != 'macos-arm'
-      uses: ocaml/setup-ocaml@v2
-      with:
-        ocaml-compiler: ${{matrix.ocaml_compiler}}
-        opam-pin: false
-        opam-depext: false
+      - name: Use OCaml ${{matrix.ocaml_compiler}}
+        if: runner.name != 'macos-arm'
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{matrix.ocaml_compiler}}
+          opam-pin: false
+          opam-depext: false
 
-    - name: Use OCaml ${{matrix.ocaml_compiler}}
-      if: runner.name == 'macos-arm'
-      uses: AbstractMachinesLab/setup-ocaml@arm-support
-      with:
-        ocaml-compiler: ${{matrix.ocaml_compiler}}
-        opam-pin: false
-        opam-depext: false
+      - name: Use OCaml ${{matrix.ocaml_compiler}}
+        if: runner.name == 'macos-arm'
+        uses: AbstractMachinesLab/setup-ocaml@arm-support
+        with:
+          ocaml-compiler: ${{matrix.ocaml_compiler}}
+          opam-pin: false
+          opam-depext: false
 
-    - name: Install dependencies
-      run: opam install . --deps-only
+      - name: Install dependencies
+        run: opam install . --deps-only
 
-    - name: Build executables
-      run: opam exec -- dune build
+      - name: Build executables
+        run: opam exec -- dune build
 
-    - name: Run roundtrip tests
-      if: runner.os != 'Windows'
-      run: opam exec -- make roundtrip-test
+      - name: Run roundtrip tests
+        if: runner.os != 'Windows'
+        run: opam exec -- make roundtrip-test
 
-    - name: Run tests (Windows)
-      if: runner.os == 'Windows'
-      run: opam exec -- make test
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        run: opam exec -- make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{env.OCAML_VERSION}}
-        # Set default repo explicitly.
-        # Windows uses https://github.com/fdopen/opam-repository-mingw otherwise which may be out of date.
-        opam-repositories: |
-          default: https://github.com/ocaml/opam-repository.git
         opam-pin: false
         opam-depext: false
 

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,12 @@ test: build
 	dune exec -- testrunner
 	dune exec -- bash ./scripts/test.sh
 	make reanalyze
-	make checkformat
 	bash ./scripts/testok.sh
 
 roundtrip-test: build
 	dune exec -- testrunner
 	ROUNDTRIP_TEST=1 dune exec -- bash ./scripts/test.sh
 	make reanalyze
-	make checkformat
 	bash ./scripts/testok.sh
 
 reanalyze: build

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -105,3 +105,16 @@ if [[ $ROUNDTRIP_TEST = 1 ]]; then
 fi
 
 rm -r temp/
+
+# Check format (does not work on Windows)
+case "$(uname -s)" in
+  Darwin|Linux)
+    echo "Checking code formatting..."
+    if dune build @fmt; then
+      printf "${successGreen}✅ Code formatting ok.${reset}\n"
+    else
+      printf "${warningYellow}⚠️ Code formatting failed.${reset}\n"
+      exit 1
+    fi
+    ;;
+esac


### PR DESCRIPTION
* Do not override default OPAM repo for Windows anymore. This fixes the Windows build.
* Beautify and format ci.yml to bring it in line with the rescript-compiler repo.