### PR TITLE
JSX v4 shared props

### DIFF
--- a/cli/react_jsx_common.ml
+++ b/cli/react_jsx_common.ml
@@ -16,6 +16,25 @@ let hasAttr (loc, _) = loc.txt = "react.component"
 let hasAttrOnBinding {pvb_attributes} =
   List.find_opt hasAttr pvb_attributes <> None
 
+let coreTypeOfAttrs attributes =
+  List.find_map
+    (fun ({txt}, payload) ->
+      match (txt, payload) with
+      | "react.component", PTyp coreType -> Some coreType
+      | _ -> None)
+    attributes
+
+let typVarsOfCoreType {ptyp_desc} =
+  match ptyp_desc with
+  | Ptyp_constr (_, coreTypes) ->
+    List.filter
+      (fun {ptyp_desc} ->
+        match ptyp_desc with
+        | Ptyp_var _ -> true
+        | _ -> false)
+      coreTypes
+  | _ -> []
+
 let raiseError ~loc msg = Location.raise_errorf ~loc msg
 
 let raiseErrorMultipleReactComponent ~loc =

--- a/tests/ppx/react/expected/sharedProps.res.txt
+++ b/tests/ppx/react/expected/sharedProps.res.txt
@@ -1,0 +1,71 @@
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4C1 = {
+  type props = sharedProps<string>
+
+  @react.component(: sharedProps<string>) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4C1" = props => make(props)
+
+    \"SharedProps$V4C1"
+  }
+}
+
+module V4C2 = {
+  type props<'a> = sharedProps<'a>
+
+  @react.component(: sharedProps<'a>) let make = ({x, y, _}: props<'a>) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4C2" = (props: props<_>) => make(props)
+
+    \"SharedProps$V4C2"
+  }
+}
+
+module V4C3 = {
+  type props = sharedProps<string>
+
+  external make: React.componentLike<props, React.element> = "default"
+}
+
+module V4C4 = {
+  type props<'a> = sharedProps<'a>
+
+  external make: React.componentLike<props<'a>, React.element> = "default"
+}
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module V4A1 = {
+  type props = sharedProps<string>
+
+  @react.component(: sharedProps<string>) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4A1" = props => make(props)
+
+    \"SharedProps$V4A1"
+  }
+}
+
+module V4A2 = {
+  type props<'a> = sharedProps<'a>
+
+  @react.component(: sharedProps<'a>) let make = ({x, y, _}: props<'a>) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4A2" = (props: props<_>) => make(props)
+
+    \"SharedProps$V4A2"
+  }
+}
+
+module V4A3 = {
+  type props = sharedProps<string>
+
+  external make: React.componentLike<props, React.element> = "default"
+}
+
+module V4A4 = {
+  type props<'a> = sharedProps<'a>
+
+  external make: React.componentLike<props<'a>, React.element> = "default"
+}

--- a/tests/ppx/react/expected/sharedProps.res.txt
+++ b/tests/ppx/react/expected/sharedProps.res.txt
@@ -23,15 +23,50 @@ module V4C2 = {
 }
 
 module V4C3 = {
+  type props<'a> = sharedProps<string, 'a>
+
+  @react.component(: sharedProps<string, 'a>)
+  let make = ({x, y, _}: props<'a>) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4C3" = (props: props<_>) => make(props)
+
+    \"SharedProps$V4C3"
+  }
+}
+
+module V4C4 = {
+  type props = sharedProps
+
+  @react.component(: sharedProps) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4C4" = props => make(props)
+
+    \"SharedProps$V4C4"
+  }
+}
+
+module V4C5 = {
   type props = sharedProps<string>
 
   external make: React.componentLike<props, React.element> = "default"
 }
 
-module V4C4 = {
+module V4C6 = {
   type props<'a> = sharedProps<'a>
 
   external make: React.componentLike<props<'a>, React.element> = "default"
+}
+
+module V4C7 = {
+  type props<'a> = sharedProps<string, 'a>
+
+  external make: React.componentLike<props<'a>, React.element> = "default"
+}
+
+module V4C8 = {
+  type props = sharedProps
+
+  external make: React.componentLike<props, React.element> = "default"
 }
 
 @@jsxConfig({version: 4, mode: "automatic"})
@@ -59,13 +94,48 @@ module V4A2 = {
 }
 
 module V4A3 = {
+  type props<'a> = sharedProps<string, 'a>
+
+  @react.component(: sharedProps<string, 'a>)
+  let make = ({x, y, _}: props<'a>) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4A3" = (props: props<_>) => make(props)
+
+    \"SharedProps$V4A3"
+  }
+}
+
+module V4A4 = {
+  type props = sharedProps
+
+  @react.component(: sharedProps) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = {
+    let \"SharedProps$V4A4" = props => make(props)
+
+    \"SharedProps$V4A4"
+  }
+}
+
+module V4A5 = {
   type props = sharedProps<string>
 
   external make: React.componentLike<props, React.element> = "default"
 }
 
-module V4A4 = {
+module V4A6 = {
   type props<'a> = sharedProps<'a>
 
   external make: React.componentLike<props<'a>, React.element> = "default"
+}
+
+module V4A7 = {
+  type props<'a> = sharedProps<string, 'a>
+
+  external make: React.componentLike<props<'a>, React.element> = "default"
+}
+
+module V4A8 = {
+  type props = sharedProps
+
+  external make: React.componentLike<props, React.element> = "default"
 }

--- a/tests/ppx/react/expected/sharedProps.resi.txt
+++ b/tests/ppx/react/expected/sharedProps.resi.txt
@@ -1,0 +1,27 @@
+@@jsxConfig({version: 4, mode: "classic"})
+
+module V4C1: {
+  type props = sharedProps<string>
+
+  let make: React.componentLike<props, React.element>
+}
+
+module V4C2: {
+  type props<'a> = sharedProps<'a>
+
+  let make: React.componentLike<props<'a>, React.element>
+}
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module V4A1: {
+  type props = sharedProps<string>
+
+  let make: React.componentLike<props, React.element>
+}
+
+module V4A2: {
+  type props<'a> = sharedProps<'a>
+
+  let make: React.componentLike<props<'a>, React.element>
+}

--- a/tests/ppx/react/expected/sharedProps.resi.txt
+++ b/tests/ppx/react/expected/sharedProps.resi.txt
@@ -12,6 +12,18 @@ module V4C2: {
   let make: React.componentLike<props<'a>, React.element>
 }
 
+module V4C3: {
+  type props<'a> = sharedProps<string, 'a>
+
+  let make: React.componentLike<props<'a>, React.element>
+}
+
+module V4C4: {
+  type props = sharedProps
+
+  let make: React.componentLike<props, React.element>
+}
+
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A1: {
@@ -24,4 +36,16 @@ module V4A2: {
   type props<'a> = sharedProps<'a>
 
   let make: React.componentLike<props<'a>, React.element>
+}
+
+module V4A3: {
+  type props<'a> = sharedProps<string, 'a>
+
+  let make: React.componentLike<props<'a>, React.element>
+}
+
+module V4A4: {
+  type props = sharedProps
+
+  let make: React.componentLike<props, React.element>
 }

--- a/tests/ppx/react/sharedProps.res
+++ b/tests/ppx/react/sharedProps.res
@@ -1,0 +1,43 @@
+@@jsxConfig({version:4, mode: "classic"})
+
+module V4C1 = {
+  @react.component(:sharedProps<string>)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4C2 = {
+  @react.component(:sharedProps<'a>)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4C3 = {
+  @react.component(:sharedProps<string>)
+  external make: (~x: string, ~y: 'a) => React.element = "default"
+}
+
+module V4C4 = {
+  @react.component(:sharedProps<'a>)
+  external make: (~x: string, ~y: 'a) => React.element = "default"
+}
+
+@@jsxConfig({version:4, mode: "automatic"})
+
+module V4A1 = {
+  @react.component(:sharedProps<string>)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4A2 = {
+  @react.component(:sharedProps<'a>)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4A3 = {
+  @react.component(:sharedProps<string>)
+  external make: (~x: string, ~y: 'a) => React.element = "default"
+}
+
+module V4A4 = {
+  @react.component(:sharedProps<'a>)
+  external make: (~x: string, ~y: 'a) => React.element = "default"
+}

--- a/tests/ppx/react/sharedProps.res
+++ b/tests/ppx/react/sharedProps.res
@@ -11,13 +11,33 @@ module V4C2 = {
 }
 
 module V4C3 = {
+  @react.component(:sharedProps<string, 'a>)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4C4 = {
+  @react.component(:sharedProps)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4C5 = {
   @react.component(:sharedProps<string>)
   external make: (~x: string, ~y: 'a) => React.element = "default"
 }
 
-module V4C4 = {
+module V4C6 = {
   @react.component(:sharedProps<'a>)
   external make: (~x: string, ~y: 'a) => React.element = "default"
+}
+
+module V4C7 = {
+  @react.component(:sharedProps<string, 'a>)
+  external make: (~x: string, ~y: string) => React.element = "default"
+}
+
+module V4C8 = {
+  @react.component(:sharedProps)
+  external make: (~x: string, ~y: string) => React.element = "default"
 }
 
 @@jsxConfig({version:4, mode: "automatic"})
@@ -33,11 +53,31 @@ module V4A2 = {
 }
 
 module V4A3 = {
+  @react.component(:sharedProps<string, 'a>)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4A4 = {
+  @react.component(:sharedProps)
+  let make = (~x, ~y) => React.string(x ++ y)
+}
+
+module V4A5 = {
   @react.component(:sharedProps<string>)
   external make: (~x: string, ~y: 'a) => React.element = "default"
 }
 
-module V4A4 = {
+module V4A6 = {
   @react.component(:sharedProps<'a>)
   external make: (~x: string, ~y: 'a) => React.element = "default"
+}
+
+module V4A7 = {
+  @react.component(:sharedProps<string, 'a>)
+  external make: (~x: string, ~y: string) => React.element = "default"
+}
+
+module V4A8 = {
+  @react.component(:sharedProps)
+  external make: (~x: string, ~y: string) => React.element = "default"
 }

--- a/tests/ppx/react/sharedProps.resi
+++ b/tests/ppx/react/sharedProps.resi
@@ -1,0 +1,23 @@
+@@jsxConfig({version:4, mode: "classic"})
+
+module V4C1: {
+  @react.component(:sharedProps<string>)
+  let make: (~x: string) => React.element
+}
+
+module V4C2: {
+  @react.component(:sharedProps<'a>)
+  let make: (~x: string) => React.element
+}
+
+@@jsxConfig({version:4, mode: "automatic"})
+
+module V4A1: {
+  @react.component(:sharedProps<string>)
+  let make: (~x: string) => React.element
+}
+
+module V4A2: {
+  @react.component(:sharedProps<'a>)
+  let make: (~x: string) => React.element
+}

--- a/tests/ppx/react/sharedProps.resi
+++ b/tests/ppx/react/sharedProps.resi
@@ -10,6 +10,16 @@ module V4C2: {
   let make: (~x: string) => React.element
 }
 
+module V4C3: {
+  @react.component(:sharedProps<string, 'a>)
+  let make: (~x: string) => React.element
+}
+
+module V4C4 : {
+  @react.component(:sharedProps)
+  let make: (~x: string) => React.element
+}
+
 @@jsxConfig({version:4, mode: "automatic"})
 
 module V4A1: {
@@ -19,5 +29,15 @@ module V4A1: {
 
 module V4A2: {
   @react.component(:sharedProps<'a>)
+  let make: (~x: string) => React.element
+}
+
+module V4A3: {
+  @react.component(:sharedProps<string, 'a>)
+  let make: (~x: string) => React.element
+}
+
+module V4A4: {
+  @react.component(:sharedProps)
   let make: (~x: string) => React.element
 }


### PR DESCRIPTION
This PR adds a new feature for JSX v4 which is using shared props type as an argument of `@react.component`
https://github.com/rescript-lang/syntax/issues/695

Example
```rescript
type sharedProps<'a> = {x: 'a, y: string}

// original
module V4C2 = {
  @react.component(:sharedProps<'a>) // <- here
  let make = (~x, ~y) => React.string(x ++ y)
}

// converted to
module V4C2 = {
  type props<'a> = sharedProps<'a>

  @react.component(: sharedProps<'a>) let make = ({x, y, _}: props<'a>) => React.string(x ++ y)
  let make = {
    let \"SharedProps$V4C2" = (props: props<_>) => make(props)

    \"SharedProps$V4C2"
  }
}
```