### PR TITLE
Dropped annotations from punned record labels.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2893,7 +2893,7 @@ and parseBracedOrRecordExpr p =
     let braces = makeBracesAttr loc in
     {expr with pexp_attributes = braces :: expr.pexp_attributes}
 
-and parseRecordRowWithStringKey p =
+and parseRecordExprRowWithStringKey p =
   match p.Parser.token with
   | String s -> (
     let loc = mkLoc p.startPos p.endPos in
@@ -2907,7 +2907,7 @@ and parseRecordRowWithStringKey p =
     | _ -> Some (field, Ast_helper.Exp.ident ~loc:field.loc field))
   | _ -> None
 
-and parseRecordRow p =
+and parseRecordExprRow p =
   let () =
     match p.Parser.token with
     | Token.DotDotDot ->
@@ -2938,7 +2938,7 @@ and parseRecordExprWithStringKeys ~startPos firstRow p =
   let rows =
     firstRow
     :: parseCommaDelimitedRegion ~grammar:Grammar.RecordRowsStringKey
-         ~closing:Rbrace ~f:parseRecordRowWithStringKey p
+         ~closing:Rbrace ~f:parseRecordExprRowWithStringKey p
   in
   let loc = mkLoc startPos p.endPos in
   let recordStrExpr =
@@ -2950,7 +2950,7 @@ and parseRecordExprWithStringKeys ~startPos firstRow p =
 and parseRecordExpr ~startPos ?(spread = None) rows p =
   let exprs =
     parseCommaDelimitedRegion ~grammar:Grammar.RecordRows ~closing:Rbrace
-      ~f:parseRecordRow p
+      ~f:parseRecordExprRow p
   in
   let rows = List.concat [rows; exprs] in
   let () =

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1206,7 +1206,7 @@ and parseConstrainedPatternRegion p =
  *	 | field , _
  *	 | field , _,
  *)
-and parseRecordPatternField p =
+and parseRecordPatternRowField p =
   let label = parseValuePath p in
   let pattern =
     match p.Parser.token with
@@ -1224,8 +1224,8 @@ and parseRecordPatternRow p =
   match p.Parser.token with
   | DotDotDot ->
     Parser.next p;
-    Some (true, PatField (parseRecordPatternField p))
-  | Uident _ | Lident _ -> Some (false, PatField (parseRecordPatternField p))
+    Some (true, PatField (parseRecordPatternRowField p))
+  | Uident _ | Lident _ -> Some (false, PatField (parseRecordPatternRowField p))
   | Underscore ->
     Parser.next p;
     Some (false, PatUnderscore)

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1206,7 +1206,7 @@ and parseConstrainedPatternRegion p =
  *	 | field , _
  *	 | field , _,
  *)
-and parseRecordPatternRowField p =
+and parseRecordPatternRowField ~attrs p =
   let label = parseValuePath p in
   let pattern =
     match p.Parser.token with
@@ -1214,18 +1214,20 @@ and parseRecordPatternRowField p =
       Parser.next p;
       parsePattern p
     | _ ->
-      Ast_helper.Pat.var ~loc:label.loc
+      Ast_helper.Pat.var ~loc:label.loc ~attrs
         (Location.mkloc (Longident.last label.txt) label.loc)
   in
   (label, pattern)
 
 (* TODO: there are better representations than PatField|Underscore ? *)
 and parseRecordPatternRow p =
+  let attrs = parseAttributes p in
   match p.Parser.token with
   | DotDotDot ->
     Parser.next p;
-    Some (true, PatField (parseRecordPatternRowField p))
-  | Uident _ | Lident _ -> Some (false, PatField (parseRecordPatternRowField p))
+    Some (true, PatField (parseRecordPatternRowField ~attrs p))
+  | Uident _ | Lident _ ->
+    Some (false, PatField (parseRecordPatternRowField ~attrs p))
   | Underscore ->
     Parser.next p;
     Some (false, PatUnderscore)

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2910,6 +2910,7 @@ and parseRecordExprRowWithStringKey p =
   | _ -> None
 
 and parseRecordExprRow p =
+  let attrs = parseAttributes p in
   let () =
     match p.Parser.token with
     | Token.DotDotDot ->
@@ -2927,7 +2928,7 @@ and parseRecordExprRow p =
       let fieldExpr = parseExpr p in
       Some (field, fieldExpr)
     | _ ->
-      let value = Ast_helper.Exp.ident ~loc:field.loc field in
+      let value = Ast_helper.Exp.ident ~loc:field.loc ~attrs field in
       let value =
         match startToken with
         | Uident _ -> removeModuleNameFromPunnedFieldValue value

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -1220,7 +1220,7 @@ and parseRecordPatternField p =
   (label, pattern)
 
 (* TODO: there are better representations than PatField|Underscore ? *)
-and parseRecordPatternItem p =
+and parseRecordPatternRow p =
   match p.Parser.token with
   | DotDotDot ->
     Parser.next p;
@@ -1236,7 +1236,7 @@ and parseRecordPattern ~attrs p =
   Parser.expect Lbrace p;
   let rawFields =
     parseCommaDelimitedReversedList p ~grammar:PatternRecord ~closing:Rbrace
-      ~f:parseRecordPatternItem
+      ~f:parseRecordPatternRow
   in
   Parser.expect Rbrace p;
   let fields, closedFlag =

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2717,7 +2717,8 @@ and printExpression (e : Parsetree.expression) cmtTbl =
                     Doc.join
                       ~sep:(Doc.concat [Doc.text ","; Doc.line])
                       (List.map
-                         (fun row -> printRecordRow row cmtTbl punningAllowed)
+                         (fun row ->
+                           printExpressionRecordRow row cmtTbl punningAllowed)
                          rows);
                   ]);
              Doc.trailingComma;
@@ -4639,7 +4640,7 @@ and printDirectionFlag flag =
   | Asttypes.Downto -> Doc.text " downto "
   | Asttypes.Upto -> Doc.text " to "
 
-and printRecordRow (lbl, expr) cmtTbl punningAllowed =
+and printExpressionRecordRow (lbl, expr) cmtTbl punningAllowed =
   let cmtLoc = {lbl.loc with loc_end = expr.pexp_loc.loc_end} in
   let doc =
     Doc.group

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -2342,9 +2342,10 @@ and printPatternRecordRow row cmtTbl =
   match row with
   (* punned {x}*)
   | ( ({Location.txt = Longident.Lident ident} as longident),
-      {Parsetree.ppat_desc = Ppat_var {txt; _}} )
+      {Parsetree.ppat_desc = Ppat_var {txt; _}; ppat_attributes} )
     when ident = txt ->
-    printLidentPath longident cmtTbl
+    Doc.concat
+      [printAttributes ppat_attributes cmtTbl; printLidentPath longident cmtTbl]
   | longident, pattern ->
     let locForComments =
       {longident.loc with loc_end = pattern.Parsetree.ppat_loc.loc_end}
@@ -4646,7 +4647,11 @@ and printRecordRow (lbl, expr) cmtTbl punningAllowed =
       | Pexp_ident {txt = Lident key; loc = _keyLoc}
         when punningAllowed && Longident.last lbl.txt = key ->
         (* print punned field *)
-        printLidentPath lbl cmtTbl
+        Doc.concat
+          [
+            printAttributes expr.pexp_attributes cmtTbl;
+            printLidentPath lbl cmtTbl;
+          ]
       | _ ->
         Doc.concat
           [

--- a/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -12,3 +12,15 @@ let r = { expr with pexp_attributes = [||]; pexp_loc = loc }
 let r = { expr with pexp_attributes = [||] }
 let r = { (make () : myRecord) with foo = bar }
 let r = { (make () : myRecord) with foo = bar }
+let r =
+  {
+    x = ((None)[@optional ]);
+    y = ((None)[@optional ]);
+    z = ((None)[@optional ])
+  }
+let z name = { name = ((name)[@optional ]); x = 3 }
+let _ =
+  match z with
+  | { x = ((None)[@optional ]); y = ((None)[@optional ]);
+      z = ((None)[@optional ]) } -> 11
+  | { name = ((name)[@optional ]); x = 3 } -> 42

--- a/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -24,3 +24,4 @@ let _ =
   | { x = ((None)[@optional ]); y = ((None)[@optional ]);
       z = ((None)[@optional ]) } -> 11
   | { name = ((name)[@optional ]); x = 3 } -> 42
+  | { name = ((name)[@optional ]); x = 3 } -> 4242

--- a/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -19,6 +19,7 @@ let r =
     z = ((None)[@optional ])
   }
 let z name = { name = ((name)[@optional ]); x = 3 }
+let z name = { name = ((name)[@optional ]); x = 3 }
 let z name = { name; x = ((x)[@optional ]) }
 let _ =
   match z with

--- a/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -19,6 +19,7 @@ let r =
     z = ((None)[@optional ])
   }
 let z name = { name = ((name)[@optional ]); x = 3 }
+let z name = { name; x = ((x)[@optional ]) }
 let _ =
   match z with
   | { x = ((None)[@optional ]); y = ((None)[@optional ]);

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -23,3 +23,12 @@ let r = {...expr, pexp_attributes: [],} // trailing comma
 // with type constraint on spread
 let r = {...make() : myRecord, foo: bar}
 let r = {...(make() : myRecord), foo: bar} // parens optional
+
+let r = {x: @optional None, y: @optional None, z: @optional None}
+
+let z = name => { name : @optional name, x: 3}
+
+let _ = switch z {
+  | {x: @optional None, y: @optional None, z: @optional None} => 11
+  | {name:  @optional name, x: 3} => 42
+}

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -30,6 +30,8 @@ let z = name => { name : @optional name, x: 3}
 
 // let z = name => { @optional name, x: 3}
 
+// let z = name => { name, @optional x }
+
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11
   | {name:  @optional name, x: 3} => 42

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -31,4 +31,5 @@ let z = name => { name : @optional name, x: 3}
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11
   | {name:  @optional name, x: 3} => 42
+//  | {@optional name, x: 3} => 4242
 }

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -30,7 +30,7 @@ let z = name => { name : @optional name, x: 3}
 
 // let z = name => { @optional name, x: 3}
 
-// let z = name => { name, @optional x }
+let z = name => { name, @optional x }
 
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -28,7 +28,7 @@ let r = {x: @optional None, y: @optional None, z: @optional None}
 
 let z = name => { name : @optional name, x: 3}
 
-// let z = name => { @optional name, x: 3}
+let z = name => { @optional name, x: 3}
 
 let z = name => { name, @optional x }
 

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -31,5 +31,5 @@ let z = name => { name : @optional name, x: 3}
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11
   | {name:  @optional name, x: 3} => 42
-//  | {@optional name, x: 3} => 4242
+  | {@optional name, x: 3} => 4242
 }

--- a/tests/parsing/grammar/expressions/record.res
+++ b/tests/parsing/grammar/expressions/record.res
@@ -28,6 +28,8 @@ let r = {x: @optional None, y: @optional None, z: @optional None}
 
 let z = name => { name : @optional name, x: 3}
 
+// let z = name => { @optional name, x: 3}
+
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11
   | {name:  @optional name, x: 3} => 42

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -76,9 +76,10 @@ let r = {a /* a */, b /* b */}
 
 let r = {x: @optional None, y: @optional None, z: @optional None}
 
-let z = name => {name, x: 3}
+let z = name => {@optional name, x: 3}
 
 let _ = switch z {
 | {x: @optional None, y: @optional None, z: @optional None} => 11
-| {name, x: 3} => 42
+| {@optional name, x: 3} => 42
+| {name: @optional dd, x: 3} => 42
 }

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -80,7 +80,7 @@ let z = name => {@optional name, x: 3}
 
 let z = name => {@optional name, x: 3}
 
-// let z = name => { @optional name, x: 3}
+let z = name => {name, @optional x}
 
 let _ = switch z {
 | {x: @optional None, y: @optional None, z: @optional None} => 11

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -78,6 +78,10 @@ let r = {x: @optional None, y: @optional None, z: @optional None}
 
 let z = name => {@optional name, x: 3}
 
+let z = name => {@optional name, x: 3}
+
+// let z = name => { @optional name, x: 3}
+
 let _ = switch z {
 | {x: @optional None, y: @optional None, z: @optional None} => 11
 | {@optional name, x: 3} => 42

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -73,3 +73,12 @@ let r = {
   b /* b */,
 }
 let r = {a /* a */, b /* b */}
+
+let r = {x: @optional None, y: @optional None, z: @optional None}
+
+let z = name => {name, x: 3}
+
+let _ = switch z {
+| {x: @optional None, y: @optional None, z: @optional None} => 11
+| {name, x: 3} => 42
+}

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -68,9 +68,9 @@ let r = {x: @optional None, y: @optional None, z: @optional None}
 
 let z = name => { name : @optional name, x: 3}
 
-let z = name => { name : @optional name, x: 3}
+let z = name => { @optional name, x: 3}
 
-// let z = name => { @optional name, x: 3}
+let z = name => { name, @optional x }
 
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -63,3 +63,12 @@ let r = {
   b /* b */,
 }
 let r = {a /* a */, b /* b */}
+
+let r = {x: @optional None, y: @optional None, z: @optional None}
+
+let z = name => { name : @optional name, x: 3}
+
+let _ = switch z {
+  | {x: @optional None, y: @optional None, z: @optional None} => 11
+  | {name:  @optional name, x: 3} => 42
+}

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -68,6 +68,10 @@ let r = {x: @optional None, y: @optional None, z: @optional None}
 
 let z = name => { name : @optional name, x: 3}
 
+let z = name => { name : @optional name, x: 3}
+
+// let z = name => { @optional name, x: 3}
+
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11
   | {name:  @optional name, x: 3} => 42

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -71,4 +71,5 @@ let z = name => { name : @optional name, x: 3}
 let _ = switch z {
   | {x: @optional None, y: @optional None, z: @optional None} => 11
   | {name:  @optional name, x: 3} => 42
+  | {name:  @optional dd, x: 3} => 42
 }


### PR DESCRIPTION
Add examples of expression and patterns showing where they are dropped.
Support all the cases discussed in https://github.com/rescript-lang/syntax/issues/583