### PR TITLE
Make empty props as generic type

### DIFF
--- a/tests/ppx/react/expected/forwardRef.res.txt
+++ b/tests/ppx/react/expected/forwardRef.res.txt
@@ -99,10 +99,10 @@ module V4C = {
       \"ForwardRef$V4C$FancyInput"
     })
   }
-  type props = {}
+  type props<_> = {}
 
   @react.component
-  let make = (_: props) => {
+  let make = (_: props<_>) => {
     let input = React.useRef(Js.Nullable.null)
 
     ReactDOMRe.createDOMElementVariadic(
@@ -159,10 +159,10 @@ module V4A = {
       \"ForwardRef$V4A$FancyInput"
     })
   }
-  type props = {}
+  type props<_> = {}
 
   @react.component
-  let make = (_: props) => {
+  let make = (_: props<_>) => {
     let input = React.useRef(Js.Nullable.null)
     ReactDOM.jsx(
       "div",

--- a/tests/ppx/react/expected/interface.res.txt
+++ b/tests/ppx/react/expected/interface.res.txt
@@ -1,0 +1,19 @@
+module A = {
+  type props<'x> = {x: 'x}
+  @react.component let make = ({x, _}: props<'x>) => React.string(x)
+  let make = {
+    let \"Interface$A" = (props: props<_>) => make(props)
+    \"Interface$A"
+  }
+}
+
+module NoProps = {
+  type props<_> = {}
+
+  @react.component let make = (_: props<_>) => ReactDOM.jsx("div", {})
+  let make = {
+    let \"Interface$NoProps" = props => make(props)
+
+    \"Interface$NoProps"
+  }
+}

--- a/tests/ppx/react/expected/interface.resi.txt
+++ b/tests/ppx/react/expected/interface.resi.txt
@@ -1,2 +1,10 @@
-type props<'x> = {x: 'x}
-let make: React.componentLike<props<string>, React.element>
+module A: {
+  type props<'x> = {x: 'x}
+  let make: React.componentLike<props<string>, React.element>
+}
+
+module NoProps: {
+  type props<_> = {}
+
+  let make: React.componentLike<props<_>, React.element>
+}

--- a/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -1,0 +1,38 @@
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4CA = {
+  type props<_> = {}
+
+  @react.component let make = (_: props<_>) => ReactDOMRe.createDOMElementVariadic("div", [])
+  let make = {
+    let \"NoPropsWithKey$V4CA" = props => make(props)
+
+    \"NoPropsWithKey$V4CA"
+  }
+}
+
+module V4CB = {
+  type props<_> = {}
+
+  @module("c")
+  external make: React.componentLike<props<_>, React.element> = "component"
+}
+
+module V4C = {
+  type props<_> = {}
+
+  @react.component
+  let make = (_: props<_>) =>
+    ReactDOMRe.createElement(
+      ReasonReact.fragment,
+      [
+        React.createElement(V4CA.make, Jsx.addKeyProp(({}: V4CA.props<_>), "k")),
+        React.createElement(V4CB.make, Jsx.addKeyProp(({}: V4CB.props<_>), "k")),
+      ],
+    )
+  let make = {
+    let \"NoPropsWithKey$V4C" = props => make(props)
+
+    \"NoPropsWithKey$V4C"
+  }
+}

--- a/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -23,10 +23,10 @@ module HasChildren = {
     \"RemovedKeyProp$HasChildren"
   }
 }
-type props = {}
+type props<_> = {}
 
 @react.component
-let make = (_: props) =>
+let make = (_: props<_>) =>
   ReactDOMRe.createElement(
     ReasonReact.fragment,
     [

--- a/tests/ppx/react/interface.res
+++ b/tests/ppx/react/interface.res
@@ -1,0 +1,9 @@
+module A = {
+  @react.component
+  let make = (~x) => React.string(x)
+}
+
+module NoProps = {
+  @react.component
+  let make = () => <div />
+}

--- a/tests/ppx/react/interface.resi
+++ b/tests/ppx/react/interface.resi
@@ -1,2 +1,9 @@
-@react.component
-let make: (~x:string) => React.element
+module A: {
+  @react.component
+  let make: (~x: string) => React.element
+}
+
+module NoProps: {
+  @react.component
+  let make: unit => React.element
+}

--- a/tests/ppx/react/noPropsWithKey.res
+++ b/tests/ppx/react/noPropsWithKey.res
@@ -1,0 +1,16 @@
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4CA = {
+  @react.component
+  let make = () => <div />
+}
+
+module V4CB = {
+  @module("c") @react.component
+  external make: unit => React.element = "component"
+}
+
+module V4C = {
+  @react.component
+  let make = () => <><V4CA key="k" /> <V4CB key="k" /></>
+}


### PR DESCRIPTION
This PR fixes the inconsistency of props type depending on the count of props.
```rescript
// no props
type props = {}

// props >= 1
type props<'a, 'b, ...> = {a: 'a, b: 'b, ...}
```
Therefore, it causes the type error
```rescript
module A = {
  type props = {}
}

let c = React.createElement(A.make, Jsx.addKeyProp({}: A.props<_>, "key")) // Error
// The type A.props is not generic so expects no arguments,
// but is here applied to 1 argument(s)
```
Simply, dropping the type annotation from the first argument of `Jsx.addKeyProp` is not solving a problem. If it doesn't have the type annotation `A.props<_>`, it causes another case of type error.
```rescript
module A = {
  type props<'x> = {x: 'x}
}

let c = React.createElement(A.make, Jsx.addKeyProp({x: "x"}, "key")) // Error
// record can't find ...
```

The solution is making the props type as generic even it has no props at all.
```rescript
type props<_> = {}
let make = (_: props<_>) => { ... }
```