### PR TITLE
Fix several printing issues with `async` including an infinite loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix issue where the JSX prop has type annotation of the first class module https://github.com/rescript-lang/syntax/pull/666
 - Fix issue where a spread `...x` in non-last position would not be reported as syntax error https://github.com/rescript-lang/syntax/pull/673/
 - Fix issue where the formatter would delete `async` in a function with labelled arguments.
+- Fix several printing issues with `async` including an infinite loop https://github.com/rescript-lang/syntax/pull/680
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4698,7 +4698,7 @@ and printExprFunParameters ~customLayout ~inCallback ~async ~uncurried
     let txtDoc =
       let var = printIdentLike stringLoc.txt in
       let var = if hasConstraint then addParens var else var in
-      if async then addAsync (Doc.concat [Doc.lparen; var; Doc.rparen]) else var
+      if async then addAsync var else var
     in
     printComments txtDoc cmtTbl stringLoc.loc
   (* let f = () => () *)

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -90,3 +90,5 @@ let f = async x => async y => 3
 let f = async (~x) => async y => 3
 let f = async x => async (~y) => 3
 let f = async (~x) => async (~y) => 3
+let f = x => async (~y) => 3
+let f = x => async y => 3

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -93,3 +93,6 @@ let f8 = async (~x1, ~x2) => async (~y) => 3
 let f9 = x => async (~y) => 3
 let f10 = x => async y => 3
 let f11 = (. ~x) => (. ~y) => 3
+
+let f12 = @a (@b x) => 3
+let f13 = @a @b (~x) => 3

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -82,13 +82,14 @@ let _ = await {
     Js.Promise.resolve(x)
 }
 
-let f = async (~x, ~y) => x + y
-let f = async (@foo ~x, @bar ~y) => x + y
-let f = @foo async ( @bar ~x as @zz z, ~y) => x + y
-let f = async x => x
-let f = async x => async y => 3
-let f = async (~x) => async y => 3
-let f = async x => async (~y) => 3
-let f = async (~x) => async (~y) => 3
-let f = x => async (~y) => 3
-let f = x => async y => 3
+let f1 = async (~x, ~y) => x + y
+let f2 = async (@foo ~x, @bar ~y) => x + y
+let f3 = @foo async (@bar ~x as @zz z, ~y) => x + y
+let f4 = async x => x
+let f5 = async x => async y => 3
+let f6 = async (~x1, ~x2) => async y => 3
+let f7 = async x => async (~y) => 3
+let f8 = async (~x1, ~x2) => async (~y) => 3
+let f9 = x => async (~y) => 3
+let f10 = x => async y => 3
+let f11 = (. ~x) => (. ~y) => 3

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -85,3 +85,8 @@ let _ = await {
 let f = async (~x, ~y) => x + y
 let f = async (@foo ~x, @bar ~y) => x + y
 let f = @foo async ( @bar ~x as @zz z, ~y) => x + y
+let f = async x => x
+let f = async x => async y => 3
+let f = async (~x) => async y => 3
+let f = async x => async (~y) => 3
+let f = async (~x) => async (~y) => 3

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -112,3 +112,5 @@ let f = async (x) => async (y) => 3
 let f = async (~x) => async (y) => 3
 let f = async (x, ~y) => 3
 let f = async (~x, ~y) => 3
+let f = async (x, ~y) => 3
+let f = x => async (y) => 3

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -107,3 +107,8 @@ let _ = await {
 let f = async (~x, ~y) => x + y
 let f = async (@foo ~x, @bar ~y) => x + y
 let f = async (@bar @foo ~x as @zz z, ~y) => x + y
+let f = async (x) => x
+let f = async (x) => async (y) => 3
+let f = async (~x) => async (y) => 3
+let f = async (x, ~y) => 3
+let f = async (~x, ~y) => 3

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -115,3 +115,6 @@ let f8 = async (~x1, ~x2) => async (~y) => 3
 let f9 = x => async (~y) => 3
 let f10 = x => async y => 3
 let f11 = (. ~x) => (. ~y) => 3
+
+let f12 = @a x => 3
+let f13 = (@a @b ~x) => 3

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -104,13 +104,14 @@ let _ = await {
   Js.Promise.resolve(x)
 }
 
-let f = async (~x, ~y) => x + y
-let f = async (@foo ~x, @bar ~y) => x + y
-let f = async (@bar @foo ~x as @zz z, ~y) => x + y
-let f = async (x) => x
-let f = async (x) => async (y) => 3
-let f = async (~x) => async (y) => 3
-let f = async (x, ~y) => 3
-let f = async (~x, ~y) => 3
-let f = async (x, ~y) => 3
-let f = x => async (y) => 3
+let f1 = async (~x, ~y) => x + y
+let f2 = async (@foo ~x, @bar ~y) => x + y
+let f3 = async (@bar @foo ~x as @zz z, ~y) => x + y
+let f4 = async (x) => x
+let f5 = async (x) => async (y) => 3
+let f6 = async (~x1, ~x2) => async (y) => 3
+let f7 = async (x) => async (~y) => 3
+let f8 = async (~x1, ~x2) => async (~y) => 3
+let f9 = x => async (~y) => 3
+let f10 = x => async (y) => 3
+let f11 = (. ~x) => (. ~y) => 3

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -8,7 +8,7 @@ let sequentialAwait = async () => {
 
 let f = async () => ()
 let f = async (. ()) => ()
-let f = async (f) => f()
+let f = async f => f()
 let f = async (a, b) => a + b
 let f = async (. a, b) => a + b
 
@@ -107,11 +107,11 @@ let _ = await {
 let f1 = async (~x, ~y) => x + y
 let f2 = async (@foo ~x, @bar ~y) => x + y
 let f3 = async (@bar @foo ~x as @zz z, ~y) => x + y
-let f4 = async (x) => x
-let f5 = async (x) => async (y) => 3
-let f6 = async (~x1, ~x2) => async (y) => 3
-let f7 = async (x) => async (~y) => 3
+let f4 = async x => x
+let f5 = async x => async y => 3
+let f6 = async (~x1, ~x2) => async y => 3
+let f7 = async x => async (~y) => 3
 let f8 = async (~x1, ~x2) => async (~y) => 3
 let f9 = x => async (~y) => 3
-let f10 = x => async (y) => 3
+let f10 = x => async y => 3
 let f11 = (. ~x) => (. ~y) => 3

--- a/tests/printer/expr/expected/fun.res.txt
+++ b/tests/printer/expr/expected/fun.res.txt
@@ -73,7 +73,7 @@ let f = @attr (@attrOnA a, @attrOnB b) => @attr2 (@attrOnC c, @attrOnD d) => ()
 let f = @attr (. a, b) => @attr2 (. c, d) => ()
 
 let f = (@attr ~a, @attr ~b) => ()
-let f = (. @attr ~a, . @attr ~b) => ()
+let f = (. @attr ~a) => (. @attr ~b) => ()
 
 let f = (
   thisIsAVeryLongNaaaaaaaaaaaaaaaaaaameeeeeeeeeeeee,


### PR DESCRIPTION
See https://github.com/rescript-lang/syntax/issues/679