### PR TITLE
fix: Avoid tail comments inside tag from being eaten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - Fix location issue in error messages with JSX V4 where the multiple props types are defined https://github.com/rescript-lang/syntax/pull/655
 - Fix location issue in make function in JSX V4 that breaks dead code elimination https://github.com/rescript-lang/syntax/pull/660
 - Fix parsing (hence pretty printing) of expressions with underscore `_` and comments.
+- Fix printing of comments inside JSX tag https://github.com/rescript-lang/syntax/pull/664
+- Fix issue where formatter erases tail comments inside JSX tag https://github.com/rescript-lang/syntax/issues/663
 
 ## ReScript 10.0
 

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -1333,12 +1333,11 @@ and walkExpression expr t comments =
       | None -> ()
       | Some childrenExpr ->
         let leading, inside, _ = partitionByLoc after childrenExpr.pexp_loc in
-        if props = [] then (
+        if props = [] then
           let afterExpr, _ =
             partitionAdjacentTrailing callExpr.pexp_loc after
           in
-          attach t.trailing callExpr.pexp_loc afterExpr;
-          walkExpression childrenExpr t inside)
+          attach t.trailing callExpr.pexp_loc afterExpr
         else
           walkList (props |> List.map (fun (_, e) -> ExprArgument e)) t leading;
         walkExpression childrenExpr t inside)

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -114,19 +114,6 @@ let partitionLeadingTrailing comments loc =
   in
   loop ([], []) comments
 
-let partitionLeading comments loc =
-  let rec loop leading comments =
-    let open Location in
-    match comments with
-    | comment :: rest ->
-      let cmtLoc = Comment.loc comment in
-      if cmtLoc.loc_end.pos_cnum <= loc.loc_start.pos_cnum then
-        loop (comment :: leading) rest
-      else loop leading rest
-    | [] -> List.rev leading
-  in
-  loop [] comments
-
 let partitionByOnSameLine loc comments =
   let rec loop (onSameLine, onOtherLine) comments =
     let open Location in

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -1326,10 +1326,17 @@ and walkExpression expr t comments =
                label = Asttypes.Labelled "children")
       in
       match maybeChildren with
+      (* There is no need to deal with this situation as the children cannot be NONE *)
       | None -> ()
       | Some (_, children) ->
         let leading, inside, _ = partitionByLoc after children.pexp_loc in
         if props = [] then
+          (* All comments inside a tag are trailing comments of the tag if there are no props
+             <A
+             // comment
+             // comment
+             />
+          *)
           let afterExpr, _ =
             partitionAdjacentTrailing callExpr.pexp_loc after
           in

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -1320,19 +1320,15 @@ and walkExpression expr t comments =
                | Asttypes.Nolabel -> false
                | _ -> true)
       in
-      let children =
-        match
-          arguments
-          |> List.find_opt (fun (label, _) ->
-                 label = Asttypes.Labelled "children")
-        with
-        | None -> None
-        | Some (_, e) -> Some e
+      let maybeChildren =
+        arguments
+        |> List.find_opt (fun (label, _) ->
+               label = Asttypes.Labelled "children")
       in
-      match children with
+      match maybeChildren with
       | None -> ()
-      | Some childrenExpr ->
-        let leading, inside, _ = partitionByLoc after childrenExpr.pexp_loc in
+      | Some (_, children) ->
+        let leading, inside, _ = partitionByLoc after children.pexp_loc in
         if props = [] then
           let afterExpr, _ =
             partitionAdjacentTrailing callExpr.pexp_loc after
@@ -1340,7 +1336,7 @@ and walkExpression expr t comments =
           attach t.trailing callExpr.pexp_loc afterExpr
         else
           walkList (props |> List.map (fun (_, e) -> ExprArgument e)) t leading;
-        walkExpression childrenExpr t inside)
+        walkExpression children t inside)
     else
       let afterExpr, rest = partitionAdjacentTrailing callExpr.pexp_loc after in
       attach t.trailing callExpr.pexp_loc afterExpr;

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4039,20 +4039,15 @@ and printJsxExpression ~customLayout lident args cmtTbl =
                     {
                       Parsetree.pexp_desc =
                         Pexp_construct ({txt = Longident.Lident "[]"}, None);
-                      pexp_loc = loc;
-                    } ->
-                  if isSelfClosing then
-                    Doc.concat
-                      [Doc.line; printComments (Doc.text "/>") cmtTbl loc]
-                  else
-                    Doc.concat [Doc.softLine; printComments Doc.nil cmtTbl loc]
-                | _ -> Doc.nil);
+                    }
+                  when isSelfClosing ->
+                  Doc.concat [Doc.line; Doc.text "/>"]
+                | _ -> Doc.concat [Doc.softLine; Doc.greaterThan]);
               ]);
          (if isSelfClosing then Doc.nil
          else
            Doc.concat
              [
-               Doc.greaterThan;
                (if hasChildren then printChildren children
                else
                  match children with

--- a/tests/conversion/reason/expected/bracedJsx.res.txt
+++ b/tests/conversion/reason/expected/bracedJsx.res.txt
@@ -111,7 +111,8 @@ let make = () => {
     <div
       className=Styles.terminal
       onClick={event => (event->ReactEvent.Mouse.target)["querySelector"]("input")["focus"]()}
-      ref={containerRef->ReactDOMRe.Ref.domRef}>
+      ref={containerRef->ReactDOMRe.Ref.domRef}
+    >
       {state.history
       ->Array.mapWithIndex((index, item) =>
         <div key={j`$index`} className=Styles.line>

--- a/tests/printer/comments/expected/jsx.res.txt
+++ b/tests/printer/comments/expected/jsx.res.txt
@@ -20,20 +20,10 @@ module Cite = {
 
 <A
   // comment1
-  foo="1"
+  value=""
   // comment2
 >
-  // comment3
-  <B
-    // comment5
-    foo="1"
-    // comment6
-  >
-    // comment7
-    <C />
-    // comment8
-  </B>
-  // comment4
+  <B /* comment3 */ />
 </A>
 
 <div>

--- a/tests/printer/comments/expected/jsx.res.txt
+++ b/tests/printer/comments/expected/jsx.res.txt
@@ -18,6 +18,24 @@ module Cite = {
   // Comment
 </A>
 
+<A
+  // comment1
+  foo="1"
+  // comment2
+>
+  // comment3
+  <B
+    // comment5
+    foo="1"
+    // comment6
+  >
+    // comment7
+    <C />
+    // comment8
+  </B>
+  // comment4
+</A>
+
 <div>
   // Must not jump inside braces
   {React.string("Hello, World!")}

--- a/tests/printer/comments/expected/jsx.res.txt
+++ b/tests/printer/comments/expected/jsx.res.txt
@@ -19,6 +19,11 @@ module Cite = {
 </A>
 
 <A
+// comment1
+// comment 2
+/>
+
+<A
   // comment1
   value=""
   // comment2

--- a/tests/printer/comments/expected/jsx.res.txt
+++ b/tests/printer/comments/expected/jsx.res.txt
@@ -9,7 +9,7 @@ module Cite = {
 
 <A
   value=""
-// Comment
+  // Comment
 />
 
 <A /* comment */ />

--- a/tests/printer/comments/jsx.res
+++ b/tests/printer/comments/jsx.res
@@ -20,6 +20,24 @@ module Cite = {
   // Comment
 </A>
 
+<A
+// comment1
+foo="1"
+// comment2
+>
+  // comment3
+  <B
+  // comment5
+  foo="1"
+  // comment6
+  >
+  // comment7
+  <C />
+  // comment8
+  </B>
+  // comment4
+</A>
+
 <div>
   // Must not jump inside braces
   {React.string("Hello, World!")}

--- a/tests/printer/comments/jsx.res
+++ b/tests/printer/comments/jsx.res
@@ -22,20 +22,10 @@ module Cite = {
 
 <A
 // comment1
-foo="1"
+value=""
 // comment2
 >
-  // comment3
-  <B
-  // comment5
-  foo="1"
-  // comment6
-  >
-  // comment7
-  <C />
-  // comment8
-  </B>
-  // comment4
+  <B /* comment3 */ />
 </A>
 
 <div>

--- a/tests/printer/comments/jsx.res
+++ b/tests/printer/comments/jsx.res
@@ -22,6 +22,11 @@ module Cite = {
 
 <A
 // comment1
+// comment 2
+/>
+
+<A
+// comment1
 value=""
 // comment2
 >

--- a/tests/printer/expr/expected/jsx.res.txt
+++ b/tests/printer/expr/expected/jsx.res.txt
@@ -104,7 +104,8 @@ let avatarSection =
           onMouseLeave={_ => setHoveringAdmin(false)}
           onClick={_e => {
             stopImpersonating(csrfToken)
-          }}>
+          }}
+        >
           <Avatar user={viewer} size={45} />
         </div>
       : React.nullElement}

--- a/tests/printer/other/expected/signaturePicker.res.txt
+++ b/tests/printer/other/expected/signaturePicker.res.txt
@@ -28,7 +28,8 @@ let make = () => {
     <div className="pr-2 font-bold text-gray-400 text-lg"> {"Signature"->string} </div>
     <select
       id="country"
-      className="transition duration-150 ease-in-out sm:text-sm sm:leading-5 border-none font-bold text-2xl text-gray-600 bg-transparent">
+      className="transition duration-150 ease-in-out sm:text-sm sm:leading-5 border-none font-bold text-2xl text-gray-600 bg-transparent"
+    >
       {options
       ->Belt.List.map(option =>
         <option key={option->TimeSignature.toString}>
@@ -47,7 +48,8 @@ let make = () => {
       fill="none"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="text-gray-400">
+      className="text-gray-400"
+    >
       <polyline points="6 9 12 15 18 9" />
     </svg>
   </label>


### PR DESCRIPTION
Closes https://github.com/rescript-lang/syntax/issues/663

```res
// The minimal reproducible example
<A
a="1"
// comment
>
  <B />
</A>
```

tweak the output of `jsx` tag
```res
// before
<A
// comment  
  a="1"
/* comment */> 
  <B />
</A>

// now
<A
  // comment -- align with a="1"
  a="1"
  /* comment */   //  align with a="1"
>       // print > on a separate line -- same as prettier
  <B />
</A>

```