### PR TITLE
Fix comments after function parameters disappearing

### DIFF
--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4585,11 +4585,12 @@ and printExprFunParameters ~customLayout ~inCallback ~uncurried ~hasConstraint
        attrs = [];
        lbl = Asttypes.Nolabel;
        defaultExpr = None;
-       pat = {Parsetree.ppat_desc = Ppat_any};
+       pat = {Parsetree.ppat_desc = Ppat_any; ppat_loc};
      };
   ]
     when not uncurried ->
-    if hasConstraint then Doc.text "(_)" else Doc.text "_"
+    let doc = if hasConstraint then Doc.text "(_)" else Doc.text "_" in
+    printComments doc cmtTbl ppat_loc
   (* let f = a => () *)
   | [
    ParsetreeViewer.Parameter
@@ -4613,11 +4614,13 @@ and printExprFunParameters ~customLayout ~inCallback ~uncurried ~hasConstraint
        attrs = [];
        lbl = Asttypes.Nolabel;
        defaultExpr = None;
-       pat = {ppat_desc = Ppat_construct ({txt = Longident.Lident "()"}, None)};
+       pat =
+         {ppat_desc = Ppat_construct ({txt = Longident.Lident "()"; loc}, None)};
      };
   ]
     when not uncurried ->
-    Doc.text "()"
+    let doc = Doc.text "()" in
+    printComments doc cmtTbl loc
   (* let f = (~greeting, ~from as hometown, ~x=?) => () *)
   | parameters ->
     let inCallback =

--- a/tests/printer/comments/expected/expr.res.txt
+++ b/tests/printer/comments/expected/expr.res.txt
@@ -228,6 +228,17 @@ let multiply = (
   /* c2 */ m2 /* c3 */,
 ) => ()
 
+f(() => 1)
+// c1
+f(_ => 1)
+// c2
+f(a => 1)
+// c3
+f((~a) =>
+  // c4
+  1
+)
+
 // ternary
 let x = /* c0 */ test /* c1 */ ? /* c2 */ true /* c3 */ : /* c4 */ false /* c5 */
 

--- a/tests/printer/comments/expr.res
+++ b/tests/printer/comments/expr.res
@@ -219,6 +219,19 @@ let f = (/* c0 */ ~greeting /* c1 */, /* c2 */ ~from /* c3 */ as /* c4 */ hometo
 let multiply = (/* c-2 */ type t /* c-1 */,/* c0 */ m1 /* c1 */, /* c2 */ m2 /* c3 */) => () 
 let multiply = (/* c-4 */ type t /* c-3 */,/* c0 */ m1 /* c1 */, /* c-2 */ type s /* c-1 */, /* c2 */ m2 /* c3 */) => () 
 
+f(()
+  // c1
+  => 1);
+f(_
+  // c2
+  => 1);
+f(a
+  // c3
+  => 1);
+f((~a)
+  // c4
+  => 1);
+
 // ternary
 let x = /* c0 */ test /* c1 */ ? /* c2 */ true /* c3 */ : /* c4 */ false /* c5 */
 


### PR DESCRIPTION
This PR fixes c1 and c2 in the test disappearing. (c3 and c4 print the same as they would have before, had they been in the test.)

I was looking into this some time ago and did not submit the PR as I wasn't happy with the locations where the comments are printed. But I think for now it is good enough that they don't disappear anymore, the location can be improved separately.