### PR TITLE
Add spread element check when the last element is a spread. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - Fix printing of comments inside JSX tag https://github.com/rescript-lang/syntax/pull/664
 - Fix issue where formatter erases tail comments inside JSX tag https://github.com/rescript-lang/syntax/issues/663
 - Fix issue where the JSX prop has type annotation of the first class module https://github.com/rescript-lang/syntax/pull/666
-- Fix issue where the syntax error caused by non-last spread doesn't report when its last element is a spread https://github.com/rescript-lang/syntax/pull/673/
+- Fix issue where a spread `...x` in non-last position would not be reported as syntax error https://github.com/rescript-lang/syntax/pull/673/
 
 #### :eyeglasses: Spec Compliance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix printing of comments inside JSX tag https://github.com/rescript-lang/syntax/pull/664
 - Fix issue where formatter erases tail comments inside JSX tag https://github.com/rescript-lang/syntax/issues/663
 - Fix issue where the JSX prop has type annotation of the first class module https://github.com/rescript-lang/syntax/pull/666
+- Fix issue where the syntax error caused by non-last spread doesn't report when its last element is a spread https://github.com/rescript-lang/syntax/pull/673/
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3731,7 +3731,8 @@ and parseListExpr ~startPos p =
   Parser.expect Rbrace p;
   let loc = mkLoc startPos p.prevEndPos in
   match listExprsRev with
-  | (true, expr) :: exprs ->
+  | (true, (* spread expression *)
+     expr) :: exprs ->
     let exprs = check_all_non_spread_exp exprs in
     makeListExpression loc exprs (Some expr)
   | exprs ->

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3722,7 +3722,8 @@ and parseListExpr ~startPos p =
            if spread then
              Parser.err p (Diagnostics.message ErrorMessages.listExprSpread);
            expr)
-    |> List.rev in
+    |> List.rev
+  in
   let listExprs =
     parseCommaDelimitedReversedList p ~grammar:Grammar.ListExpr ~closing:Rbrace
       ~f:parseSpreadExprRegion
@@ -3734,8 +3735,7 @@ and parseListExpr ~startPos p =
     let exprs = check_all_non_spread_exp exprs in
     makeListExpression loc exprs (Some expr)
   | exprs ->
-    let exprs = check_all_non_spread_exp exprs 
-    in
+    let exprs = check_all_non_spread_exp exprs in
     makeListExpression loc exprs None
 
 (* Overparse ... and give a nice error message *)

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3732,7 +3732,7 @@ and parseListExpr ~startPos p =
   let loc = mkLoc startPos p.prevEndPos in
   match listExprsRev with
   | (true, (* spread expression *)
-     expr) :: exprs ->
+           expr) :: exprs ->
     let exprs = check_all_non_spread_exp exprs in
     makeListExpression loc exprs (Some expr)
   | exprs ->

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3724,13 +3724,13 @@ and parseListExpr ~startPos p =
            expr)
     |> List.rev
   in
-  let listExprs =
+  let listExprsRev =
     parseCommaDelimitedReversedList p ~grammar:Grammar.ListExpr ~closing:Rbrace
       ~f:parseSpreadExprRegion
   in
   Parser.expect Rbrace p;
   let loc = mkLoc startPos p.prevEndPos in
-  match listExprs with
+  match listExprsRev with
   | (true, expr) :: exprs ->
     let exprs = check_all_non_spread_exp exprs in
     makeListExpression loc exprs (Some expr)

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -50,7 +50,7 @@ module ErrorMessages = struct
   let listPatternSpread =
     "List pattern matches only supports one `...` spread, at the end.\n\
      Explanation: a list spread at the tail is efficient, but a spread in the \
-     middle would create new list[s]; out of performance concern, our pattern \
+     middle would create new list{s}; out of performance concern, our pattern \
      matching currently guarantees to never create new intermediate data."
 
   let recordPatternSpread =
@@ -84,8 +84,8 @@ module ErrorMessages = struct
   let listExprSpread =
     "Lists can only have one `...` spread, and at the end.\n\
      Explanation: lists are singly-linked list, where a node contains a value \
-     and points to the next node. `list[a, ...bc]` efficiently creates a new \
-     item and links `bc` as its next nodes. `[...bc, a]` would be expensive, \
+     and points to the next node. `list{a, ...bc}` efficiently creates a new \
+     item and links `bc` as its next nodes. `{...bc, a}` would be expensive, \
      as it'd need to traverse `bc` and prepend each item to `a` one by one. We \
      therefore disallow such syntax sugar.\n\
      Solution: directly use `concat`."

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -50,7 +50,7 @@ module ErrorMessages = struct
   let listPatternSpread =
     "List pattern matches only supports one `...` spread, at the end.\n\
      Explanation: a list spread at the tail is efficient, but a spread in the \
-     middle would create new list{s}; out of performance concern, our pattern \
+     middle would create new lists; out of performance concern, our pattern \
      matching currently guarantees to never create new intermediate data."
 
   let recordPatternSpread =
@@ -85,7 +85,7 @@ module ErrorMessages = struct
     "Lists can only have one `...` spread, and at the end.\n\
      Explanation: lists are singly-linked list, where a node contains a value \
      and points to the next node. `list{a, ...bc}` efficiently creates a new \
-     item and links `bc` as its next nodes. `{...bc, a}` would be expensive, \
+     item and links `bc` as its next nodes. `list{...bc, a}` would be expensive, \
      as it'd need to traverse `bc` and prepend each item to `a` one by one. We \
      therefore disallow such syntax sugar.\n\
      Solution: directly use `concat`."

--- a/tests/parsing/errors/other/expected/spread.res.txt
+++ b/tests/parsing/errors/other/expected/spread.res.txt
@@ -50,6 +50,20 @@ Solution: you need to pull out each field you want explicitly.
 
 
   Syntax error!
+  tests/parsing/errors/other/spread.res:8:1-3
+
+   6 │ 
+   7 │ let myList = list{...x, ...y}
+   8 │ let list{...x, ...y} = myList
+   9 │ 
+  10 │ type t = {...a}
+
+  Lists can only have one `...` spread, and at the end.
+Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list[a, ...bc]` efficiently creates a new item and links `bc` as its next nodes. `[...bc, a]` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
+Solution: directly use `concat`.
+
+
+  Syntax error!
   tests/parsing/errors/other/spread.res:8:13-22
 
    6 │ 

--- a/tests/parsing/errors/other/expected/spread.res.txt
+++ b/tests/parsing/errors/other/expected/spread.res.txt
@@ -59,7 +59,7 @@ Solution: you need to pull out each field you want explicitly.
   10 │ type t = {...a}
 
   Lists can only have one `...` spread, and at the end.
-Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list[a, ...bc]` efficiently creates a new item and links `bc` as its next nodes. `[...bc, a]` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
+Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list{a, ...bc}` efficiently creates a new item and links `bc` as its next nodes. `{...bc, a}` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
 Solution: directly use `concat`.
 
 
@@ -73,7 +73,7 @@ Solution: directly use `concat`.
   10 │ type t = {...a}
 
   List pattern matches only supports one `...` spread, at the end.
-Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list[s]; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
+Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list{s}; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
 
 
   Syntax error!

--- a/tests/parsing/errors/other/expected/spread.res.txt
+++ b/tests/parsing/errors/other/expected/spread.res.txt
@@ -59,7 +59,7 @@ Solution: you need to pull out each field you want explicitly.
   10 │ type t = {...a}
 
   Lists can only have one `...` spread, and at the end.
-Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list{a, ...bc}` efficiently creates a new item and links `bc` as its next nodes. `{...bc, a}` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
+Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `list{a, ...bc}` efficiently creates a new item and links `bc` as its next nodes. `list{...bc, a}` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
 Solution: directly use `concat`.
 
 
@@ -73,7 +73,7 @@ Solution: directly use `concat`.
   10 │ type t = {...a}
 
   List pattern matches only supports one `...` spread, at the end.
-Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list{s}; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
+Explanation: a list spread at the tail is efficient, but a spread in the middle would create new lists; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
 
 
   Syntax error!


### PR DESCRIPTION
The current behavior is: if the last list element expression is a [spread](https://rescript-lang.org/docs/manual/latest/array-and-list#immutable-prepend), the parser will not check the rest element whether contains a spread expression. 
This PR adds a spread element check when the last list element is a spread.
Please see #670 for more details.