### PR TITLE
Fix the usage of spreadProps without any other props

### DIFF
--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -208,20 +208,21 @@ let recordFromProps ~loc ~removeKey callArguments =
   let spreadFields =
     propsToSpread |> List.map (fun (_, expression) -> expression)
   in
-  match spreadFields with
-  | [] ->
+  match (fields, spreadFields) with
+  | [], [spreadProps] | [], spreadProps :: _ -> spreadProps
+  | _, [] ->
     {
       pexp_desc = Pexp_record (fields, None);
       pexp_loc = loc;
       pexp_attributes = [];
     }
-  | [spreadProps] ->
+  | _, [spreadProps] ->
     {
       pexp_desc = Pexp_record (fields, Some spreadProps);
       pexp_loc = loc;
       pexp_attributes = [];
     }
-  | spreadProps :: _ ->
+  | _, spreadProps :: _ ->
     {
       pexp_desc = Pexp_record (fields, Some spreadProps);
       pexp_loc = loc;

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -216,12 +216,8 @@ let recordFromProps ~loc ~removeKey callArguments =
       pexp_loc = loc;
       pexp_attributes = [];
     }
-  | _, [spreadProps] ->
-    {
-      pexp_desc = Pexp_record (fields, Some spreadProps);
-      pexp_loc = loc;
-      pexp_attributes = [];
-    }
+  | _, [spreadProps]
+  (* take the first spreadProps only *)
   | _, spreadProps :: _ ->
     {
       pexp_desc = Pexp_record (fields, Some spreadProps);

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -183,7 +183,16 @@ let recordFromProps ~loc ~removeKey callArguments =
     | (Nolabel, {pexp_loc}) :: _rest ->
       React_jsx_common.raiseError ~loc:pexp_loc
         "JSX: found non-labelled argument before the last position"
-    | prop :: rest -> removeLastPositionUnitAux rest (prop :: acc)
+    | ((Labelled txt, {pexp_loc}) as prop) :: rest
+    | ((Optional txt, {pexp_loc}) as prop) :: rest ->
+      if txt = "_spreadProps" then
+        match acc with
+        | [] -> removeLastPositionUnitAux rest (prop :: acc)
+        | _ ->
+          React_jsx_common.raiseError ~loc:pexp_loc
+            "JSX: spread props should be first in order than other props\n\
+            \            and multiple spread props are not allowed."
+      else removeLastPositionUnitAux rest (prop :: acc)
   in
   let props, propsToSpread =
     removeLastPositionUnitAux callArguments []

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -175,6 +175,7 @@ let makeModuleName fileName nestedModules fnName =
 
 (* make record from props and spread props if exists *)
 let recordFromProps ~loc ~removeKey callArguments =
+  let spreadPropsLabel = "_spreadProps" in
   let rec removeLastPositionUnitAux props acc =
     match props with
     | [] -> acc
@@ -185,13 +186,13 @@ let recordFromProps ~loc ~removeKey callArguments =
         "JSX: found non-labelled argument before the last position"
     | ((Labelled txt, {pexp_loc}) as prop) :: rest
     | ((Optional txt, {pexp_loc}) as prop) :: rest ->
-      if txt = "_spreadProps" then
+      if txt = spreadPropsLabel then
         match acc with
         | [] -> removeLastPositionUnitAux rest (prop :: acc)
         | _ ->
           React_jsx_common.raiseError ~loc:pexp_loc
-            "JSX: spread props should be first in order than other props\n\
-            \            and multiple spread props are not allowed."
+            "JSX: use {...p} {x: v} not {x: v} {...p} \n\
+            \     multiple spreads {...p} {...p} not allowed."
       else removeLastPositionUnitAux rest (prop :: acc)
   in
   let props, propsToSpread =

--- a/tests/ppx/react/expected/spreadProps.res.txt
+++ b/tests/ppx/react/expected/spreadProps.res.txt
@@ -1,3 +1,16 @@
+@@jsxConfig({version: 4, mode: "classic"})
+let c0 = React.createElement(A.make, {...p, x: "x"})
+
+// ignore second one
+let c0 = React.createElement(A.make, {...p0, x: "x"})
+
+// only spread props
+let c1 = React.createElement(A.make, p)
+
+// reversed order
+let c2 = React.createElement(A.make, {...p, x: "x"})
+
+@@jsxConfig({version: 4, mode: "automatic"})
 let c0 = React.jsx(A.make, {...p, x: "x"})
 
 // ignore second one

--- a/tests/ppx/react/expected/spreadProps.res.txt
+++ b/tests/ppx/react/expected/spreadProps.res.txt
@@ -1,8 +1,9 @@
 @@jsxConfig({version: 4, mode: "classic"})
-let c0 = React.createElement(A.make, {...p, x: "x"})
+// Error: spreadProps should be first in order than other props
+// let c0 = <A x="x" {...p} />
 
-// ignore second one
-let c0 = React.createElement(A.make, {...p0, x: "x"})
+// Error: multiple spreadProps not allowed
+// let c0 = <A x="x" {...p0} {...p1} />
 
 // only spread props
 let c1 = React.createElement(A.make, p)
@@ -11,10 +12,11 @@ let c1 = React.createElement(A.make, p)
 let c2 = React.createElement(A.make, {...p, x: "x"})
 
 @@jsxConfig({version: 4, mode: "automatic"})
-let c0 = React.jsx(A.make, {...p, x: "x"})
+// Error: spreadProps should be first in order than other props
+// let c0 = <A x="x" {...p} />
 
-// ignore second one
-let c0 = React.jsx(A.make, {...p0, x: "x"})
+// Error: multiple spreadProps not allowed
+// let c0 = <A x="x" {...p0} {...p1} />
 
 // only spread props
 let c1 = React.jsx(A.make, p)

--- a/tests/ppx/react/expected/spreadProps.res.txt
+++ b/tests/ppx/react/expected/spreadProps.res.txt
@@ -1,0 +1,10 @@
+let c0 = React.jsx(A.make, {...p, x: "x"})
+
+// ignore second one
+let c0 = React.jsx(A.make, {...p0, x: "x"})
+
+// only spread props
+let c1 = React.jsx(A.make, p)
+
+// reversed order
+let c2 = React.jsx(A.make, {...p, x: "x"})

--- a/tests/ppx/react/spreadProps.res
+++ b/tests/ppx/react/spreadProps.res
@@ -1,0 +1,10 @@
+let c0 = <A x="x" {...p} />
+
+// ignore second one
+let c0 = <A x="x" {...p0} {...p1} />
+
+// only spread props
+let c1 = <A {...p} />
+
+// reversed order
+let c2 = <A {...p} x="x" />

--- a/tests/ppx/react/spreadProps.res
+++ b/tests/ppx/react/spreadProps.res
@@ -1,3 +1,16 @@
+@@jsxConfig({version:4, mode: "classic"})
+let c0 = <A x="x" {...p} />
+
+// ignore second one
+let c0 = <A x="x" {...p0} {...p1} />
+
+// only spread props
+let c1 = <A {...p} />
+
+// reversed order
+let c2 = <A {...p} x="x" />
+
+@@jsxConfig({version:4, mode: "automatic"})
 let c0 = <A x="x" {...p} />
 
 // ignore second one

--- a/tests/ppx/react/spreadProps.res
+++ b/tests/ppx/react/spreadProps.res
@@ -1,8 +1,9 @@
 @@jsxConfig({version:4, mode: "classic"})
-let c0 = <A x="x" {...p} />
+// Error: spreadProps should be first in order than other props
+// let c0 = <A x="x" {...p} />
 
-// ignore second one
-let c0 = <A x="x" {...p0} {...p1} />
+// Error: multiple spreadProps not allowed
+// let c0 = <A x="x" {...p0} {...p1} />
 
 // only spread props
 let c1 = <A {...p} />
@@ -11,10 +12,11 @@ let c1 = <A {...p} />
 let c2 = <A {...p} x="x" />
 
 @@jsxConfig({version:4, mode: "automatic"})
-let c0 = <A x="x" {...p} />
+// Error: spreadProps should be first in order than other props
+// let c0 = <A x="x" {...p} />
 
-// ignore second one
-let c0 = <A x="x" {...p0} {...p1} />
+// Error: multiple spreadProps not allowed
+// let c0 = <A x="x" {...p0} {...p1} />
 
 // only spread props
 let c1 = <A {...p} />


### PR DESCRIPTION
```rescript
// original
let c1 = <A {...p} />

// converted to
// v4 classic
let c1 = React.createElement(A.make, p)

// v4 automatic
let c1 = React.jsx(A.make, p)
```