### PR TITLE
Use JsxPPXReactSupport module from compiler

### DIFF
--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -428,7 +428,7 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
         (Exp.ident
            {
              loc = Location.none;
-             txt = Ldot (Lident "ReactPPX4Support", "createElementWithKey");
+             txt = Ldot (Lident "JsxPPXReactSupport", "createElementWithKey");
            })
         [key; (nolabel, makeID); (nolabel, props)]
     | None, [] ->
@@ -442,7 +442,7 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
            {
              loc = Location.none;
              txt =
-               Ldot (Lident "ReactPPX4Support", "createElementVariadicWithKey");
+               Ldot (Lident "JsxPPXReactSupport", "createElementVariadicWithKey");
            })
         [key; (nolabel, makeID); (nolabel, props); (nolabel, children)]
     | Some children, [] ->

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -401,6 +401,9 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
   let makeID =
     Exp.ident ~loc:callExprLoc {txt = ident ~suffix:"make"; loc = callExprLoc}
   in
+  let makeReactCreateElement name =
+    Exp.ident {txt = Ldot (Lident "React", name); loc = Location.none}
+  in
   match config.mode with
   (* The new jsx transform *)
   | "automatic" ->
@@ -428,9 +431,14 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
         (Exp.ident
            {
              loc = Location.none;
-             txt = Ldot (Lident "React", "createElementWithKey");
+             txt = Ldot (Lident "ReactPPX4Support", "createElementWithKey");
            })
-        [key; (nolabel, makeID); (nolabel, props)]
+        [
+          key;
+          (nolabel, makeReactCreateElement "createElement");
+          (nolabel, makeID);
+          (nolabel, props);
+        ]
     | None, [] ->
       Exp.apply ~attrs
         (Exp.ident
@@ -441,9 +449,16 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
         (Exp.ident
            {
              loc = Location.none;
-             txt = Ldot (Lident "React", "createElementVariadicWithKey");
+             txt =
+               Ldot (Lident "ReactPPX4Support", "createElementVariadicWithKey");
            })
-        [key; (nolabel, makeID); (nolabel, props); (nolabel, children)]
+        [
+          key;
+          (nolabel, makeReactCreateElement "createElementVariadicWithKey");
+          (nolabel, makeID);
+          (nolabel, props);
+          (nolabel, children);
+        ]
     | Some children, [] ->
       Exp.apply ~attrs
         (Exp.ident

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -401,9 +401,6 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
   let makeID =
     Exp.ident ~loc:callExprLoc {txt = ident ~suffix:"make"; loc = callExprLoc}
   in
-  let makeReactCreateElement name =
-    Exp.ident {txt = Ldot (Lident "React", name); loc = Location.none}
-  in
   match config.mode with
   (* The new jsx transform *)
   | "automatic" ->
@@ -433,12 +430,7 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
              loc = Location.none;
              txt = Ldot (Lident "ReactPPX4Support", "createElementWithKey");
            })
-        [
-          key;
-          (nolabel, makeReactCreateElement "createElement");
-          (nolabel, makeID);
-          (nolabel, props);
-        ]
+        [key; (nolabel, makeID); (nolabel, props)]
     | None, [] ->
       Exp.apply ~attrs
         (Exp.ident
@@ -452,13 +444,7 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
              txt =
                Ldot (Lident "ReactPPX4Support", "createElementVariadicWithKey");
            })
-        [
-          key;
-          (nolabel, makeReactCreateElement "createElementVariadic");
-          (nolabel, makeID);
-          (nolabel, props);
-          (nolabel, children);
-        ]
+        [key; (nolabel, makeID); (nolabel, props); (nolabel, children)]
     | Some children, [] ->
       Exp.apply ~attrs
         (Exp.ident

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -454,7 +454,7 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
            })
         [
           key;
-          (nolabel, makeReactCreateElement "createElementVariadicWithKey");
+          (nolabel, makeReactCreateElement "createElementVariadic");
           (nolabel, makeID);
           (nolabel, props);
           (nolabel, children);

--- a/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -26,8 +26,8 @@ module V4C = {
     ReactDOM.createElement(
       React.fragment,
       [
-        React.createElementWithKey(~key="k", V4CA.make, {}),
-        React.createElementWithKey(~key="k", V4CB.make, {}),
+        ReactPPX4Support.createElementWithKey(~key="k", React.createElement, V4CA.make, {}),
+        ReactPPX4Support.createElementWithKey(~key="k", React.createElement, V4CB.make, {}),
       ],
     )
   let make = {

--- a/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -26,8 +26,8 @@ module V4C = {
     ReactDOM.createElement(
       React.fragment,
       [
-        ReactPPX4Support.createElementWithKey(~key="k", V4CA.make, {}),
-        ReactPPX4Support.createElementWithKey(~key="k", V4CB.make, {}),
+        JsxPPXReactSupport.createElementWithKey(~key="k", V4CA.make, {}),
+        JsxPPXReactSupport.createElementWithKey(~key="k", V4CB.make, {}),
       ],
     )
   let make = {

--- a/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -26,8 +26,8 @@ module V4C = {
     ReactDOM.createElement(
       React.fragment,
       [
-        ReactPPX4Support.createElementWithKey(~key="k", React.createElement, V4CA.make, {}),
-        ReactPPX4Support.createElementWithKey(~key="k", React.createElement, V4CB.make, {}),
+        ReactPPX4Support.createElementWithKey(~key="k", V4CA.make, {}),
+        ReactPPX4Support.createElementWithKey(~key="k", V4CB.make, {}),
       ],
     )
   let make = {

--- a/tests/ppx/react/expected/optionalKeyType.res.txt
+++ b/tests/ppx/react/expected/optionalKeyType.res.txt
@@ -30,9 +30,9 @@ let _ = ReactDOMRe.createDOMElementVariadic(
 
 @@jsxConfig({version: 4, mode: "classic"})
 
-let _ = ReactPPX4Support.createElementWithKey(~key="k", React.createElement, C.make, {})
-let _ = ReactPPX4Support.createElementWithKey(~key=?Some("k"), React.createElement, C.make, {})
-let _ = ReactPPX4Support.createElementWithKey(~key?, React.createElement, C.make, {})
+let _ = ReactPPX4Support.createElementWithKey(~key="k", C.make, {})
+let _ = ReactPPX4Support.createElementWithKey(~key=?Some("k"), C.make, {})
+let _ = ReactPPX4Support.createElementWithKey(~key?, C.make, {})
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: "k"}, [])
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: ?Some("k")}, [])
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: ?key}, [])

--- a/tests/ppx/react/expected/optionalKeyType.res.txt
+++ b/tests/ppx/react/expected/optionalKeyType.res.txt
@@ -30,9 +30,9 @@ let _ = ReactDOMRe.createDOMElementVariadic(
 
 @@jsxConfig({version: 4, mode: "classic"})
 
-let _ = ReactPPX4Support.createElementWithKey(~key="k", C.make, {})
-let _ = ReactPPX4Support.createElementWithKey(~key=?Some("k"), C.make, {})
-let _ = ReactPPX4Support.createElementWithKey(~key?, C.make, {})
+let _ = JsxPPXReactSupport.createElementWithKey(~key="k", C.make, {})
+let _ = JsxPPXReactSupport.createElementWithKey(~key=?Some("k"), C.make, {})
+let _ = JsxPPXReactSupport.createElementWithKey(~key?, C.make, {})
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: "k"}, [])
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: ?Some("k")}, [])
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: ?key}, [])

--- a/tests/ppx/react/expected/optionalKeyType.res.txt
+++ b/tests/ppx/react/expected/optionalKeyType.res.txt
@@ -30,9 +30,9 @@ let _ = ReactDOMRe.createDOMElementVariadic(
 
 @@jsxConfig({version: 4, mode: "classic"})
 
-let _ = React.createElementWithKey(~key="k", C.make, {})
-let _ = React.createElementWithKey(~key=?Some("k"), C.make, {})
-let _ = React.createElementWithKey(~key?, C.make, {})
+let _ = ReactPPX4Support.createElementWithKey(~key="k", React.createElement, C.make, {})
+let _ = ReactPPX4Support.createElementWithKey(~key=?Some("k"), React.createElement, C.make, {})
+let _ = ReactPPX4Support.createElementWithKey(~key?, React.createElement, C.make, {})
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: "k"}, [])
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: ?Some("k")}, [])
 let _ = ReactDOM.createDOMElementVariadic("div", ~props={key: ?key}, [])

--- a/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -34,10 +34,16 @@ let make = (_: props) =>
   ReactDOM.createElement(
     React.fragment,
     [
-      React.createElementWithKey(~key="k", Foo.make, {x: "x", y: "y"}),
-      React.createElement(Foo.make, {x: "x", y: "y"}),
-      React.createElementWithKey(
+      ReactPPX4Support.createElementWithKey(
         ~key="k",
+        React.createElement,
+        Foo.make,
+        {x: "x", y: "y"},
+      ),
+      React.createElement(Foo.make, {x: "x", y: "y"}),
+      ReactPPX4Support.createElementWithKey(
+        ~key="k",
+        React.createElement,
         HasChildren.make,
         {
           children: React.createElement(Foo.make, {x: "x", y: "y"}),

--- a/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -34,9 +34,9 @@ let make = (_: props) =>
   ReactDOM.createElement(
     React.fragment,
     [
-      ReactPPX4Support.createElementWithKey(~key="k", Foo.make, {x: "x", y: "y"}),
+      JsxPPXReactSupport.createElementWithKey(~key="k", Foo.make, {x: "x", y: "y"}),
       React.createElement(Foo.make, {x: "x", y: "y"}),
-      ReactPPX4Support.createElementWithKey(
+      JsxPPXReactSupport.createElementWithKey(
         ~key="k",
         HasChildren.make,
         {

--- a/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -34,16 +34,10 @@ let make = (_: props) =>
   ReactDOM.createElement(
     React.fragment,
     [
-      ReactPPX4Support.createElementWithKey(
-        ~key="k",
-        React.createElement,
-        Foo.make,
-        {x: "x", y: "y"},
-      ),
+      ReactPPX4Support.createElementWithKey(~key="k", Foo.make, {x: "x", y: "y"}),
       React.createElement(Foo.make, {x: "x", y: "y"}),
       ReactPPX4Support.createElementWithKey(
         ~key="k",
-        React.createElement,
         HasChildren.make,
         {
           children: React.createElement(Foo.make, {x: "x", y: "y"}),


### PR DESCRIPTION
This PR makes JSX v4 calls `ReactPPX4Support` helper functions from the compiler.
https://github.com/rescript-lang/rescript-react/issues/76