### PR TITLE
More generalized props type for ref and type variables

### DIFF
--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -248,7 +248,7 @@ let stripJsNullable coreType =
    ptyp_desc =
      Ptyp_constr ({txt = Ldot (Ldot (Lident "Js", "Nullable"), "t")}, coreTypes);
   } ->
-    List.nth_opt coreTypes 0
+    List.nth_opt coreTypes 0 [@doesNotRaise]
   | _ -> Some coreType
 
 (* Make type params of the props type *)

--- a/tests/ppx/react/expected/externalWithRef.res.txt
+++ b/tests/ppx/react/expected/externalWithRef.res.txt
@@ -1,0 +1,36 @@
+@@jsxConfig({version: 3})
+
+module V3 = {
+  @obj
+  external makeProps: (
+    ~x: string,
+    ~ref: ReactDOM.Ref.currentDomRef=?,
+    ~key: string=?,
+    unit,
+  ) => {"x": string, "ref": option<ReactDOM.Ref.currentDomRef>} = ""
+  @module("componentForwardRef")
+  external make: React.componentLike<
+    {"x": string, "ref": option<ReactDOM.Ref.currentDomRef>},
+    React.element,
+  > = "component"
+}
+
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4C = {
+  type props<'x, 'ref> = {x: 'x, ref?: 'ref}
+
+  @module("componentForwardRef")
+  external make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element> =
+    "component"
+}
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module V4C = {
+  type props<'x, 'ref> = {x: 'x, ref?: 'ref}
+
+  @module("componentForwardRef")
+  external make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element> =
+    "component"
+}

--- a/tests/ppx/react/expected/externalWithTypeVariables.res.txt
+++ b/tests/ppx/react/expected/externalWithTypeVariables.res.txt
@@ -1,0 +1,32 @@
+@@jsxConfig({version: 3})
+
+module V3 = {
+  @obj
+  external makeProps: (
+    ~x: t<'a>,
+    ~children: React.element,
+    ~key: string=?,
+    unit,
+  ) => {"x": t<'a>, "children": React.element} = ""
+  @module("c")
+  external make: React.componentLike<{"x": t<'a>, "children": React.element}, React.element> =
+    "component"
+}
+
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4C = {
+  type props<'x, 'children> = {x: 'x, children: 'children}
+
+  @module("c")
+  external make: React.componentLike<props<t<'a>, React.element>, React.element> = "component"
+}
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module V4C = {
+  type props<'x, 'children> = {x: 'x, children: 'children}
+
+  @module("c")
+  external make: React.componentLike<props<t<'a>, React.element>, React.element> = "component"
+}

--- a/tests/ppx/react/expected/forwardRef.res.txt
+++ b/tests/ppx/react/expected/forwardRef.res.txt
@@ -66,14 +66,17 @@ module V3 = {
 
 module V4C = {
   module FancyInput = {
-    type props<'className, 'children> = {
-      ref?: ReactDOM.Ref.currentDomRef,
+    type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
+      ref?: 'ref,
     }
 
     @react.component
-    let make = ({?className, children, _}: props<'className, 'children>, ref) =>
+    let make = (
+      {?className, children, _}: props<'className, 'children, ReactRef.currentDomRef>,
+      ref: Js.Nullable.t<ReactRef.currentDomRef>,
+    ) =>
       ReactDOMRe.createDOMElementVariadic(
         "div",
         [
@@ -82,7 +85,7 @@ module V4C = {
             ~props=ReactDOMRe.domProps(
               ~type_="text",
               ~className?,
-              ~ref=?{Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)},
+              ~ref=?{Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)},
               (),
             ),
             [],
@@ -123,14 +126,17 @@ module V4C = {
 
 module V4A = {
   module FancyInput = {
-    type props<'className, 'children> = {
-      ref?: ReactDOM.Ref.currentDomRef,
+    type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
+      ref?: 'ref,
     }
 
     @react.component
-    let make = ({?className, children, _}: props<'className, 'children>, ref) =>
+    let make = (
+      {?className, children, _}: props<'className, 'children, ReactDOM.Ref.currentDomRef>,
+      ref,
+    ) =>
       ReactDOM.jsxs(
         "div",
         {

--- a/tests/ppx/react/expected/interfaceWithRef.res.txt
+++ b/tests/ppx/react/expected/interfaceWithRef.res.txt
@@ -1,0 +1,13 @@
+type props<'x, 'ref> = {x: 'x, ref?: 'ref}
+@react.component
+let make = (
+  {x, _}: props<string, ReactDOM.Ref.currentDomRef>,
+  ref: Js.Nullable.t<ReactDOM.Ref.currentDomRef>,
+) => {
+  let _ = ref->Js.Nullable.toOption->Belt.Option.map(ReactDOM.Ref.domRef)
+  React.string(x)
+}
+let make = React.forwardRef({
+  let \"InterfaceWithRef" = (props: props<_>, ref) => make(props, ref)
+  \"InterfaceWithRef"
+})

--- a/tests/ppx/react/expected/interfaceWithRef.resi.txt
+++ b/tests/ppx/react/expected/interfaceWithRef.resi.txt
@@ -1,0 +1,2 @@
+type props<'x, 'ref> = {x: 'x, ref?: 'ref}
+let make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element>

--- a/tests/ppx/react/externalWithRef.res
+++ b/tests/ppx/react/externalWithRef.res
@@ -1,0 +1,29 @@
+@@jsxConfig({version: 3})
+
+module V3 = {
+  @module("componentForwardRef") @react.component
+    external make: (
+      ~x: string,
+      ~ref: ReactDOM.Ref.currentDomRef=?,
+    ) => React.element = "component"
+}
+
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4C = {
+  @module("componentForwardRef") @react.component
+    external make: (
+      ~x: string,
+      ~ref: ReactDOM.Ref.currentDomRef=?,
+    ) => React.element = "component"
+}
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module V4C = {
+  @module("componentForwardRef") @react.component
+    external make: (
+      ~x: string,
+      ~ref: ReactDOM.Ref.currentDomRef=?,
+    ) => React.element = "component"
+}

--- a/tests/ppx/react/externalWithTypeVariables.res
+++ b/tests/ppx/react/externalWithTypeVariables.res
@@ -1,0 +1,29 @@
+@@jsxConfig({version: 3})
+
+module V3 = {
+  @module("c") @react.component
+    external make: (
+      ~x: t<'a>,
+      ~children: React.element,
+    ) => React.element = "component"
+}
+
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4C = {
+  @module("c") @react.component
+    external make: (
+      ~x: t<'a>,
+      ~children: React.element,
+    ) => React.element = "component"
+}
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module V4C = {
+  @module("c") @react.component
+    external make: (
+      ~x: t<'a>,
+      ~children: React.element,
+    ) => React.element = "component"
+}

--- a/tests/ppx/react/forwardRef.res
+++ b/tests/ppx/react/forwardRef.res
@@ -30,12 +30,12 @@ module V3 = {
 module V4C = {
   module FancyInput = {
     @react.component
-    let make = React.forwardRef((~className=?, ~children, ref) =>
+    let make = React.forwardRef((~className=?, ~children, ref: Js.Nullable.t<ReactRef.currentDomRef>) =>
       <div>
         <input
           type_="text"
           ?className
-          ref=?{Js.Nullable.toOption(ref)->Belt.Option.map(ReactDOM.Ref.domRef)}
+          ref=?{Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)}
         />
         children
       </div>

--- a/tests/ppx/react/interfaceWithRef.res
+++ b/tests/ppx/react/interfaceWithRef.res
@@ -1,0 +1,5 @@
+@react.component
+let make = React.forwardRef((~x: string, ref: Js.Nullable.t<ReactDOM.Ref.currentDomRef>) => {
+  let _ = ref->Js.Nullable.toOption->Belt.Option.map(ReactDOM.Ref.domRef)
+  React.string(x)
+})

--- a/tests/ppx/react/interfaceWithRef.resi
+++ b/tests/ppx/react/interfaceWithRef.resi
@@ -1,0 +1,2 @@
+@react.component
+let make: (~x: string, ~ref: ReactDOM.Ref.currentDomRef=?) => React.element


### PR DESCRIPTION
This PR has two purposes. 

#### 1. The props type with unbounded type variables
Fix the issue https://forum.rescript-lang.org/t/call-for-help-test-the-react-jsx-v4/3713/57?u=moondaddi, which is how to handle type variables for making props type.
```rescript
type t<'a>

// original
external make: (~ref: t<'a>) => React.element = "..."

// converted to
// before
type props = {ref: t<'a>} // Unbound type parameter 'a
external make: React.componentLike<props, React.element> = "..."

// after
type props<'ref> = {ref: 'ref}
external make: React.componentLike<props<t<'a>>, React.element> = "..."
}
```

#### 2. More generalized type for ref
The above issue reminds me that the constraint of type ref. The type constraint `ReactDOM.Ref.currentDomRef` is not flexible in case the JSX ppx is used with other jsx libraries, such as React Native. The type of ref would be different in each library.

Without type annotation for ref, `ReactDOM.Ref.currentDomRef` as default
```rescript
// original
@react.component React.forwardRef((~x, ref) => body)

// before
type props<'x> = {
  ref?: ReactDOM.Ref.currentDomRef,
  x: x,
}

({x, _}: props<'x>, ref) => body

// after
type props<'x, 'ref> = {
  x: 'x,
  ref?: 'ref,
}

({x, _}: props<'x, ReactRef.currentDomRef>, ref) => body
```
With type annotation
```rescript
// original
@react.component React.forwardRef((~x, ref: Js.Nullable.t<ReactNative.Ref.t>) => body)

// after
type props<'x, 'ref> = {
  x: 'x,
  ref?: 'ref,
}

({x, _}: props<'x, ReactNative.Ref.t>, ref: Js.Nullable.t<ReactNative.Ref.t>) => {
  let _ = ref->Js.Nullable.toOption->Belt.Option.map(ReactNative.Ref.domRef)
}
```
`Js.Nullable.t<'ref>` is used for the runtime safety instead of `option<'ref>`, because the value of ref could be `null`. `'ref` should be used in the props type for calling from the other application sites.