### PR TITLE
Fix issue where the formatter would delete `async` in a function with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fix issue where formatter erases tail comments inside JSX tag https://github.com/rescript-lang/syntax/issues/663
 - Fix issue where the JSX prop has type annotation of the first class module https://github.com/rescript-lang/syntax/pull/666
 - Fix issue where a spread `...x` in non-last position would not be reported as syntax error https://github.com/rescript-lang/syntax/pull/673/
+- Fix issue where the formatter would delete `async` in a function with labelled arguments.
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_parsetree_viewer.ml
+++ b/src/res_parsetree_viewer.ml
@@ -167,8 +167,15 @@ let funExpr expr =
          (((Labelled _ | Optional _) as lbl), defaultExpr, pattern, returnExpr);
      pexp_attributes = attrs;
     } ->
-      let parameter = Parameter {attrs; lbl; defaultExpr; pat = pattern} in
-      collect attrsBefore (parameter :: acc) returnExpr
+      (* Normally attributes are attached to the labelled argument, e.g. (@foo ~x) => ...
+         In the case of `@res.async`, pass the attribute to the outside *)
+      let attrs_async, attrs_other =
+        attrs |> List.partition (fun ({Location.txt}, _) -> txt = "res.async")
+      in
+      let parameter =
+        Parameter {attrs = attrs_other; lbl; defaultExpr; pat = pattern}
+      in
+      collect (attrs_async @ attrsBefore) (parameter :: acc) returnExpr
     | expr -> (attrsBefore, List.rev acc, expr)
   in
   match expr with

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -81,3 +81,5 @@ let _ = await {
     let x = 1
     Js.Promise.resolve(x)
 }
+
+let f = async (~x, ~y) => x + y

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -83,3 +83,5 @@ let _ = await {
 }
 
 let f = async (~x, ~y) => x + y
+let f = async (@foo ~x, @bar ~y) => x + y
+let f = @foo async ( @bar ~x as @zz z, ~y) => x + y

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -105,3 +105,5 @@ let _ = await {
 }
 
 let f = async (~x, ~y) => x + y
+let f = async (@foo ~x, @bar ~y) => x + y
+let f = async (@bar @foo ~x as @zz z, ~y) => x + y

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -103,3 +103,5 @@ let _ = await {
   let x = 1
   Js.Promise.resolve(x)
 }
+
+let f = async (~x, ~y) => x + y


### PR DESCRIPTION
… labelled arguments.