### PR TITLE
Do not generate leading and trailing `""` in template expressions.

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -2158,8 +2158,10 @@ and parseTemplateExpr ?(prefix = "js") p =
         Ast_helper.Exp.constant ~attrs:[templateLiteralAttr] ~loc
           (Pconst_string (txt, Some prefix))
       in
-      Ast_helper.Exp.apply ~attrs:[templateLiteralAttr] ~loc hiddenOperator
-        [(Nolabel, acc); (Nolabel, str)]
+      if txt = "" then acc
+      else
+        Ast_helper.Exp.apply ~attrs:[templateLiteralAttr] ~loc hiddenOperator
+          [(Nolabel, acc); (Nolabel, str)]
     | TemplatePart txt ->
       Parser.next p;
       let loc = mkLoc startPos p.prevEndPos in
@@ -2201,9 +2203,11 @@ and parseTemplateExpr ?(prefix = "js") p =
         (Pconst_string (txt, Some prefix))
     in
     let next =
-      Ast_helper.Exp.apply ~attrs:[templateLiteralAttr] ~loc:fullLoc
-        hiddenOperator
-        [(Nolabel, str); (Nolabel, expr)]
+      if txt = "" then expr
+      else
+        Ast_helper.Exp.apply ~attrs:[templateLiteralAttr] ~loc:fullLoc
+          hiddenOperator
+          [(Nolabel, str); (Nolabel, expr)]
     in
     parseParts next
   | token ->

--- a/tests/parsing/errors/structure/expected/gh16B.res.txt
+++ b/tests/parsing/errors/structure/expected/gh16B.res.txt
@@ -15,9 +15,7 @@ open Ws
 let wss = Server.make { port = 82 }
 let address = wss |. Server.address
 let log msg =
-  Js.log
-    (((((({js|> Server: |js})[@res.template ]) ^ msg)[@res.template ]) ^
-        (({js||js})[@res.template ]))[@res.template ])
+  Js.log (((({js|> Server: |js})[@res.template ]) ^ msg)[@res.template ])
 ;;log
     (((((((((((({js|Running on: |js})[@res.template ]) ^ address.address)
               [@res.template ]) ^ (({js|:|js})[@res.template ]))

--- a/tests/parsing/grammar/expressions/expected/es6template.res.txt
+++ b/tests/parsing/grammar/expressions/expected/es6template.res.txt
@@ -4,62 +4,23 @@ let s = (({js|multi
 
 string
 |js})[@res.template ])
+let s = foo
+let s = (((({js|before|js})[@res.template ]) ^ foo)[@res.template ])
+let s = (((({js|before |js})[@res.template ]) ^ foo)[@res.template ])
+let s = (((({js|before  |js})[@res.template ]) ^ foo)[@res.template ])
+let s = ((foo ^ (({js|after|js})[@res.template ]))[@res.template ])
+let s = ((foo ^ (({js| after|js})[@res.template ]))[@res.template ])
+let s = ((foo ^ (({js|  after|js})[@res.template ]))[@res.template ])
+let s = ((foo ^ (({js||js})[@res.template ]))[@res.template ]) ^ bar
 let s =
-  (((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^ (({js||js})
-      [@res.template ]))
-  [@res.template ])
-let s =
-  (((((({js|before|js})[@res.template ]) ^ foo)[@res.template ]) ^
+  (((((foo ^ (({js||js})[@res.template ]))[@res.template ]) ^ bar) ^
       (({js||js})[@res.template ]))
-  [@res.template ])
+    [@res.template ]) ^ baz
+let s = ((foo ^ (({js| |js})[@res.template ]))[@res.template ]) ^ bar
 let s =
-  (((((({js|before |js})[@res.template ]) ^ foo)[@res.template ]) ^
-      (({js||js})[@res.template ]))
-  [@res.template ])
-let s =
-  (((((({js|before  |js})[@res.template ]) ^ foo)[@res.template ]) ^
-      (({js||js})[@res.template ]))
-  [@res.template ])
-let s =
-  (((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^ (({js|after|js})
-      [@res.template ]))
-  [@res.template ])
-let s =
-  (((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^
-      (({js| after|js})[@res.template ]))
-  [@res.template ])
-let s =
-  (((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^
-      (({js|  after|js})[@res.template ]))
-  [@res.template ])
-let s =
-  ((((((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^ (({js||js})
-         [@res.template ]))
-       [@res.template ]) ^ bar)
-      ^ (({js||js})[@res.template ]))
-  [@res.template ])
-let s =
-  (((((((((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^
-            (({js||js})[@res.template ]))
-          [@res.template ]) ^ bar)
-         ^ (({js||js})[@res.template ]))
-       [@res.template ]) ^ baz)
-      ^ (({js||js})[@res.template ]))
-  [@res.template ])
-let s =
-  ((((((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^ (({js| |js})
-         [@res.template ]))
-       [@res.template ]) ^ bar)
-      ^ (({js||js})[@res.template ]))
-  [@res.template ])
-let s =
-  (((((((((((({js||js})[@res.template ]) ^ foo)[@res.template ]) ^
-            (({js| |js})[@res.template ]))
-          [@res.template ]) ^ bar)
-         ^ (({js| |js})[@res.template ]))
-       [@res.template ]) ^ baz)
-      ^ (({js||js})[@res.template ]))
-  [@res.template ])
+  (((((foo ^ (({js| |js})[@res.template ]))[@res.template ]) ^ bar) ^
+      (({js| |js})[@res.template ]))
+    [@res.template ]) ^ baz
 let s =
   ((((((((({js| before |js})[@res.template ]) ^ foo)[@res.template ]) ^
          (({js| |js})[@res.template ]))
@@ -101,7 +62,5 @@ let x =
 let thisIsFine = (({js|$something|js})[@res.template ])
 let thisIsAlsoFine = (({js|fine\$|js})[@res.template ])
 let isThisFine = (({js|shouldBeFine$|js})[@res.template ])
-;;(((((({js|$|js})[@res.template ]) ^ dollarAmountInt)[@res.template ]) ^
-      (({js||js})[@res.template ]))[@res.template ])
-;;(((((({js|\$|js})[@res.template ]) ^ dollarAmountInt)[@res.template ]) ^
-      (({js||js})[@res.template ]))[@res.template ])
+;;(((({js|$|js})[@res.template ]) ^ dollarAmountInt)[@res.template ])
+;;(((({js|\$|js})[@res.template ]) ^ dollarAmountInt)[@res.template ])

--- a/tests/parsing/grammar/expressions/expected/jsx.res.txt
+++ b/tests/parsing/grammar/expressions/expected/jsx.res.txt
@@ -521,8 +521,7 @@ let _ =
 let _ =
   ((div
       ~children:[(((let left = limit |. Int.toString in
-                    (((((({js||js})[@res.template ]) ^ left)[@res.template ])
-                        ^ (({js| characters left|js})[@res.template ]))
+                    ((left ^ (({js| characters left|js})[@res.template ]))
                       [@res.template ]) |. React.string))
                 [@ns.braces ])] ())
   [@JSX ])

--- a/tests/parsing/grammar/expressions/expected/parenthesized.res.txt
+++ b/tests/parsing/grammar/expressions/expected/parenthesized.res.txt
@@ -5,10 +5,7 @@ let truth = false
 let constructor = None
 let longidentConstructor = Option.None
 let txt = {js|a string|js}
-let otherTxt =
-  (((((({js|foo bar |js})[@res.template ]) ^ txt)[@res.template ]) ^
-      (({js||js})[@res.template ]))
-  [@res.template ])
+let otherTxt = (((({js|foo bar |js})[@res.template ]) ^ txt)[@res.template ])
 let ident = myIdent
 let aList = [1; 2]
 let anArray = [|1;2|]

--- a/tests/printer/expr/expected/templateLiteral.res.txt
+++ b/tests/printer/expr/expected/templateLiteral.res.txt
@@ -13,7 +13,7 @@ let s = `a \ b`
 let s = `a \\ b`
 let s = `a \\\ b`
 
-let s = `${foo}`
+let s = foo
 
 let s = `before${foo}`
 let s = `before ${foo}`
@@ -23,11 +23,11 @@ let s = `${foo}after`
 let s = `${foo} after`
 let s = `${foo}  after`
 
-let s = `${foo}${bar}`
-let s = `${foo}${bar}${baz}`
+let s = \"^"(`${foo}`, bar)
+let s = \"^"(`${foo}${bar}`, baz)
 
-let s = `${foo} ${bar}`
-let s = `${foo} ${bar} ${baz}`
+let s = \"^"(`${foo} `, bar)
+let s = \"^"(`${foo} ${bar} `, baz)
 
 let s = ` before ${foo} ${bar} after `
 let s = `before ${foo} middle ${bar} ${baz} wow `
@@ -63,7 +63,7 @@ a ++ (` x ` ++ b)
 
 let x = json`null`
 
-let x = sql`select ${column} from ${table}`
+let x = \"^"(sql`select ${column} from `, table)
 
 module X = %graphql("
   query 123456789 {


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/5521