### PR TITLE
add API for parsing impl/interface from a raw string

### DIFF
--- a/src/res_driver.mli
+++ b/src/res_driver.mli
@@ -19,6 +19,18 @@ type 'diagnostics parsingEngine = {
   stringOfDiagnostics: source:string -> filename:string -> 'diagnostics -> unit;
 }
 
+val parseImplementationFromSource :
+  forPrinter:bool ->
+  displayFilename:string ->
+  source:string ->
+  (Parsetree.structure, Res_diagnostics.t list) parseResult
+
+val parseInterfaceFromSource :
+  forPrinter:bool ->
+  displayFilename:string ->
+  source:string ->
+  (Parsetree.signature, Res_diagnostics.t list) parseResult
+
 type printEngine = {
   printImplementation:
     width:int ->

--- a/src/res_driver.mli
+++ b/src/res_driver.mli
@@ -24,12 +24,14 @@ val parseImplementationFromSource :
   displayFilename:string ->
   source:string ->
   (Parsetree.structure, Res_diagnostics.t list) parseResult
+  [@@live]
 
 val parseInterfaceFromSource :
   forPrinter:bool ->
   displayFilename:string ->
   source:string ->
   (Parsetree.signature, Res_diagnostics.t list) parseResult
+  [@@live]
 
 type printEngine = {
   printImplementation:


### PR DESCRIPTION
This adds an API for parsing impl/interface from a raw string. Main use case right now is in https://github.com/rescript-lang/rescript-vscode/pull/547 where I need to parse a raw string and don't want to have to put the contents into a temp file just to parse it.

Tried adding it to `parseEngine` first but that required me to add implementations for re/ml, which felt unecessary.