### PR TITLE
Fix printing doc comments before attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 #### :bug: Bug Fix
 
+- Fix pretty printer where it would print doc comments on the same line as other attributes.
 - Fix location issue in error messages with JSX V4 where the body of the component is an application https://github.com/rescript-lang/syntax/pull/633
 - Fix issue where the printer would omit attributes for `->` and `|>` https://github.com/rescript-lang/syntax/pull/629
 - Fix printing of optional fields in records https://github.com/rescript-lang/rescript-compiler/issues/5654

--- a/src/res_doc.ml
+++ b/src/res_doc.ml
@@ -133,6 +133,15 @@ let join ~sep docs =
   in
   concat (loop [] sep docs)
 
+let joinWithSep docsWithSep =
+  let rec loop acc docs =
+    match docs with
+    | [] -> List.rev acc
+    | [(x, _sep)] -> List.rev (x :: acc)
+    | (x, sep) :: xs -> loop (sep :: x :: acc) xs
+  in
+  concat (loop [] docsWithSep)
+
 let fits w stack =
   let width = ref w in
   let result = ref None in

--- a/src/res_doc.mli
+++ b/src/res_doc.mli
@@ -20,6 +20,9 @@ val customLayout : t list -> t
 val breakParent : t
 val join : sep:t -> t list -> t
 
+(* [(doc1, sep1); (doc2,sep2)] joins as doc1 sep1 doc2 *)
+val joinWithSep : (t * t) list -> t
+
 val space : t
 val comma : t
 val dot : t

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -569,7 +569,7 @@ and printStructureItem ~customLayout (si : Parsetree.structure_item) cmtTbl =
     in
     Doc.concat [printAttributes ~customLayout attrs cmtTbl; exprDoc]
   | Pstr_attribute attr ->
-    printAttribute ~customLayout ~standalone:true attr cmtTbl
+    fst (printAttribute ~customLayout ~standalone:true attr cmtTbl)
   | Pstr_extension (extension, attrs) ->
     Doc.concat
       [
@@ -940,7 +940,7 @@ and printSignatureItem ~customLayout (si : Parsetree.signature_item) cmtTbl =
   | Psig_include includeDescription ->
     printIncludeDescription ~customLayout includeDescription cmtTbl
   | Psig_attribute attr ->
-    printAttribute ~customLayout ~standalone:true attr cmtTbl
+    fst (printAttribute ~customLayout ~standalone:true attr cmtTbl)
   | Psig_extension (extension, attrs) ->
     Doc.concat
       [
@@ -5033,7 +5033,7 @@ and printAttributes ?loc ?(inline = false) ~customLayout
     Doc.concat
       [
         Doc.group
-          (Doc.join ~sep:Doc.line
+          (Doc.joinWithSep
              (List.map
                 (fun attr -> printAttribute ~customLayout attr cmtTbl)
                 attrs));
@@ -5134,20 +5134,22 @@ and printAttribute ?(standalone = false) ~customLayout
               Pstr_eval ({pexp_desc = Pexp_constant (Pconst_string (txt, _))}, _);
           };
         ] ) ->
-    Doc.concat
-      [
-        Doc.text (if standalone then "/***" else "/**");
-        Doc.text txt;
-        Doc.text "*/";
-      ]
+    ( Doc.concat
+        [
+          Doc.text (if standalone then "/***" else "/**");
+          Doc.text txt;
+          Doc.text "*/";
+        ],
+      Doc.hardLine )
   | _ ->
-    Doc.group
-      (Doc.concat
-         [
-           Doc.text (if standalone then "@@" else "@");
-           Doc.text (convertBsExternalAttribute id.txt);
-           printPayload ~customLayout payload cmtTbl;
-         ])
+    ( Doc.group
+        (Doc.concat
+           [
+             Doc.text (if standalone then "@@" else "@");
+             Doc.text (convertBsExternalAttribute id.txt);
+             printPayload ~customLayout payload cmtTbl;
+           ]),
+      Doc.line )
 
 and printModExpr ~customLayout modExpr cmtTbl =
   let doc =

--- a/tests/printer/comments/docComments.res
+++ b/tests/printer/comments/docComments.res
@@ -16,7 +16,8 @@ let q = 11
   */
 type h = int
 
-/**
-  doc comment and attributes
- */
+/* comment and attribute */
+@foo let x = 10
+
+/** doc comment and attribute */
 @foo let x = 10

--- a/tests/printer/comments/docComments.res
+++ b/tests/printer/comments/docComments.res
@@ -21,3 +21,9 @@ type h = int
 
 /** doc comment and attribute */
 @foo let x = 10
+
+/** doc comment and 3 attributes */
+@foo @bar @baz let x = 10
+
+/** doc comment and 0 attributes */
+let x = 10

--- a/tests/printer/comments/docComments.res
+++ b/tests/printer/comments/docComments.res
@@ -15,3 +15,8 @@ let q = 11
   multiline doc comment
   */
 type h = int
+
+/**
+  doc comment and attributes
+ */
+@foo let x = 10

--- a/tests/printer/comments/expected/docComments.res.txt
+++ b/tests/printer/comments/expected/docComments.res.txt
@@ -22,3 +22,12 @@ type h = int
 /** doc comment and attribute */
 @foo
 let x = 10
+
+/** doc comment and 3 attributes */
+@foo
+@bar
+@baz
+let x = 10
+
+/** doc comment and 0 attributes */
+let x = 10

--- a/tests/printer/comments/expected/docComments.res.txt
+++ b/tests/printer/comments/expected/docComments.res.txt
@@ -15,3 +15,7 @@ let q = 11
   multiline doc comment
   */
 type h = int
+
+/**
+  external with doc comment
+ */ @foo let x = 10

--- a/tests/printer/comments/expected/docComments.res.txt
+++ b/tests/printer/comments/expected/docComments.res.txt
@@ -16,6 +16,7 @@ let q = 11
   */
 type h = int
 
-/**
-  external with doc comment
- */ @foo let x = 10
+/* comment and attribute */
+@foo let x = 10
+
+/** doc comment and attribute */ @foo let x = 10

--- a/tests/printer/comments/expected/docComments.res.txt
+++ b/tests/printer/comments/expected/docComments.res.txt
@@ -19,4 +19,6 @@ type h = int
 /* comment and attribute */
 @foo let x = 10
 
-/** doc comment and attribute */ @foo let x = 10
+/** doc comment and attribute */
+@foo
+let x = 10


### PR DESCRIPTION
https://github.com/rescript-lang/syntax/issues/639