### PR TITLE
JSX v4 record-based representation for lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 
 - Functions with consecutive dots now print as multiple arrow functions like in JavaScript.
 
+#### :nail_care Polish
+
+- Change the internal representation of props for the lowercase components to record. https://github.com/rescript-lang/syntax/pull/665
+
 ## ReScript 10.0
 
 - Fix printing for inline nullary functor types [#477](https://github.com/rescript-lang/syntax/pull/477)

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -463,7 +463,7 @@ let transformLowercaseCall3 ~config mapper jsxExprLoc callExprLoc attrs
       | Exact children ->
         [
           ( labelled "children",
-            Exp.apply ~attrs:optionalAttr
+            Exp.apply ~attrs:optionalAttrs
               (Exp.ident
                  {
                    txt = Ldot (Lident "ReactDOM", "someElement");

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -545,18 +545,7 @@ let transformLowercaseCall3 ~config mapper jsxExprLoc callExprLoc attrs
         ]
       | nonEmptyProps ->
         let propsRecord =
-          Exp.record
-            (nonEmptyProps
-            |> List.filter_map (fun (label, expression) ->
-                   match label with
-                   | Labelled txt | Optional txt ->
-                     Some
-                       ( {txt = Lident txt; loc = Location.none},
-                         if isOptional label then
-                           Exp.attr (mapper.expr mapper expression) optionalAttr
-                         else mapper.expr mapper expression )
-                   | Nolabel -> None))
-            None
+          recordFromProps ~loc:Location.none ~removeKey:false nonEmptyProps
         in
         [
           (* "div" *)

--- a/tests/ppx/react/expected/forwardRef.res.txt
+++ b/tests/ppx/react/expected/forwardRef.res.txt
@@ -82,12 +82,11 @@ module V4C = {
         [
           ReactDOM.createDOMElementVariadic(
             "input",
-            ~props=ReactDOM.domProps(
-              ~type_="text",
-              ~className?,
-              ~ref=?{Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef)},
-              (),
-            ),
+            ~props={
+              type_: "text",
+              ?className,
+              ref: ?Js.Nullable.toOption(ref)->Belt.Option.map(React.Ref.domRef),
+            },
             [],
           ),
           children,

--- a/tests/ppx/react/expected/lowercases.res.txt
+++ b/tests/ppx/react/expected/lowercases.res.txt
@@ -7,3 +7,9 @@ let _ = ReactDOM.createDOMElementVariadic(
   "div",
   [ReactDOM.createDOMElementVariadic("p", [{React.string(x)}])],
 )
+let _ = ReactDOM.createDOMElementVariadic("div", ~props=str, [])
+let _ = ReactDOM.createDOMElementVariadic("div", ~props={...str, x: "x"}, [])
+
+// syntax error
+// let _ = <div x="x" {...str} />
+// let _ = <div {...str} {...str} />

--- a/tests/ppx/react/expected/lowercases.res.txt
+++ b/tests/ppx/react/expected/lowercases.res.txt
@@ -1,0 +1,9 @@
+@@jsxConfig({version: 4, mode: "classic"})
+
+let _ = ReactDOM.createDOMElementVariadic("div", [])
+let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: "k"}, [])
+let _ = ReactDOM.createDOMElementVariadic("div", ~props={x: x}, [])
+let _ = ReactDOM.createDOMElementVariadic(
+  "div",
+  [ReactDOM.createDOMElementVariadic("p", [{React.string(x)}])],
+)

--- a/tests/ppx/react/lowercases.res
+++ b/tests/ppx/react/lowercases.res
@@ -4,3 +4,9 @@ let _ = <div />
 let _ = <div key="k" />
 let _ = <div x />
 let _ = <div><p>{React.string(x)}</p></div>
+let _ = <div {...str} />
+let _ = <div {...str} x="x" />
+
+// syntax error
+// let _ = <div x="x" {...str} />
+// let _ = <div {...str} {...str} />

--- a/tests/ppx/react/lowercases.res
+++ b/tests/ppx/react/lowercases.res
@@ -1,0 +1,6 @@
+@@jsxConfig({version:4, mode:"classic"})
+
+let _ = <div />
+let _ = <div key="k" />
+let _ = <div x />
+let _ = <div><p>{React.string(x)}</p></div>


### PR DESCRIPTION
This PR changes the internal representation of JSX v4 lowercase e.g. `<div />` from object to record