### PR TITLE
Remove the reason related module usage

### DIFF
--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -549,10 +549,7 @@ let transformLowercaseCall3 ~config mapper jsxExprLoc callExprLoc attrs
         let propsCall =
           Exp.apply
             (Exp.ident
-               {
-                 loc = Location.none;
-                 txt = Ldot (Lident "ReactDOMRe", "domProps");
-               })
+               {loc = Location.none; txt = Ldot (Lident "ReactDOM", "domProps")})
             (nonEmptyProps
             |> List.map (fun (label, expression) ->
                    (label, mapper.expr mapper expression)))
@@ -560,18 +557,18 @@ let transformLowercaseCall3 ~config mapper jsxExprLoc callExprLoc attrs
         [
           (* "div" *)
           (nolabel, componentNameExpr);
-          (* ReactDOMRe.domProps(~className=blabla, ~foo=bar, ()) *)
+          (* ReactDOM.domProps(~className=blabla, ~foo=bar, ()) *)
           (labelled "props", propsCall);
           (* [|moreCreateElementCallsHere|] *)
           (nolabel, childrenExpr);
         ]
     in
     Exp.apply ~loc:jsxExprLoc ~attrs
-      (* ReactDOMRe.createElement *)
+      (* ReactDOM.createElement *)
       (Exp.ident
          {
            loc = Location.none;
-           txt = Ldot (Lident "ReactDOMRe", createElementCall);
+           txt = Ldot (Lident "ReactDOM", createElementCall);
          })
       args
 
@@ -1244,7 +1241,7 @@ let transformJsxCall ~config mapper callExpression callArguments jsxExprLoc
         callArguments
     (* div(~prop1=foo, ~prop2=bar, ~children=[bla], ()) *)
     (* turn that into
-       ReactDOMRe.createElement(~props=ReactDOMRe.props(~props1=foo, ~props2=bar, ()), [|bla|]) *)
+       ReactDOM.createElement(~props=ReactDOM.props(~props1=foo, ~props2=bar, ()), [|bla|]) *)
     | {loc; txt = Lident id} ->
       transformLowercaseCall3 ~config mapper jsxExprLoc loc attrs callArguments
         id
@@ -1306,7 +1303,7 @@ let expr ~config mapper expression =
         | "automatic" ->
           Exp.ident ~loc {loc; txt = Ldot (Lident "React", "jsxFragment")}
         | "classic" | _ ->
-          Exp.ident ~loc {loc; txt = Ldot (Lident "ReasonReact", "fragment")}
+          Exp.ident ~loc {loc; txt = Ldot (Lident "React", "fragment")}
       in
       let childrenExpr = transformChildrenIfList ~mapper listItems in
       let args =
@@ -1337,15 +1334,14 @@ let expr ~config mapper expression =
       Exp.apply
         ~loc (* throw away the [@JSX] attribute and keep the others, if any *)
         ~attrs:nonJSXAttributes
-        (* ReactDOMRe.createElement *)
+        (* ReactDOM.createElement *)
         (match config.mode with
         | "automatic" ->
           if countOfChildren childrenExpr > 1 then
             Exp.ident ~loc {loc; txt = Ldot (Lident "React", "jsxs")}
           else Exp.ident ~loc {loc; txt = Ldot (Lident "React", "jsx")}
         | "classic" | _ ->
-          Exp.ident ~loc
-            {loc; txt = Ldot (Lident "ReactDOMRe", "createElement")})
+          Exp.ident ~loc {loc; txt = Ldot (Lident "ReactDOM", "createElement")})
         args)
   (* Delegate to the default mapper, a deep identity traversal *)
   | e -> default_mapper.expr mapper e

--- a/tests/ppx/react/expected/fileLevelConfig.res.txt
+++ b/tests/ppx/react/expected/fileLevelConfig.res.txt
@@ -21,7 +21,7 @@ module V4C = {
 
   @react.component
   let make = ({msg, _}: props<'msg>) => {
-    ReactDOMRe.createDOMElementVariadic("div", [{msg->React.string}])
+    ReactDOM.createDOMElementVariadic("div", [{msg->React.string}])
   }
   let make = {
     let \"FileLevelConfig$V4C" = (props: props<_>) => make(props)

--- a/tests/ppx/react/expected/forwardRef.res.txt
+++ b/tests/ppx/react/expected/forwardRef.res.txt
@@ -77,12 +77,12 @@ module V4C = {
       {?className, children, _}: props<'className, 'children, ReactRef.currentDomRef>,
       ref: Js.Nullable.t<ReactRef.currentDomRef>,
     ) =>
-      ReactDOMRe.createDOMElementVariadic(
+      ReactDOM.createDOMElementVariadic(
         "div",
         [
-          ReactDOMRe.createDOMElementVariadic(
+          ReactDOM.createDOMElementVariadic(
             "input",
-            ~props=ReactDOMRe.domProps(
+            ~props=ReactDOM.domProps(
               ~type_="text",
               ~className?,
               ~ref=?{Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)},
@@ -105,7 +105,7 @@ module V4C = {
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
 
-    ReactDOMRe.createDOMElementVariadic(
+    ReactDOM.createDOMElementVariadic(
       "div",
       [
         React.createElement(

--- a/tests/ppx/react/expected/newtype.res.txt
+++ b/tests/ppx/react/expected/newtype.res.txt
@@ -28,7 +28,7 @@ module V4C = {
 
   @react.component
   let make = ({a, b, c, _}: props<'\"type-a", array<option<[#Foo('\"type-a")]>>, 'a>) =>
-    ReactDOMRe.createDOMElementVariadic("div", [])
+    ReactDOM.createDOMElementVariadic("div", [])
   let make = {
     let \"Newtype$V4C" = (props: props<_>) => make(props)
 

--- a/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -3,7 +3,7 @@
 module V4CA = {
   type props = {}
 
-  @react.component let make = (_: props) => ReactDOMRe.createDOMElementVariadic("div", [])
+  @react.component let make = (_: props) => ReactDOM.createDOMElementVariadic("div", [])
   let make = {
     let \"NoPropsWithKey$V4CA" = props => make(props)
 
@@ -23,8 +23,8 @@ module V4C = {
 
   @react.component
   let make = (_: props) =>
-    ReactDOMRe.createElement(
-      ReasonReact.fragment,
+    ReactDOM.createElement(
+      React.fragment,
       [
         React.createElementWithKey(V4CA.make, {}, "k"),
         React.createElementWithKey(V4CB.make, {}, "k"),

--- a/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -15,8 +15,7 @@ module HasChildren = {
   type props<'children> = {children: 'children}
 
   @react.component
-  let make = ({children, _}: props<'children>) =>
-    ReactDOMRe.createElement(ReasonReact.fragment, [children])
+  let make = ({children, _}: props<'children>) => ReactDOM.createElement(React.fragment, [children])
   let make = {
     let \"RemovedKeyProp$HasChildren" = (props: props<_>) => make(props)
 
@@ -27,8 +26,8 @@ type props = {}
 
 @react.component
 let make = (_: props) =>
-  ReactDOMRe.createElement(
-    ReasonReact.fragment,
+  ReactDOM.createElement(
+    React.fragment,
     [
       React.createElementWithKey(Foo.make, {x: "x", y: "y"}, "k"),
       React.createElement(Foo.make, {x: "x", y: "y"}),

--- a/tests/ppx/react/expected/topLevel.res.txt
+++ b/tests/ppx/react/expected/topLevel.res.txt
@@ -24,7 +24,7 @@ module V4C = {
   @react.component
   let make = ({a, b, _}: props<'a, 'b>) => {
     Js.log("This function should be named 'TopLevel.react'")
-    ReactDOMRe.createDOMElementVariadic("div", [])
+    ReactDOM.createDOMElementVariadic("div", [])
   }
   let make = {
     let \"TopLevel$V4C" = (props: props<_>) => make(props)

--- a/tests/ppx/react/expected/typeConstraint.res.txt
+++ b/tests/ppx/react/expected/typeConstraint.res.txt
@@ -21,7 +21,7 @@ module V4C = {
 
   @react.component
   let make = ({a, b, _}: props<'\"type-a", '\"type-a">) =>
-    ReactDOMRe.createDOMElementVariadic("div", [])
+    ReactDOM.createDOMElementVariadic("div", [])
   let make = {
     let \"TypeConstraint$V4C" = (props: props<_>) => make(props)
 


### PR DESCRIPTION
I totally forgot this. This PR removed old reason related React module usages, e.g. `ReactDOMRe`, ReasonReact.fragment`
I'll add new bindings into `React.res` and `ReactDOM.res` in the rescript-react