### PR TITLE
jsx: improve ref prop error message

### DIFF
--- a/cli/reactjs_jsx_ppx.ml
+++ b/cli/reactjs_jsx_ppx.ml
@@ -566,8 +566,8 @@ module V3 = struct
       | Pexp_fun (Labelled "ref", _, _, _) | Pexp_fun (Optional "ref", _, _, _)
         ->
         raiseError ~loc:expr.pexp_loc
-          "Ref cannot be passed as a normal prop. Please use `forwardRef` API \
-           instead."
+          "Ref cannot be passed as a normal prop. Either give the prop a \
+           different name or use the `forwardRef` API instead."
       | Pexp_fun (arg, default, pattern, expression)
         when isOptional arg || isLabelled arg ->
         let () =


### PR DESCRIPTION
The [current rescript-react docs on forwarding refs](https://rescript-lang.org/docs/react/latest/forwarding-refs) discourages the use of `forwardRef` in favor of explicitly passing props. It seems a bit inconsistent then for the PPX to only recommend the `forwardRef` API then, if it should be mentioned at all. FOr now I've opted for mentioning both without encouraging one over the other.

The docs themselves could also be improved in a couple of ways:

1. It doesn't mention that the forwarded prop cannot be named `ref`, which along with this error message confused me quite a bit.
2. It's not clear how to specify the type of the component in an interface file when using `forwardRef`.