### PR TITLE
fix: put > on a new line if the tag or last prop has trailing comments

### DIFF
--- a/tests/printer/comments/expected/jsx.res.txt
+++ b/tests/printer/comments/expected/jsx.res.txt
@@ -33,7 +33,8 @@ module Cite = {
 
 <A
   value=""
-  /* comment */>
+  /* comment */
+>
   <B />
 </A>
 
@@ -44,7 +45,8 @@ module Cite = {
 </A>
 
 <A
-/* comment */>
+/* comment */
+>
   <B />
 </A>
 


### PR DESCRIPTION
Closes https://github.com/rescript-lang/syntax/issues/675 again...

See https://github.com/rescript-lang/syntax/issues/675#issuecomment-1279882340