### PR TITLE
improve error message of parseValuePath

### DIFF
--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -616,19 +616,21 @@ let parseHashIdent ~startPos p =
 let parseValuePath p =
   let startPos = p.Parser.startPos in
   let rec aux p path =
+    let startPos = p.Parser.startPos in
+    let token = p.token in
+
+    Parser.next p;
     if p.Parser.token = Dot then (
       Parser.expect Dot p;
 
       match p.Parser.token with
       | Lident ident -> Longident.Ldot (path, ident)
-      | Uident uident ->
-        Parser.next p;
-        aux p (Ldot (path, uident))
+      | Uident uident -> aux p (Ldot (path, uident))
       | token ->
         Parser.err p (Diagnostics.unexpected token p.breadcrumbs);
         Longident.Ldot (path, "_"))
     else (
-      Parser.err p (Diagnostics.unexpected p.Parser.token p.breadcrumbs);
+      Parser.err p ~startPos ~endPos:p.prevEndPos (Diagnostics.lident token);
       path)
   in
   let ident =
@@ -637,7 +639,6 @@ let parseValuePath p =
       Parser.next p;
       Longident.Lident ident
     | Uident ident ->
-      Parser.next p;
       let res = aux p (Lident ident) in
       Parser.nextUnsafe p;
       res

--- a/tests/parsing/errors/typeDef/expected/typeDef.res.txt
+++ b/tests/parsing/errors/typeDef/expected/typeDef.res.txt
@@ -1,47 +1,159 @@
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:1:15-2:3
+  tests/parsing/errors/typeDef/typeDef.res:2:6-7
 
-  1 │ type rec stack
-  2 │   | Empty
+  1 │ // The name must start with a lowercase
+  2 │ type T1 = D1
   3 │ 
-  4 │ // name cannot contain module access paths
+  4 │ type M.T2 += D2
+
+  Did you mean `t1` instead of `T1`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:4:8-9
+
+  2 │ type T1 = D1
+  3 │ 
+  4 │ type M.T2 += D2
+  5 │ 
+  6 │ type M1.M2.T3 += D3
+
+  Did you mean `t2` instead of `T2`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:6:12-13
+
+  4 │ type M.T2 += D2
+  5 │ 
+  6 │ type M1.M2.T3 += D3
+  7 │ 
+  8 │ type T3 += Tid: Tid.t<t>
+
+  Did you mean `t3` instead of `T3`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:8:6-7
+
+   6 │ type M1.M2.T3 += D3
+   7 │ 
+   8 │ type T3 += Tid: Tid.t<t>
+   9 │ 
+  10 │ type T4<_> = D4
+
+  Did you mean `t3` instead of `T3`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:8:15
+
+   6 │ type M1.M2.T3 += D3
+   7 │ 
+   8 │ type T3 += Tid: Tid.t<t>
+   9 │ 
+  10 │ type T4<_> = D4
+
+  I'm not sure what to parse here when looking at ":".
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:10:6-7
+
+   8 │ type T3 += Tid: Tid.t<t>
+   9 │ 
+  10 │ type T4<_> = D4
+  11 │ 
+  12 │ type M1.M2.T5<_> += D5
+
+  Did you mean `t4` instead of `T4`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:12:12-13
+
+  10 │ type T4<_> = D4
+  11 │ 
+  12 │ type M1.M2.T5<_> += D5
+  13 │ 
+  14 │ type X.Y z += D6
+
+  Did you mean `t5` instead of `T5`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:14:8
+
+  12 │ type M1.M2.T5<_> += D5
+  13 │ 
+  14 │ type X.Y z += D6
+  15 │ 
+  16 │ type rec stack
+
+  Did you mean `y` instead of `Y`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:16:15-17:3
+
+  14 │ type X.Y z += D6
+  15 │ 
+  16 │ type rec stack
+  17 │   | Empty
+  18 │ 
+  19 │ // name cannot contain module access paths
 
   Did you forget a `=` here?
 
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:5:6-12
+  tests/parsing/errors/typeDef/typeDef.res:20:6-12
 
-  3 │ 
-  4 │ // name cannot contain module access paths
-  5 │ type Foo.bar = string
-  6 │ 
-  7 │ // missing type
+  18 │ 
+  19 │ // name cannot contain module access paths
+  20 │ type Foo.bar = string
+  21 │ 
+  22 │ // missing type
 
   A type declaration's name cannot contain a module access. Did you mean `bar`?
 
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:11:1-4
+  tests/parsing/errors/typeDef/typeDef.res:26:1-4
 
-   9 │ 
-  10 │ // missing type
-  11 │ type state =
-  12 │ 
+  24 │ 
+  25 │ // missing type
+  26 │ type state =
+  27 │ 
 
   Missing a type here
 
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:12:1
+  tests/parsing/errors/typeDef/typeDef.res:27:1
 
-  10 │ // missing type
-  11 │ type state =
-  12 │ 
+  25 │ // missing type
+  26 │ type state =
+  27 │ 
 
   Missing a type here
 
+type nonrec T1
+;;D1
+type nonrec T2
+;;D2
+type nonrec T3
+;;D3
+type nonrec T3
+;;Tid
+;;(Tid.t < t) > ([%rescript.exprhole ])
+type nonrec T4
+;;([%rescript.exprhole ]) > D4
+type nonrec T5
+;;([%rescript.exprhole ]) > D5
+type X.Y +=  
+  | D6 
 type stack =
   | Empty 
 type nonrec bar = string

--- a/tests/parsing/errors/typeDef/expected/typeDef.res.txt
+++ b/tests/parsing/errors/typeDef/expected/typeDef.res.txt
@@ -1,144 +1,150 @@
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:2:6-7
+  tests/parsing/errors/typeDef/typeDef.res:1:15-2:3
 
-  1 │ // The name must start with a lowercase
-  2 │ type T1 = D1
+  1 │ type rec stack
+  2 │   | Empty
   3 │ 
-  4 │ type M.T2 += D2
-
-  Did you mean `t1` instead of `T1`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:4:8-9
-
-  2 │ type T1 = D1
-  3 │ 
-  4 │ type M.T2 += D2
-  5 │ 
-  6 │ type M1.M2.T3 += D3
-
-  Did you mean `t2` instead of `T2`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:6:12-13
-
-  4 │ type M.T2 += D2
-  5 │ 
-  6 │ type M1.M2.T3 += D3
-  7 │ 
-  8 │ type T3 += Tid: Tid.t<t>
-
-  Did you mean `t3` instead of `T3`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:8:6-7
-
-   6 │ type M1.M2.T3 += D3
-   7 │ 
-   8 │ type T3 += Tid: Tid.t<t>
-   9 │ 
-  10 │ type T4<_> = D4
-
-  Did you mean `t3` instead of `T3`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:8:15
-
-   6 │ type M1.M2.T3 += D3
-   7 │ 
-   8 │ type T3 += Tid: Tid.t<t>
-   9 │ 
-  10 │ type T4<_> = D4
-
-  I'm not sure what to parse here when looking at ":".
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:10:6-7
-
-   8 │ type T3 += Tid: Tid.t<t>
-   9 │ 
-  10 │ type T4<_> = D4
-  11 │ 
-  12 │ type M1.M2.T5<_> += D5
-
-  Did you mean `t4` instead of `T4`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:12:12-13
-
-  10 │ type T4<_> = D4
-  11 │ 
-  12 │ type M1.M2.T5<_> += D5
-  13 │ 
-  14 │ type X.Y z += D6
-
-  Did you mean `t5` instead of `T5`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:14:8
-
-  12 │ type M1.M2.T5<_> += D5
-  13 │ 
-  14 │ type X.Y z += D6
-  15 │ 
-  16 │ type rec stack
-
-  Did you mean `y` instead of `Y`?
-
-
-  Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:16:15-17:3
-
-  14 │ type X.Y z += D6
-  15 │ 
-  16 │ type rec stack
-  17 │   | Empty
-  18 │ 
-  19 │ // name cannot contain module access paths
+  4 │ // name cannot contain module access paths
 
   Did you forget a `=` here?
 
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:20:6-12
+  tests/parsing/errors/typeDef/typeDef.res:5:6-12
 
-  18 │ 
-  19 │ // name cannot contain module access paths
-  20 │ type Foo.bar = string
-  21 │ 
-  22 │ // missing type
+  3 │ 
+  4 │ // name cannot contain module access paths
+  5 │ type Foo.bar = string
+  6 │ 
+  7 │ // missing type
 
   A type declaration's name cannot contain a module access. Did you mean `bar`?
 
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:26:1-4
+  tests/parsing/errors/typeDef/typeDef.res:11:1-4
 
-  24 │ 
-  25 │ // missing type
-  26 │ type state =
-  27 │ 
+   9 │ 
+  10 │ // missing type
+  11 │ type state =
+  12 │ 
+  13 │ // prevent last error
 
   Missing a type here
 
 
   Syntax error!
-  tests/parsing/errors/typeDef/typeDef.res:27:1
+  tests/parsing/errors/typeDef/typeDef.res:14:1
 
-  25 │ // missing type
-  26 │ type state =
-  27 │ 
+  12 │ 
+  13 │ // prevent last error
+  14 │ ;
+  15 │ 
+  16 │ // The name must start with a lowercase
 
-  Missing a type here
+  I'm not sure what to parse here when looking at ";".
 
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:17:6-7
+
+  15 │ 
+  16 │ // The name must start with a lowercase
+  17 │ type T1 = D1
+  18 │ 
+  19 │ type M.T2 += D2
+
+  Did you mean `t1` instead of `T1`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:19:8-9
+
+  17 │ type T1 = D1
+  18 │ 
+  19 │ type M.T2 += D2
+  20 │ 
+  21 │ type M1.M2.T3 += D3
+
+  Did you mean `t2` instead of `T2`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:21:12-13
+
+  19 │ type M.T2 += D2
+  20 │ 
+  21 │ type M1.M2.T3 += D3
+  22 │ 
+  23 │ type T3 += Tid: Tid.t<t>
+
+  Did you mean `t3` instead of `T3`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:23:6-7
+
+  21 │ type M1.M2.T3 += D3
+  22 │ 
+  23 │ type T3 += Tid: Tid.t<t>
+  24 │ 
+  25 │ type T4<_> = D4
+
+  Did you mean `t3` instead of `T3`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:23:15
+
+  21 │ type M1.M2.T3 += D3
+  22 │ 
+  23 │ type T3 += Tid: Tid.t<t>
+  24 │ 
+  25 │ type T4<_> = D4
+
+  I'm not sure what to parse here when looking at ":".
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:25:6-7
+
+  23 │ type T3 += Tid: Tid.t<t>
+  24 │ 
+  25 │ type T4<_> = D4
+  26 │ 
+  27 │ type M1.M2.T5<_> += D5
+
+  Did you mean `t4` instead of `T4`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:27:12-13
+
+  25 │ type T4<_> = D4
+  26 │ 
+  27 │ type M1.M2.T5<_> += D5
+  28 │ 
+  29 │ type X.Y z += D6
+
+  Did you mean `t5` instead of `T5`?
+
+
+  Syntax error!
+  tests/parsing/errors/typeDef/typeDef.res:29:8
+
+  27 │ type M1.M2.T5<_> += D5
+  28 │ 
+  29 │ type X.Y z += D6
+  30 │ 
+
+  Did you mean `y` instead of `Y`?
+
+type stack =
+  | Empty 
+type nonrec bar = string
+type nonrec t = [%rescript.typehole ]
+type nonrec state = [%rescript.typehole ]
 type nonrec T1
 ;;D1
 type nonrec T2
@@ -154,8 +160,3 @@ type nonrec T5
 ;;([%rescript.exprhole ]) > D5
 type X.Y +=  
   | D6 
-type stack =
-  | Empty 
-type nonrec bar = string
-type nonrec t = [%rescript.typehole ]
-type nonrec state = [%rescript.typehole ]

--- a/tests/parsing/errors/typeDef/typeDef.res
+++ b/tests/parsing/errors/typeDef/typeDef.res
@@ -1,3 +1,18 @@
+// The name must start with a lowercase
+type T1 = D1
+
+type M.T2 += D2
+
+type M1.M2.T3 += D3
+
+type T3 += Tid: Tid.t<t>
+
+type T4<_> = D4
+
+type M1.M2.T5<_> += D5
+
+type X.Y z += D6
+
 type rec stack
   | Empty
 

--- a/tests/parsing/errors/typeDef/typeDef.res
+++ b/tests/parsing/errors/typeDef/typeDef.res
@@ -1,3 +1,18 @@
+type rec stack
+  | Empty
+
+// name cannot contain module access paths
+type Foo.bar = string
+
+// missing type
+type t =
+
+// missing type
+type state =
+
+// prevent last error
+;
+
 // The name must start with a lowercase
 type T1 = D1
 
@@ -12,15 +27,3 @@ type T4<_> = D4
 type M1.M2.T5<_> += D5
 
 type X.Y z += D6
-
-type rec stack
-  | Empty
-
-// name cannot contain module access paths
-type Foo.bar = string
-
-// missing type
-type t =
-
-// missing type
-type state =


### PR DESCRIPTION
I added error handling for the case where the last of Longident is not Lident.
I think this pr can solve part of #122 
If anyone has a better opinion, please suggest. I'll work on it.