### PR TITLE
Fix issue where printing nested pipe discards await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fix issue where the formatter would delete `async` in a function with labelled arguments.
 - Fix several printing issues with `async` including an infinite loop https://github.com/rescript-lang/syntax/pull/680
 - Fix issue where certain JSX expressions would be formatted differenctly in compiler 10.1.0-rc.1 https://github.com/rescript-lang/syntax/issues/675
+- Fix issue where printing nested pipe discards await https://github.com/rescript-lang/syntax/issues/687
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3604,17 +3604,23 @@ and printBinaryExpression ~customLayout (expr : Parsetree.expression) cmtTbl =
               | [] -> doc
               | _ -> addParens doc
             in
+            let isAwait =
+              ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes
+            in
             let doc =
               Doc.concat
                 [
+                  (if isAwait then Doc.text "await " else Doc.nil);
                   leftPrinted;
                   printBinaryOperator ~inlineRhs:false operator;
                   rightPrinted;
                 ]
             in
             let doc =
-              if (not isLhs) && Parens.rhsBinaryExprOperand operator expr then
-                Doc.concat [Doc.lparen; doc; Doc.rparen]
+              if
+                isAwait
+                || ((not isLhs) && Parens.rhsBinaryExprOperand operator expr)
+              then Doc.concat [Doc.lparen; doc; Doc.rparen]
               else doc
             in
             printComments doc cmtTbl expr.pexp_loc

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3608,19 +3608,28 @@ and printBinaryExpression ~customLayout (expr : Parsetree.expression) cmtTbl =
               ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes
             in
             let doc =
-              Doc.concat
-                [
-                  (if isAwait then Doc.text "await " else Doc.nil);
-                  leftPrinted;
-                  printBinaryOperator ~inlineRhs:false operator;
-                  rightPrinted;
-                ]
+              if isAwait then
+                Doc.concat
+                  [
+                    Doc.text "await ";
+                    Doc.lparen;
+                    leftPrinted;
+                    printBinaryOperator ~inlineRhs:false operator;
+                    rightPrinted;
+                    Doc.rparen;
+                  ]
+              else
+                Doc.concat
+                  [
+                    leftPrinted;
+                    printBinaryOperator ~inlineRhs:false operator;
+                    rightPrinted;
+                  ]
             in
+
             let doc =
-              if
-                isAwait
-                || ((not isLhs) && Parens.rhsBinaryExprOperand operator expr)
-              then Doc.concat [Doc.lparen; doc; Doc.rparen]
+              if (not isLhs) && Parens.rhsBinaryExprOperand operator expr then
+                Doc.concat [Doc.lparen; doc; Doc.rparen]
               else doc
             in
             printComments doc cmtTbl expr.pexp_loc

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -96,3 +96,6 @@ let f11 = (. ~x) => (. ~y) => 3
 
 let f12 = @a (@b x) => 3
 let f13 = @a @b (~x) => 3
+
+let aw = (await (server->start))->foo
+let aw = (@foo (server->start))->foo

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -118,3 +118,6 @@ let f11 = (. ~x) => (. ~y) => 3
 
 let f12 = @a x => 3
 let f13 = (@a @b ~x) => 3
+
+let aw = (await server->start)->foo
+let aw = @foo (server->start)->foo

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -119,5 +119,5 @@ let f11 = (. ~x) => (. ~y) => 3
 let f12 = @a x => 3
 let f13 = (@a @b ~x) => 3
 
-let aw = (await server->start)->foo
+let aw = await (server->start)->foo
 let aw = @foo (server->start)->foo


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/687

Certain nested patterns for binary operators are printed "manually" so the special printing for await is not used.