### PR TITLE
Emit an error when a @string or @int attribute is used in V4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix printing of comments inside JSX tag https://github.com/rescript-lang/syntax/pull/664
 - Fix issue where formatter erases tail comments inside JSX tag https://github.com/rescript-lang/syntax/issues/663
 - Fix issue where the JSX prop has type annotation of the first class module https://github.com/rescript-lang/syntax/pull/666
+- Emit an error when a `@string` or `@int` attribute is used in a V4 component https://github.com/rescript-lang/rescript-compiler/issues/5724
 
 #### :eyeglasses: Spec Compliance
 

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -708,7 +708,19 @@ let argToConcreteType types (name, _loc, type_) =
   | name when isOptional name -> (true, getLabel name, [], type_) :: types
   | _ -> types
 
+let check_string_int_attribute_iter =
+  let attribute _ ({txt; loc}, _) =
+    if txt = "string" || txt = "int" then
+      React_jsx_common.raiseError ~loc
+        "@string and @int attributes not supported. See \
+         https://github.com/rescript-lang/rescript-compiler/issues/5724"
+  in
+
+  {Ast_iterator.default_iterator with attribute}
+
 let transformStructureItem ~config mapper item =
+  check_string_int_attribute_iter.structure_item check_string_int_attribute_iter
+    item;
   match item with
   (* external *)
   | {
@@ -1158,6 +1170,8 @@ let transformStructureItem ~config mapper item =
   | _ -> [item]
 
 let transformSignatureItem ~config _mapper item =
+  check_string_int_attribute_iter.signature_item check_string_int_attribute_iter
+    item;
   match item with
   | {
       psig_loc;

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -719,8 +719,6 @@ let check_string_int_attribute_iter =
   {Ast_iterator.default_iterator with attribute}
 
 let transformStructureItem ~config mapper item =
-  check_string_int_attribute_iter.structure_item check_string_int_attribute_iter
-    item;
   match item with
   (* external *)
   | {
@@ -736,6 +734,8 @@ let transformStructureItem ~config mapper item =
         React_jsx_common.raiseErrorMultipleReactComponent ~loc:pstr_loc
       else (
         config.hasReactComponent <- true;
+        check_string_int_attribute_iter.structure_item
+          check_string_int_attribute_iter item;
         let rec getPropTypes types ({ptyp_loc; ptyp_desc} as fullType) =
           match ptyp_desc with
           | Ptyp_arrow (name, type_, ({ptyp_desc = Ptyp_arrow _} as rest))
@@ -1170,8 +1170,6 @@ let transformStructureItem ~config mapper item =
   | _ -> [item]
 
 let transformSignatureItem ~config _mapper item =
-  check_string_int_attribute_iter.signature_item check_string_int_attribute_iter
-    item;
   match item with
   | {
       psig_loc;
@@ -1184,6 +1182,8 @@ let transformSignatureItem ~config _mapper item =
       if config.React_jsx_common.hasReactComponent then
         React_jsx_common.raiseErrorMultipleReactComponent ~loc:psig_loc
       else config.hasReactComponent <- true;
+      check_string_int_attribute_iter.signature_item
+        check_string_int_attribute_iter item;
       let hasForwardRef = ref false in
       let rec getPropTypes types ({ptyp_loc; ptyp_desc} as fullType) =
         match ptyp_desc with


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/5724