### PR TITLE
Done, but do not merge yet: Async/Await syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,39 @@
-## Unreleased
+## Master
 
-* Fix printing for inline nullary functor types [#477](https://github.com/rescript-lang/syntax/pull/477)
-* Fix stripping of quotes for empty poly variants [#474](https://github.com/rescript-lang/syntax/pull/474)
-* Implement syntax for arity zero vs arity one in uncurried application in [#139](https://github.com/rescript-lang/syntax/pull/139)
-* Fix parsing of first class module exprs as part of binary/ternary expr in [#256](https://github.com/rescript-lang/syntax/pull/256)
-* Fix formatter hanging on deeply nested function calls [#261](https://github.com/rescript-lang/syntax/issues/261)
-* Remove parsing of "import" and "export" which was never officially supported.
+#### :rocket: New Feature
+
+- Add surface syntax for `async`/`await` https://github.com/rescript-lang/syntax/pull/600
+
+## ReScript 10.0
+
+- Fix printing for inline nullary functor types [#477](https://github.com/rescript-lang/syntax/pull/477)
+- Fix stripping of quotes for empty poly variants [#474](https://github.com/rescript-lang/syntax/pull/474)
+- Implement syntax for arity zero vs arity one in uncurried application in [#139](https://github.com/rescript-lang/syntax/pull/139)
+- Fix parsing of first class module exprs as part of binary/ternary expr in [#256](https://github.com/rescript-lang/syntax/pull/256)
+- Fix formatter hanging on deeply nested function calls [#261](https://github.com/rescript-lang/syntax/issues/261)
+- Remove parsing of "import" and "export" which was never officially supported.
 
 ## ReScript 9.0.0
 
-* Fix parsing of poly-var typexpr consisting of one tag-spec-first in [#254](https://github.com/rescript-lang/syntax/pull/254)
-* Implement new syntax for guards on pattern match cases in [#248](https://github.com/rescript-lang/syntax/pull/248)
-* Implement intelligent breaking for poly-var type expressions in [#246](https://github.com/rescript-lang/syntax/pull/246)
-* Improve indentation of fast pipe chain in let binding in [#244](https://github.com/rescript-lang/syntax/pull/244)
-* Improve printing of non-callback arguments in call expressions with callback in [#241](https://github.com/rescript-lang/syntax/pull/241/files)
-* Fix printing of constrained expressions in rhs of js objects [#240](https://github.com/rescript-lang/syntax/pull/240)
-* Improve printing of trailing comments under lhs of "pipe" expression in [#329](https://github.com/rescript-lang/syntax/pull/239/files)
-* Improve printing of jsx children and props with leading line comment in [#236](https://github.com/rescript-lang/syntax/pull/236)
-* Improve conversion of quoted strings from Reason in [#238](https://github.com/rescript-lang/syntax/pull/238)
-* Print attributes/extension without bs prefix where possible in [#230](https://github.com/rescript-lang/syntax/pull/230)
-* Cleanup gentype attribute printing [fe05e1051aa94b16f6993ddc5ba9651f89e86907](https://github.com/rescript-lang/syntax/commit/fe05e1051aa94b16f6993ddc5ba9651f89e86907)
-* Implement light weight syntax for poly-variants [f84c5760b3f743f65e934195c87fc06bf88bff75](https://github.com/rescript-lang/syntax/commit/f84c5760b3f743f65e934195c87fc06bf88bff75)
-* Fix bug in fast pipe conversion from Reason. [3d5f2daba5418b821c577ba03e2de1afb0dd66de](https://github.com/rescript-lang/syntax/commit/3d5f2daba5418b821c577ba03e2de1afb0dd66de)
-* Improve parsed AST when tilde is missing in arrow expr parameters. [e52a0c89ac39b578a2062ef15fae2be625962e1f](https://github.com/rescript-lang/syntax/commit/e52a0c89ac39b578a2062ef15fae2be625962e1f)
-* Improve parser diagnostics for missing tilde in labeled parameters. [a0d7689d5d2bfc31dc251e966ac33a3001200171](https://github.com/rescript-lang/syntax/commit/a0d7689d5d2bfc31dc251e966ac33a3001200171)
-* Improve printing of uncurried application with a huggable expression in [c8767215186982e171fe9f9101d518150a65f0d7](https://github.com/rescript-lang/syntax/commit/c8767215186982e171fe9f9101d518150a65f0d7)
-* Improve printing of uncurried arrow typexpr outcome printer in [4d953b668cf47358deccb8b730566f24de25b9ee](https://github.com/rescript-lang/syntax/commit/4d953b668cf47358deccb8b730566f24de25b9ee)
-* Remove support for nativeint syntax in [72d9b7034fc28f317672c94994b322bee520acca](https://github.com/rescript-lang/syntax/commit/72d9b7034fc28f317672c94994b322bee520acca)
-* Improve printing of poly variant typexprs with attributes in [bf6561b](https://github.com/rescript-lang/syntax/commit/bf6561bb5d84557b8b6cbbcd40078c39526af4af) 
-
+- Fix parsing of poly-var typexpr consisting of one tag-spec-first in [#254](https://github.com/rescript-lang/syntax/pull/254)
+- Implement new syntax for guards on pattern match cases in [#248](https://github.com/rescript-lang/syntax/pull/248)
+- Implement intelligent breaking for poly-var type expressions in [#246](https://github.com/rescript-lang/syntax/pull/246)
+- Improve indentation of fast pipe chain in let binding in [#244](https://github.com/rescript-lang/syntax/pull/244)
+- Improve printing of non-callback arguments in call expressions with callback in [#241](https://github.com/rescript-lang/syntax/pull/241/files)
+- Fix printing of constrained expressions in rhs of js objects [#240](https://github.com/rescript-lang/syntax/pull/240)
+- Improve printing of trailing comments under lhs of "pipe" expression in [#329](https://github.com/rescript-lang/syntax/pull/239/files)
+- Improve printing of jsx children and props with leading line comment in [#236](https://github.com/rescript-lang/syntax/pull/236)
+- Improve conversion of quoted strings from Reason in [#238](https://github.com/rescript-lang/syntax/pull/238)
+- Print attributes/extension without bs prefix where possible in [#230](https://github.com/rescript-lang/syntax/pull/230)
+- Cleanup gentype attribute printing [fe05e1051aa94b16f6993ddc5ba9651f89e86907](https://github.com/rescript-lang/syntax/commit/fe05e1051aa94b16f6993ddc5ba9651f89e86907)
+- Implement light weight syntax for poly-variants [f84c5760b3f743f65e934195c87fc06bf88bff75](https://github.com/rescript-lang/syntax/commit/f84c5760b3f743f65e934195c87fc06bf88bff75)
+- Fix bug in fast pipe conversion from Reason. [3d5f2daba5418b821c577ba03e2de1afb0dd66de](https://github.com/rescript-lang/syntax/commit/3d5f2daba5418b821c577ba03e2de1afb0dd66de)
+- Improve parsed AST when tilde is missing in arrow expr parameters. [e52a0c89ac39b578a2062ef15fae2be625962e1f](https://github.com/rescript-lang/syntax/commit/e52a0c89ac39b578a2062ef15fae2be625962e1f)
+- Improve parser diagnostics for missing tilde in labeled parameters. [a0d7689d5d2bfc31dc251e966ac33a3001200171](https://github.com/rescript-lang/syntax/commit/a0d7689d5d2bfc31dc251e966ac33a3001200171)
+- Improve printing of uncurried application with a huggable expression in [c8767215186982e171fe9f9101d518150a65f0d7](https://github.com/rescript-lang/syntax/commit/c8767215186982e171fe9f9101d518150a65f0d7)
+- Improve printing of uncurried arrow typexpr outcome printer in [4d953b668cf47358deccb8b730566f24de25b9ee](https://github.com/rescript-lang/syntax/commit/4d953b668cf47358deccb8b730566f24de25b9ee)
+- Remove support for nativeint syntax in [72d9b7034fc28f317672c94994b322bee520acca](https://github.com/rescript-lang/syntax/commit/72d9b7034fc28f317672c94994b322bee520acca)
+- Improve printing of poly variant typexprs with attributes in [bf6561b](https://github.com/rescript-lang/syntax/commit/bf6561bb5d84557b8b6cbbcd40078c39526af4af)
 
 ## ReScript 8.4.2 (December 11, 2020)
 

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -161,6 +161,8 @@ let uncurryAttr = (Location.mknoloc "bs", Parsetree.PStr [])
 let ternaryAttr = (Location.mknoloc "ns.ternary", Parsetree.PStr [])
 let ifLetAttr = (Location.mknoloc "ns.iflet", Parsetree.PStr [])
 let optionalAttr = (Location.mknoloc "ns.optional", Parsetree.PStr [])
+let makeAwaitAttr loc = (Location.mkloc "res.await" loc, Parsetree.PStr [])
+let makeAsyncAttr loc = (Location.mkloc "res.async" loc, Parsetree.PStr [])
 
 let makeExpressionOptional ~optional (e : Parsetree.expression) =
   if optional then {e with pexp_attributes = optionalAttr :: e.pexp_attributes}
@@ -3117,9 +3119,7 @@ and parseExprBlock ?first p =
 and parseAsyncArrowExpression p =
   let startPos = p.Parser.startPos in
   Parser.expect (Lident "async") p;
-  let asyncAttr =
-    (Location.mkloc "async" (mkLoc startPos p.prevEndPos), Parsetree.PStr [])
-  in
+  let asyncAttr = makeAsyncAttr (mkLoc startPos p.prevEndPos) in
   let expr = parseEs6ArrowExpression p in
   {
     expr with
@@ -3129,7 +3129,7 @@ and parseAsyncArrowExpression p =
 
 and parseAwaitExpression p =
   let awaitLoc = mkLoc p.Parser.startPos p.endPos in
-  let awaitAttr = (Location.mkloc "await" awaitLoc, Parsetree.PStr []) in
+  let awaitAttr = makeAwaitAttr awaitLoc in
   Parser.expect Await p;
   let expr = parseUnaryExpr p in
   {

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -237,11 +237,9 @@ let rec goToClosing closingToken state =
 (* Madness *)
 let isEs6ArrowExpression ~inTernary p =
   Parser.lookahead p (fun state ->
-      let () =
-        match state.Parser.token with
-        | Lident "async" -> Parser.next state
-        | _ -> ()
-      in
+      (match state.Parser.token with
+      | Lident "async" -> Parser.next state
+      | _ -> ());
       match state.Parser.token with
       | Lident _ | Underscore -> (
         Parser.next state;

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3118,19 +3118,16 @@ and parseExprBlock ?first p =
 
 and parseAsyncArrowExpression p =
   let startPos = p.Parser.startPos in
-  match p.token with
-  | Lident "async" ->
-    let asyncAttr =
-      (Location.mkloc "async" (mkLoc startPos p.endPos), Parsetree.PStr [])
-    in
-    Parser.next p;
-    let expr = parseEs6ArrowExpression p in
-    {
-      expr with
-      pexp_attributes = asyncAttr :: expr.pexp_attributes;
-      pexp_loc = {expr.pexp_loc with loc_start = startPos};
-    }
-  | _ -> assert false
+  Parser.expect (Lident "async") p;
+  let asyncAttr =
+    (Location.mkloc "async" (mkLoc startPos p.prevEndPos), Parsetree.PStr [])
+  in
+  let expr = parseEs6ArrowExpression p in
+  {
+    expr with
+    pexp_attributes = asyncAttr :: expr.pexp_attributes;
+    pexp_loc = {expr.pexp_loc with loc_start = startPos};
+  }
 
 and parseAwaitExpression p =
   let awaitLoc = mkLoc p.Parser.startPos p.endPos in

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2037,6 +2037,11 @@ and parseOperandExpr ~context p =
       let loc = mkLoc startPos p.prevEndPos in
       Ast_helper.Exp.assert_ ~loc expr
     | Lident "async"
+    (* we need to be careful when we're in a ternary true branch:
+       `condition ? ternary-true-branch : false-branch`
+       Arrow expressions could be of the form: `async (): int => stuff()`
+       But if we're in a ternary, the `:` of the ternary takes precedence
+    *)
       when isEs6ArrowExpression ~inTernary:(context = TernaryTrueBranchExpr) p
       ->
       parseAsyncArrowExpression p

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2031,6 +2031,17 @@ and parseOperandExpr ~context p =
       let expr = parseUnaryExpr p in
       let loc = mkLoc startPos p.prevEndPos in
       Ast_helper.Exp.assert_ ~loc expr
+    | Async ->
+      let asyncAttr =
+        (Location.mkloc "async" (mkLoc startPos p.endPos), Parsetree.PStr [])
+      in
+      Parser.next p;
+      let expr = parseEs6ArrowExpression p in
+      {
+        expr with
+        pexp_attributes = asyncAttr :: expr.pexp_attributes;
+        pexp_loc = {expr.pexp_loc with loc_start = startPos};
+      }
     | Await ->
       let awaitLoc = mkLoc startPos p.endPos in
       let awaitAttr = (Location.mkloc "await" awaitLoc, Parsetree.PStr []) in

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2759,6 +2759,14 @@ and parseBracedOrRecordExpr p =
     let expr = parseRecordExpr ~startPos [] p in
     Parser.expect Rbrace p;
     expr
+  (*
+    The branch below takes care of the "braced" expression {async}.
+    The big reason that we need all these branches is that {x} isn't a record with a punned field x, but a braced expression… There's lots of "ambiguity" between a record with a single punned field and a braced expression…
+    What is {x}?
+      1) record {x: x}
+      2) expression x which happens to wrapped in braces
+    Due to historical reasons, we always follow 2
+  *)
   | Lident "async" when isEs6ArrowExpression ~inTernary:false p ->
     let expr = parseAsyncArrowExpression p in
     let expr = parseExprBlock ~first:expr p in

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2031,6 +2031,16 @@ and parseOperandExpr ~context p =
       let expr = parseUnaryExpr p in
       let loc = mkLoc startPos p.prevEndPos in
       Ast_helper.Exp.assert_ ~loc expr
+    | Await ->
+      let awaitLoc = mkLoc startPos p.endPos in
+      let awaitAttr = (Location.mkloc "await" awaitLoc, Parsetree.PStr []) in
+      Parser.next p;
+      let expr = parseUnaryExpr p in
+      {
+        expr with
+        pexp_attributes = awaitAttr :: expr.pexp_attributes;
+        pexp_loc = {expr.pexp_loc with loc_start = awaitLoc.loc_start};
+      }
     | Lazy ->
       Parser.next p;
       let expr = parseUnaryExpr p in

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -255,11 +255,11 @@ let isAttributeStart = function
 let isJsxChildStart = isAtomicExprStart
 
 let isBlockExprStart = function
-  | Token.At | Hash | Percent | Minus | MinusDot | Plus | PlusDot | Bang | True
-  | False | Float _ | Int _ | String _ | Codepoint _ | Lident _ | Uident _
-  | Lparen | List | Lbracket | Lbrace | Forwardslash | Assert | Await | Lazy
-  | If | For | While | Switch | Open | Module | Exception | Let | LessThan
-  | Backtick | Try | Underscore ->
+  | Token.Assert | At | Await | Backtick | Bang | Codepoint _ | Exception
+  | False | Float _ | For | Forwardslash | Hash | If | Int _ | Lazy | Lbrace
+  | Lbracket | LessThan | Let | Lident _ | List | Lparen | Minus | MinusDot
+  | Module | Open | Percent | Plus | PlusDot | String _ | Switch | True | Try
+  | Uident _ | Underscore | While ->
     true
   | _ -> false
 

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -151,7 +151,7 @@ let isExprStart = function
   | Underscore (* _ => doThings() *)
   | Uident _ | Lident _ | Hash | Lparen | List | Module | Lbracket | Lbrace
   | LessThan | Minus | MinusDot | Plus | PlusDot | Bang | Percent | At | If
-  | Switch | While | For | Assert | Lazy | Try ->
+  | Switch | While | For | Assert | Lazy | Try | Await ->
     true
   | _ -> false
 

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -151,7 +151,7 @@ let isExprStart = function
   | Underscore (* _ => doThings() *)
   | Uident _ | Lident _ | Hash | Lparen | List | Module | Lbracket | Lbrace
   | LessThan | Minus | MinusDot | Plus | PlusDot | Bang | Percent | At | If
-  | Switch | While | For | Assert | Lazy | Try | Await ->
+  | Switch | While | For | Assert | Lazy | Try | Async | Await ->
     true
   | _ -> false
 

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -151,7 +151,7 @@ let isExprStart = function
   | Underscore (* _ => doThings() *)
   | Uident _ | Lident _ | Hash | Lparen | List | Module | Lbracket | Lbrace
   | LessThan | Minus | MinusDot | Plus | PlusDot | Bang | Percent | At | If
-  | Switch | While | For | Assert | Lazy | Try ->
+  | Switch | While | For | Assert | Await | Lazy | Try ->
     true
   | _ -> false
 
@@ -257,9 +257,9 @@ let isJsxChildStart = isAtomicExprStart
 let isBlockExprStart = function
   | Token.At | Hash | Percent | Minus | MinusDot | Plus | PlusDot | Bang | True
   | False | Float _ | Int _ | String _ | Codepoint _ | Lident _ | Uident _
-  | Lparen | List | Lbracket | Lbrace | Forwardslash | Assert | Lazy | If | For
-  | While | Switch | Open | Module | Exception | Let | LessThan | Backtick | Try
-  | Underscore ->
+  | Lparen | List | Lbracket | Lbrace | Forwardslash | Assert | Await | Lazy
+  | If | For | While | Switch | Open | Module | Exception | Let | LessThan
+  | Backtick | Try | Underscore ->
     true
   | _ -> false
 

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -147,11 +147,11 @@ let isAtomicTypExprStart = function
   | _ -> false
 
 let isExprStart = function
-  | Token.True | False | Int _ | String _ | Float _ | Codepoint _ | Backtick
-  | Underscore (* _ => doThings() *)
-  | Uident _ | Lident _ | Hash | Lparen | List | Module | Lbracket | Lbrace
-  | LessThan | Minus | MinusDot | Plus | PlusDot | Bang | Percent | At | If
-  | Switch | While | For | Assert | Await | Lazy | Try ->
+  | Token.Assert | At | Await | Backtick | Bang | Codepoint _ | False | Float _
+  | For | Hash | If | Int _ | Lazy | Lbrace | Lbracket | LessThan | Lident _
+  | List | Lparen | Minus | MinusDot | Module | Percent | Plus | PlusDot
+  | String _ | Switch | True | Try | Uident _ | Underscore (* _ => doThings() *)
+  | While ->
     true
   | _ -> false
 

--- a/src/res_grammar.ml
+++ b/src/res_grammar.ml
@@ -151,7 +151,7 @@ let isExprStart = function
   | Underscore (* _ => doThings() *)
   | Uident _ | Lident _ | Hash | Lparen | List | Module | Lbracket | Lbrace
   | LessThan | Minus | MinusDot | Plus | PlusDot | Bang | Percent | At | If
-  | Switch | While | For | Assert | Lazy | Try | Async | Await ->
+  | Switch | While | For | Assert | Lazy | Try ->
     true
   | _ -> false
 

--- a/src/res_parens.ml
+++ b/src/res_parens.ml
@@ -45,6 +45,8 @@ let callExpr expr =
        | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
+    | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
+      Parenthesized
     | _ -> Nothing)
 
 let structureExpr expr =
@@ -96,6 +98,8 @@ let unaryExprOperand expr =
        | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
+    | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
+      Parenthesized
     | _ -> Nothing)
 
 let binaryExprOperand ~isLhs expr =
@@ -120,6 +124,8 @@ let binaryExprOperand ~isLhs expr =
     | expr when ParsetreeViewer.isBinaryExpression expr -> Parenthesized
     | expr when ParsetreeViewer.isTernaryExpr expr -> Parenthesized
     | {pexp_desc = Pexp_lazy _ | Pexp_assert _} when isLhs -> Parenthesized
+    | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
+      Parenthesized
     | {Parsetree.pexp_attributes = attrs} ->
       if ParsetreeViewer.hasPrintableAttributes attrs then Parenthesized
       else Nothing)
@@ -196,6 +202,8 @@ let lazyOrAssertExprRhs expr =
        | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
+    | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
+      Parenthesized
     | _ -> Nothing)
 
 let isNegativeConstant constant =
@@ -239,6 +247,8 @@ let fieldExpr expr =
        | Pexp_match _ | Pexp_try _ | Pexp_while _ | Pexp_for _
        | Pexp_ifthenelse _ );
     } ->
+      Parenthesized
+    | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
       Parenthesized
     | _ -> Nothing)
 
@@ -302,6 +312,8 @@ let jsxPropExpr expr =
       }
         when startsWithMinus x ->
         Parenthesized
+      | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
+        Parenthesized
       | {
        Parsetree.pexp_desc =
          ( Pexp_ident _ | Pexp_constant _ | Pexp_field _ | Pexp_construct _
@@ -337,6 +349,8 @@ let jsxChildExpr expr =
        pexp_attributes = [];
       }
         when startsWithMinus x ->
+        Parenthesized
+      | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
         Parenthesized
       | {
        Parsetree.pexp_desc =

--- a/src/res_parens.ml
+++ b/src/res_parens.ml
@@ -175,7 +175,7 @@ let flattenOperandRhs parentOperator rhs =
   | _ when ParsetreeViewer.isTernaryExpr rhs -> true
   | _ -> false
 
-let lazyOrAssertExprRhs expr =
+let lazyOrAssertOrAwaitExprRhs expr =
   let optBraces, _ = ParsetreeViewer.processBracesAttr expr in
   match optBraces with
   | Some ({Location.loc = bracesLoc}, _) -> Braced bracesLoc

--- a/src/res_parens.mli
+++ b/src/res_parens.mli
@@ -10,7 +10,7 @@ val subBinaryExprOperand : string -> string -> bool
 val rhsBinaryExprOperand : string -> Parsetree.expression -> bool
 val flattenOperandRhs : string -> Parsetree.expression -> bool
 
-val lazyOrAssertExprRhs : Parsetree.expression -> kind
+val lazyOrAssertOrAwaitExprRhs : Parsetree.expression -> kind
 
 val fieldExpr : Parsetree.expression -> kind
 

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -532,6 +532,8 @@ let isPrintableAttribute attr =
 
 let hasPrintableAttributes attrs = List.exists isPrintableAttribute attrs
 
+let filterPrintableAttributes attrs = List.filter isPrintableAttribute attrs
+
 let partitionPrintableAttributes attrs =
   List.partition isPrintableAttribute attrs
 

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -65,6 +65,13 @@ let processFunctionAttributes attrs =
   in
   process false false [] attrs
 
+let hasAwaitAttribute attrs =
+  List.exists
+    (function
+      | {Location.txt = "await"}, _ -> true
+      | _ -> false)
+    attrs
+
 let collectListExpressions expr =
   let rec collect acc expr =
     match expr.pexp_desc with
@@ -178,8 +185,8 @@ let filterParsingAttrs attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "ns.ternary" | "ns.braces" | "res.template" | "bs" | "ns.iflet"
-              | "ns.namedArgLoc" | "ns.optional" );
+              ( "ns.ternary" | "ns.braces" | "res.template" | "await" | "bs"
+              | "ns.iflet" | "ns.namedArgLoc" | "ns.optional" );
           },
           _ ) ->
         false

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -55,10 +55,16 @@ let processUncurriedAttribute attrs =
   in
   process false [] attrs
 
+type functionAttributesInfo = {
+  async: bool;
+  uncurried: bool;
+  attributes: Parsetree.attributes;
+}
+
 let processFunctionAttributes attrs =
   let rec process async uncurried acc attrs =
     match attrs with
-    | [] -> (async, uncurried, List.rev acc)
+    | [] -> {async; uncurried; attributes = List.rev acc}
     | ({Location.txt = "bs"}, _) :: rest -> process async true acc rest
     | ({Location.txt = "async"}, _) :: rest -> process true uncurried acc rest
     | attr :: rest -> process async uncurried (attr :: acc) rest

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -192,9 +192,9 @@ let filterParsingAttrs attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "ns.ternary" | "ns.braces" | "res.template" | "res.await"
-              | "res.async" | "bs" | "ns.iflet" | "ns.namedArgLoc"
-              | "ns.optional" );
+              ( "bs" | "ns.braces" | "ns.iflet" | "ns.namedArgLoc"
+              | "ns.optional" | "ns.ternary" | "res.async" | "res.await"
+              | "res.template" );
           },
           _ ) ->
         false
@@ -341,8 +341,8 @@ let hasAttributes attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "bs" | "res.async" | "res.await" | "res.template" | "ns.ternary"
-              | "ns.braces" | "ns.iflet" );
+              ( "bs" | "ns.braces" | "ns.iflet" | "ns.ternary" | "res.async"
+              | "res.await" | "res.template" );
           },
           _ ) ->
         false

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -523,16 +523,14 @@ let isPrintableAttribute attr =
   match attr with
   | ( {
         Location.txt =
-          ( "bs" | "res.template" | "ns.ternary" | "ns.braces" | "ns.iflet"
-          | "JSX" );
+          ( "bs" | "ns.iflet" | "ns.braces" | "JSX" | "res.async" | "res.await"
+          | "res.template" | "ns.ternary" );
       },
       _ ) ->
     false
   | _ -> true
 
 let hasPrintableAttributes attrs = List.exists isPrintableAttribute attrs
-
-let filterPrintableAttributes attrs = List.filter isPrintableAttribute attrs
 
 let partitionPrintableAttributes attrs =
   List.partition isPrintableAttribute attrs

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -11,7 +11,7 @@ let arrowType ct =
       process attrsBefore (arg :: acc) typ2
     | {
      ptyp_desc = Ptyp_arrow ((Nolabel as lbl), typ1, typ2);
-     ptyp_attributes = [({txt = "bs" | "async"}, _)] as attrs;
+     ptyp_attributes = [({txt = "bs" | "res.async"}, _)] as attrs;
     } ->
       let arg = (attrs, lbl, typ1) in
       process attrsBefore (arg :: acc) typ2
@@ -66,7 +66,8 @@ let processFunctionAttributes attrs =
     match attrs with
     | [] -> {async; uncurried; attributes = List.rev acc}
     | ({Location.txt = "bs"}, _) :: rest -> process async true acc rest
-    | ({Location.txt = "async"}, _) :: rest -> process true uncurried acc rest
+    | ({Location.txt = "res.async"}, _) :: rest ->
+      process true uncurried acc rest
     | attr :: rest -> process async uncurried (attr :: acc) rest
   in
   process false false [] attrs
@@ -74,7 +75,7 @@ let processFunctionAttributes attrs =
 let hasAwaitAttribute attrs =
   List.exists
     (function
-      | {Location.txt = "await"}, _ -> true
+      | {Location.txt = "res.await"}, _ -> true
       | _ -> false)
     attrs
 
@@ -191,8 +192,9 @@ let filterParsingAttrs attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "ns.ternary" | "ns.braces" | "res.template" | "await" | "bs"
-              | "ns.iflet" | "ns.namedArgLoc" | "ns.optional" );
+              ( "ns.ternary" | "ns.braces" | "res.template" | "res.await"
+              | "res.async" | "bs" | "ns.iflet" | "ns.namedArgLoc"
+              | "ns.optional" );
           },
           _ ) ->
         false
@@ -339,8 +341,8 @@ let hasAttributes attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "bs" | "async" | "res.template" | "ns.ternary" | "ns.braces"
-              | "ns.iflet" );
+              ( "bs" | "res.async" | "res.await" | "res.template" | "ns.ternary"
+              | "ns.braces" | "ns.iflet" );
           },
           _ ) ->
         false

--- a/src/res_parsetree_viewer.mli
+++ b/src/res_parsetree_viewer.mli
@@ -99,6 +99,7 @@ val hasOptionalAttribute : Parsetree.attributes -> bool
 val shouldIndentBinaryExpr : Parsetree.expression -> bool
 val shouldInlineRhsBinaryExpr : Parsetree.expression -> bool
 val hasPrintableAttributes : Parsetree.attributes -> bool
+val filterPrintableAttributes : Parsetree.attributes -> Parsetree.attributes
 val partitionPrintableAttributes :
   Parsetree.attributes -> Parsetree.attributes * Parsetree.attributes
 

--- a/src/res_parsetree_viewer.mli
+++ b/src/res_parsetree_viewer.mli
@@ -17,6 +17,11 @@ val functorType :
 val processUncurriedAttribute :
   Parsetree.attributes -> bool * Parsetree.attributes
 
+(* determines whether a function is async and/or uncurried based on the given attributes *)
+val processFunctionAttributes :
+  Parsetree.attributes ->
+  bool (* async *) * bool (* uncurried *) * Parsetree.attributes
+
 type ifConditionKind =
   | If of Parsetree.expression
   | IfLet of Parsetree.pattern * Parsetree.expression

--- a/src/res_parsetree_viewer.mli
+++ b/src/res_parsetree_viewer.mli
@@ -17,10 +17,14 @@ val functorType :
 val processUncurriedAttribute :
   Parsetree.attributes -> bool * Parsetree.attributes
 
+type functionAttributesInfo = {
+  async: bool;
+  uncurried: bool;
+  attributes: Parsetree.attributes;
+}
+
 (* determines whether a function is async and/or uncurried based on the given attributes *)
-val processFunctionAttributes :
-  Parsetree.attributes ->
-  bool (* async *) * bool (* uncurried *) * Parsetree.attributes
+val processFunctionAttributes : Parsetree.attributes -> functionAttributesInfo
 
 val hasAwaitAttribute : Parsetree.attributes -> bool
 

--- a/src/res_parsetree_viewer.mli
+++ b/src/res_parsetree_viewer.mli
@@ -22,6 +22,8 @@ val processFunctionAttributes :
   Parsetree.attributes ->
   bool (* async *) * bool (* uncurried *) * Parsetree.attributes
 
+val hasAwaitAttribute : Parsetree.attributes -> bool
+
 type ifConditionKind =
   | If of Parsetree.expression
   | IfLet of Parsetree.pattern * Parsetree.expression

--- a/src/res_parsetree_viewer.mli
+++ b/src/res_parsetree_viewer.mli
@@ -99,7 +99,6 @@ val hasOptionalAttribute : Parsetree.attributes -> bool
 val shouldIndentBinaryExpr : Parsetree.expression -> bool
 val shouldInlineRhsBinaryExpr : Parsetree.expression -> bool
 val hasPrintableAttributes : Parsetree.attributes -> bool
-val filterPrintableAttributes : Parsetree.attributes -> Parsetree.attributes
 val partitionPrintableAttributes :
   Parsetree.attributes -> Parsetree.attributes * Parsetree.attributes
 

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3135,7 +3135,7 @@ and printExpression ~customLayout (e : Parsetree.expression) cmtTbl =
         cmtTbl
     | Pexp_fun _ | Pexp_newtype _ ->
       let attrsOnArrow, parameters, returnExpr = ParsetreeViewer.funExpr e in
-      let async, uncurried, attrs =
+      let ParsetreeViewer.{async; uncurried; attributes = attrs} =
         ParsetreeViewer.processFunctionAttributes attrsOnArrow
       in
       let returnExpr, typConstraint =
@@ -3302,7 +3302,7 @@ and printExpression ~customLayout (e : Parsetree.expression) cmtTbl =
 
 and printPexpFun ~customLayout ~inCallback e cmtTbl =
   let attrsOnArrow, parameters, returnExpr = ParsetreeViewer.funExpr e in
-  let async, uncurried, attrs =
+  let ParsetreeViewer.{async; uncurried; attributes = attrs} =
     ParsetreeViewer.processFunctionAttributes attrsOnArrow
   in
   let returnExpr, typConstraint =

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3278,6 +3278,11 @@ and printExpression ~customLayout (e : Parsetree.expression) cmtTbl =
     | Pexp_poly _ -> Doc.text "Pexp_poly not impemented in printer"
     | Pexp_object _ -> Doc.text "Pexp_object not impemented in printer"
   in
+  let exprWithAwait =
+    if ParsetreeViewer.hasAwaitAttribute e.pexp_attributes then
+      Doc.concat [Doc.text "await "; printedExpression]
+    else printedExpression
+  in
   let shouldPrintItsOwnAttributes =
     match e.pexp_desc with
     | Pexp_apply _ | Pexp_fun _ | Pexp_newtype _ | Pexp_setfield _
@@ -3289,12 +3294,11 @@ and printExpression ~customLayout (e : Parsetree.expression) cmtTbl =
     | _ -> false
   in
   match e.pexp_attributes with
-  | [] -> printedExpression
+  | [] -> exprWithAwait
   | attrs when not shouldPrintItsOwnAttributes ->
     Doc.group
-      (Doc.concat
-         [printAttributes ~customLayout attrs cmtTbl; printedExpression])
-  | _ -> printedExpression
+      (Doc.concat [printAttributes ~customLayout attrs cmtTbl; exprWithAwait])
+  | _ -> exprWithAwait
 
 and printPexpFun ~customLayout ~inCallback e cmtTbl =
   let attrsOnArrow, parameters, returnExpr = ParsetreeViewer.funExpr e in

--- a/src/res_token.ml
+++ b/src/res_token.ml
@@ -1,8 +1,6 @@
 module Comment = Res_comment
 
 type t =
-  | Async
-  | Await
   | Open
   | True
   | False
@@ -113,8 +111,6 @@ let precedence = function
   | _ -> 0
 
 let toString = function
-  | Async -> "async"
-  | Await -> "await"
   | Open -> "open"
   | True -> "true"
   | False -> "false"
@@ -211,8 +207,6 @@ let toString = function
   | ModuleComment (_loc, s) -> "ModuleComment " ^ s
 
 let keywordTable = function
-  | "async" -> Async
-  | "await" -> Await
   | "and" -> And
   | "as" -> As
   | "assert" -> Assert
@@ -244,10 +238,9 @@ let keywordTable = function
   [@@raises Not_found]
 
 let isKeyword = function
-  | Async | Await | And | As | Assert | Constraint | Else | Exception | External
-  | False | For | If | In | Include | Land | Lazy | Let | List | Lor | Module
-  | Mutable | Of | Open | Private | Rec | Switch | True | Try | Typ | When
-  | While ->
+  | And | As | Assert | Constraint | Else | Exception | External | False | For
+  | If | In | Include | Land | Lazy | Let | List | Lor | Module | Mutable | Of
+  | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
     true
   | _ -> false
 

--- a/src/res_token.ml
+++ b/src/res_token.ml
@@ -1,6 +1,7 @@
 module Comment = Res_comment
 
 type t =
+  | Await
   | Open
   | True
   | False
@@ -111,6 +112,7 @@ let precedence = function
   | _ -> 0
 
 let toString = function
+  | Await -> "await"
   | Open -> "open"
   | True -> "true"
   | False -> "false"
@@ -210,6 +212,7 @@ let keywordTable = function
   | "and" -> And
   | "as" -> As
   | "assert" -> Assert
+  | "await" -> Await
   | "constraint" -> Constraint
   | "else" -> Else
   | "exception" -> Exception
@@ -238,9 +241,9 @@ let keywordTable = function
   [@@raises Not_found]
 
 let isKeyword = function
-  | And | As | Assert | Constraint | Else | Exception | External | False | For
-  | If | In | Include | Land | Lazy | Let | List | Lor | Module | Mutable | Of
-  | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
+  | Await | And | As | Assert | Constraint | Else | Exception | External | False
+  | For | If | In | Include | Land | Lazy | Let | List | Lor | Module | Mutable
+  | Of | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
     true
   | _ -> false
 

--- a/src/res_token.ml
+++ b/src/res_token.ml
@@ -1,6 +1,7 @@
 module Comment = Res_comment
 
 type t =
+  | Await
   | Open
   | True
   | False
@@ -111,6 +112,7 @@ let precedence = function
   | _ -> 0
 
 let toString = function
+  | Await -> "await"
   | Open -> "open"
   | True -> "true"
   | False -> "false"
@@ -207,6 +209,7 @@ let toString = function
   | ModuleComment (_loc, s) -> "ModuleComment " ^ s
 
 let keywordTable = function
+  | "await" -> Await
   | "and" -> And
   | "as" -> As
   | "assert" -> Assert
@@ -238,9 +241,9 @@ let keywordTable = function
   [@@raises Not_found]
 
 let isKeyword = function
-  | And | As | Assert | Constraint | Else | Exception | External | False | For
-  | If | In | Include | Land | Lazy | Let | List | Lor | Module | Mutable | Of
-  | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
+  | Await | And | As | Assert | Constraint | Else | Exception | External | False
+  | For | If | In | Include | Land | Lazy | Let | List | Lor | Module | Mutable
+  | Of | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
     true
   | _ -> false
 

--- a/src/res_token.ml
+++ b/src/res_token.ml
@@ -1,6 +1,7 @@
 module Comment = Res_comment
 
 type t =
+  | Async
   | Await
   | Open
   | True
@@ -112,6 +113,7 @@ let precedence = function
   | _ -> 0
 
 let toString = function
+  | Async -> "async"
   | Await -> "await"
   | Open -> "open"
   | True -> "true"
@@ -209,6 +211,7 @@ let toString = function
   | ModuleComment (_loc, s) -> "ModuleComment " ^ s
 
 let keywordTable = function
+  | "async" -> Async
   | "await" -> Await
   | "and" -> And
   | "as" -> As
@@ -241,9 +244,10 @@ let keywordTable = function
   [@@raises Not_found]
 
 let isKeyword = function
-  | Await | And | As | Assert | Constraint | Else | Exception | External | False
-  | For | If | In | Include | Land | Lazy | Let | List | Lor | Module | Mutable
-  | Of | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
+  | Async | Await | And | As | Assert | Constraint | Else | Exception | External
+  | False | For | If | In | Include | Land | Lazy | Let | List | Lor | Module
+  | Mutable | Of | Open | Private | Rec | Switch | True | Try | Typ | When
+  | While ->
     true
   | _ -> false
 

--- a/test.res
+++ b/test.res
@@ -1,2 +1,0 @@
-let f = (.) => ()
-let f = async () => delay(20)

--- a/test.res
+++ b/test.res
@@ -1,0 +1,2 @@
+let f = (.) => ()
+let f = async () => delay(20)

--- a/tests/parsing/grammar/expressions/async.res
+++ b/tests/parsing/grammar/expressions/async.res
@@ -1,0 +1,10 @@
+let greetUser = async (userId) => {
+  let name = await getUserName(. userId)  
+  "Hello " ++ name ++ "!"
+}
+
+async () => 123
+
+let fetch = {
+    async (. url) => browserFetch(. url)
+}

--- a/tests/parsing/grammar/expressions/async.res
+++ b/tests/parsing/grammar/expressions/async.res
@@ -25,3 +25,5 @@ let async = {
 
     result->async->mapAsync(a => doStuff(a))
 }
+
+let f = isPositive ? (async (a, b) : int => a + b) : async (c, d) : int => c - d

--- a/tests/parsing/grammar/expressions/async.res
+++ b/tests/parsing/grammar/expressions/async.res
@@ -13,3 +13,15 @@ let fetch2 = {
     async (. url) => browserFetch(. url)
     async (. url) => browserFetch2(. url)
 }
+
+// don't parse async es6 arrow
+let async = {
+    let f = async()
+    ()->async
+    async()
+    async.async
+
+    {async: async[async]}
+
+    result->async->mapAsync(a => doStuff(a))
+}

--- a/tests/parsing/grammar/expressions/async.res
+++ b/tests/parsing/grammar/expressions/async.res
@@ -8,3 +8,8 @@ async () => 123
 let fetch = {
     async (. url) => browserFetch(. url)
 }
+
+let fetch2 = {
+    async (. url) => browserFetch(. url)
+    async (. url) => browserFetch2(. url)
+}

--- a/tests/parsing/grammar/expressions/await.res
+++ b/tests/parsing/grammar/expressions/await.res
@@ -15,3 +15,12 @@ let () = {
   let comments = (await (await fetch("comment.json")).json())[0];
   Js.log2(users, comments)
 }
+
+let () = {
+    await delay(10)
+}
+
+let () = {
+    await delay(10)
+    await delay(20)
+}

--- a/tests/parsing/grammar/expressions/await.res
+++ b/tests/parsing/grammar/expressions/await.res
@@ -1,0 +1,17 @@
+await wait(2)
+
+let maybeSomeValue = switch await fetchData(url) {    
+| data => Some(data)
+| exception JsError(_) => None
+}
+
+let x = await 1 + 2
+
+let x = await wait(1) + await wait(2)
+
+let () = {
+  let response = await fetch("/users.json"); // get users list
+  let users = await response.json(); // parse JSON
+  let comments = (await (await fetch("comment.json")).json())[0];
+  Js.log2(users, comments)
+}

--- a/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -1,17 +1,17 @@
 let greetUser =
   ((fun userId ->
-      ((let name = ((getUserName userId)[@await ][@bs ]) in
+      ((let name = ((getUserName userId)[@res.await ][@bs ]) in
         ({js|Hello |js} ^ name) ^ {js|!|js})
       [@ns.braces ]))
-  [@async ])
-;;((fun () -> 123)[@async ])
+  [@res.async ])
+;;((fun () -> 123)[@res.async ])
 let fetch = ((fun url -> ((browserFetch url)[@bs ]))
-  [@ns.braces ][@async ][@bs ])
+  [@ns.braces ][@res.async ][@bs ])
 let fetch2 =
   (((((fun url -> ((browserFetch url)[@bs ])))
-    [@async ][@bs ]);
+    [@res.async ][@bs ]);
     (((fun url -> ((browserFetch2 url)[@bs ])))
-    [@async ][@bs ]))
+    [@res.async ][@bs ]))
   [@ns.braces ])
 let async =
   ((let f = async () in

--- a/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -1,0 +1,9 @@
+let greetUser =
+  ((fun userId ->
+      ((let name = ((getUserName userId)[@await ][@bs ]) in
+        ({js|Hello |js} ^ name) ^ {js|!|js})
+      [@ns.braces ]))
+  [@async ])
+;;((fun () -> 123)[@async ])
+let fetch = ((fun url -> ((browserFetch url)[@bs ]))
+  [@ns.braces ][@async ][@bs ])

--- a/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -13,3 +13,11 @@ let fetch2 =
     (((fun url -> ((browserFetch2 url)[@bs ])))
     [@async ][@bs ]))
   [@ns.braces ])
+let async =
+  ((let f = async () in
+    () |. async;
+    async ();
+    async.async;
+    { async = (async.(async)) };
+    (result |. async) |. (mapAsync (fun a -> doStuff a)))
+  [@ns.braces ])

--- a/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -7,3 +7,9 @@ let greetUser =
 ;;((fun () -> 123)[@async ])
 let fetch = ((fun url -> ((browserFetch url)[@bs ]))
   [@ns.braces ][@async ][@bs ])
+let fetch2 =
+  (((((fun url -> ((browserFetch url)[@bs ])))
+    [@async ][@bs ]);
+    (((fun url -> ((browserFetch2 url)[@bs ])))
+    [@async ][@bs ]))
+  [@ns.braces ])

--- a/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -21,3 +21,8 @@ let async =
     { async = (async.(async)) };
     (result |. async) |. (mapAsync (fun a -> doStuff a)))
   [@ns.braces ])
+let f =
+  ((if isPositive
+    then ((fun a -> fun b -> (a + b : int))[@res.async ])
+    else (((fun c -> fun d -> (c - d : int)))[@res.async ]))
+  [@ns.ternary ])

--- a/tests/parsing/grammar/expressions/expected/await.res.txt
+++ b/tests/parsing/grammar/expressions/expected/await.res.txt
@@ -12,3 +12,5 @@ let () =
       ((((fetch {js|comment.json|js})[@await ]).json ())[@await ]).(0) in
     Js.log2 users comments)
   [@ns.braces ])
+let () = ((delay 10)[@ns.braces ][@await ])
+let () = ((((delay 10)[@await ]); ((delay 20)[@await ]))[@ns.braces ])

--- a/tests/parsing/grammar/expressions/expected/await.res.txt
+++ b/tests/parsing/grammar/expressions/expected/await.res.txt
@@ -1,16 +1,18 @@
-;;((wait 2)[@await ])
+;;((wait 2)[@res.await ])
 let maybeSomeValue =
-  match ((fetchData url)[@await ]) with
+  match ((fetchData url)[@res.await ]) with
   | data -> Some data
   | exception JsError _ -> None
-let x = ((1)[@await ]) + 2
-let x = ((wait 1)[@await ]) + ((wait 2)[@await ])
+let x = ((1)[@res.await ]) + 2
+let x = ((wait 1)[@res.await ]) + ((wait 2)[@res.await ])
 let () =
-  ((let response = ((fetch {js|/users.json|js})[@await ]) in
-    let users = ((response.json ())[@await ]) in
+  ((let response = ((fetch {js|/users.json|js})[@res.await ]) in
+    let users = ((response.json ())[@res.await ]) in
     let comments =
-      ((((fetch {js|comment.json|js})[@await ]).json ())[@await ]).(0) in
+      ((((fetch {js|comment.json|js})[@res.await ]).json ())
+      [@res.await ]).(0) in
     Js.log2 users comments)
   [@ns.braces ])
-let () = ((delay 10)[@ns.braces ][@await ])
-let () = ((((delay 10)[@await ]); ((delay 20)[@await ]))[@ns.braces ])
+let () = ((delay 10)[@ns.braces ][@res.await ])
+let () = ((((delay 10)[@res.await ]); ((delay 20)[@res.await ]))
+  [@ns.braces ])

--- a/tests/parsing/grammar/expressions/expected/await.res.txt
+++ b/tests/parsing/grammar/expressions/expected/await.res.txt
@@ -1,0 +1,14 @@
+;;((wait 2)[@await ])
+let maybeSomeValue =
+  match ((fetchData url)[@await ]) with
+  | data -> Some data
+  | exception JsError _ -> None
+let x = ((1)[@await ]) + 2
+let x = ((wait 1)[@await ]) + ((wait 2)[@await ])
+let () =
+  ((let response = ((fetch {js|/users.json|js})[@await ]) in
+    let users = ((response.json ())[@await ]) in
+    let comments =
+      ((((fetch {js|comment.json|js})[@await ]).json ())[@await ]).(0) in
+    Js.log2 users comments)
+  [@ns.braces ])

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -11,3 +11,9 @@ let f = async (.) => ()
 let f = async f => f()
 let f = async (a, b) => a + b
 let f = async (. a, b) => a + b
+
+
+let maybeSomeValue = switch await fetchData(url) {    
+| data => Some(data)
+| exception JsError(_) => None
+}

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -17,3 +17,16 @@ let maybeSomeValue = switch await fetchData(url) {
 | data => Some(data)
 | exception JsError(_) => None
 }
+
+(await f)(a, b) 
+-(await f)
+await 1 + await 2
+
+lazy (await f())
+assert (await f())
+
+(await f).json()
+
+user.data = await fetch()
+
+<Navbar promise={await gc()}>{await weirdReactSuspenseApi}</Navbar>

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -34,4 +34,50 @@ user.data = await fetch()
 let inBinaryExpression = await x->Js.Promise.resolve + 1
 let inBinaryExpression = await x->Js.Promise.resolve + await y->Js.Promise.resolve
 
+let withCallback = async (. ()) => {
+    async (. x) => await (x->Js.promise.resolve) + 1
+}
+
 let () = await (await fetch(url))->(await resolve)
+
+let _ = await (1 + 1)
+let _ = await 1 + 1
+let _ = await (-1)
+let _ = await - 1
+let _ = await !ref 
+let _ = await f
+let _ = await %extension 
+let _ = await "test"
+let _ = await ((a, b) => a + b)
+let _ = await (async (a, b) => a + b)
+let _ = await (switch x { | A => () | B => ()})
+let _ = await [1, 2, 3]
+let _ = await (1, 2, 3)
+let _ = await {name: "Steve", age: 32}
+let _ = await (user.name = "Steve")
+let _ = await (if 20 { true } else {false})
+let _ = await (condition() ? true : false)
+let _ = await f(x)
+let _ = await f(. x)
+let _ = await (f(x) : Js.Promise.t<unit>)
+let _ = await (while true { infiniteLoop() })
+let _ = await (try ok() catch { | _  =>  logError() })
+let _ = await (for i in 0 to 10 { sideEffect()})
+let _ = await (lazy x)
+let _ = await (assert x)
+let _ = await promises[0]
+let _ = await promises["resolved"]
+let _ = await (promises["resolved"] = sideEffect())
+let _ = await (@attr expr)
+let _ = await module(Foo)
+let _ = await module(Foo: Bar)
+let _ = await Promise
+let _ = await Promise(status)
+
+// braces are being dropped, because the ast only has space to record braces surrounding the await
+let _ = await {x}
+// here braces stay, because of precedence
+let _ = await {
+    let x = 1
+    Js.Promise.resolve(x)
+}

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -1,0 +1,13 @@
+let sequentialAwait = async () => {
+  let result1 = await paused("first")
+  nodeJsAssert.equal(result1, "first")
+  
+  let result2 = await paused("second")
+  nodeJsAssert.equal(result2, "second")
+}
+
+let f = async () => ()
+let f = async (.) => ()
+let f = async f => f()
+let f = async (a, b) => a + b
+let f = async (. a, b) => a + b

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -30,3 +30,8 @@ assert (await f())
 user.data = await fetch()
 
 <Navbar promise={await gc()}>{await weirdReactSuspenseApi}</Navbar>
+
+let inBinaryExpression = await x->Js.Promise.resolve + 1
+let inBinaryExpression = await x->Js.Promise.resolve + await y->Js.Promise.resolve
+
+let () = await (await fetch(url))->(await resolve)

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -33,4 +33,73 @@ user.data = await fetch()
 let inBinaryExpression = (await x)->Js.Promise.resolve + 1
 let inBinaryExpression = (await x)->Js.Promise.resolve + (await y)->Js.Promise.resolve
 
+let withCallback = async (. ()) => {
+  async (. x) => await (x->Js.promise.resolve) + 1
+}
+
 let () = (await fetch(url))->(await resolve)
+
+let _ = await (1 + 1)
+let _ = (await 1) + 1
+let _ = await -1
+let _ = await -1
+let _ = await !ref
+let _ = await f
+let _ = await %extension
+let _ = await "test"
+let _ = await ((a, b) => a + b)
+let _ = await (async (a, b) => a + b)
+let _ = await (
+  switch x {
+  | A => ()
+  | B => ()
+  }
+)
+let _ = await [1, 2, 3]
+let _ = await (1, 2, 3)
+let _ = await {name: "Steve", age: 32}
+let _ = await (user.name = "Steve")
+let _ = await (
+  if 20 {
+    true
+  } else {
+    false
+  }
+)
+let _ = await (condition() ? true : false)
+let _ = await f(x)
+let _ = await f(. x)
+let _ = (await (f(x): Js.Promise.t<unit>))
+let _ = await (
+  while true {
+    infiniteLoop()
+  }
+)
+let _ = await (
+  try ok() catch {
+  | _ => logError()
+  }
+)
+let _ = await (
+  for i in 0 to 10 {
+    sideEffect()
+  }
+)
+let _ = await (lazy x)
+let _ = await (assert x)
+let _ = await promises[0]
+let _ = await promises["resolved"]
+let _ = await promises["resolved"] = sideEffect()
+let _ = @attr await (expr)
+let _ = await module(Foo)
+let _ = await module(Foo: Bar)
+let _ = await Promise
+let _ = await Promise(status)
+
+// braces are being dropped, because the ast only has space to record braces surrounding the await
+let _ = await x
+// here braces stay, because of precedence
+let _ = await {
+  let x = 1
+  Js.Promise.resolve(x)
+}

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -29,3 +29,8 @@ assert (await f())
 user.data = await fetch()
 
 <Navbar promise={await gc()}> {await weirdReactSuspenseApi} </Navbar>
+
+let inBinaryExpression = (await x)->Js.Promise.resolve + 1
+let inBinaryExpression = (await x)->Js.Promise.resolve + (await y)->Js.Promise.resolve
+
+let () = (await fetch(url))->(await resolve)

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -1,0 +1,13 @@
+let sequentialAwait = async () => {
+  let result1 = @await paused("first")
+  nodeJsAssert.equal(result1, "first")
+
+  let result2 = @await paused("second")
+  nodeJsAssert.equal(result2, "second")
+}
+
+let f = async () => ()
+let f = async (. ()) => ()
+let f = async (f) => f()
+let f = async (a, b) => a + b
+let f = async (. a, b) => a + b

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -1,8 +1,8 @@
 let sequentialAwait = async () => {
-  let result1 = @await paused("first")
+  let result1 = await paused("first")
   nodeJsAssert.equal(result1, "first")
 
-  let result2 = @await paused("second")
+  let result2 = await paused("second")
   nodeJsAssert.equal(result2, "second")
 }
 
@@ -11,3 +11,8 @@ let f = async (. ()) => ()
 let f = async (f) => f()
 let f = async (a, b) => a + b
 let f = async (. a, b) => a + b
+
+let maybeSomeValue = switch await fetchData(url) {
+| data => Some(data)
+| exception JsError(_) => None
+}

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -16,3 +16,16 @@ let maybeSomeValue = switch await fetchData(url) {
 | data => Some(data)
 | exception JsError(_) => None
 }
+
+(await f)(a, b)
+-(await f)
+(await 1) + (await 2)
+
+lazy (await f())
+assert (await f())
+
+(await f).json()
+
+user.data = await fetch()
+
+<Navbar promise={await gc()}> {await weirdReactSuspenseApi} </Navbar>


### PR DESCRIPTION
Async/await surface syntax cf. https://forum.rescript-lang.org/t/ann-async-await-is-coming-to-rescript/3488

* `async` is a "non-keyword" for backwards compatibility.
* `await` has been implemented as normal keyword. Turned out to be too difficult to move forward otherwise: https://github.com/rescript-lang/syntax/pull/600#issuecomment-1175832866
