### PR TITLE
Treat await as an almost-unary operator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Fix issue where the JSX key type is not an optional string https://github.com/rescript-lang/syntax/pull/693
 - Fix issue where the JSX fragment without children build error https://github.com/rescript-lang/syntax/pull/704
 - Fix issue where async as an id cannot be used with application and labelled arguments https://github.com/rescript-lang/syntax/issues/707
-
+- Treat await as almost-unary operator weaker than pipe so `await foo->bar` means `await (foo->bar)` https://github.com/rescript-lang/syntax/pull/711
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_core.ml
+++ b/src/res_core.ml
@@ -3134,7 +3134,8 @@ and parseAwaitExpression p =
   let awaitLoc = mkLoc p.Parser.startPos p.endPos in
   let awaitAttr = makeAwaitAttr awaitLoc in
   Parser.expect Await p;
-  let expr = parseUnaryExpr p in
+  let tokenPrec = Token.precedence MinusGreater in
+  let expr = parseBinaryExpr ~context:OrdinaryExpr p tokenPrec in
   {
     expr with
     pexp_attributes = awaitAttr :: expr.pexp_attributes;

--- a/src/res_parens.ml
+++ b/src/res_parens.ml
@@ -175,7 +175,7 @@ let flattenOperandRhs parentOperator rhs =
   | _ when ParsetreeViewer.isTernaryExpr rhs -> true
   | _ -> false
 
-let lazyOrAssertOrAwaitExprRhs expr =
+let lazyOrAssertOrAwaitExprRhs ?(inAwait = false) expr =
   let optBraces, _ = ParsetreeViewer.processBracesAttr expr in
   match optBraces with
   | Some ({Location.loc = bracesLoc}, _) -> Braced bracesLoc
@@ -186,6 +186,16 @@ let lazyOrAssertOrAwaitExprRhs expr =
            | _ :: _ -> true
            | [] -> false ->
       Parenthesized
+    | {
+     pexp_desc =
+       Pexp_apply ({pexp_desc = Pexp_ident {txt = Longident.Lident operator}}, _);
+    }
+      when inAwait
+           && ParsetreeViewer.isBinaryExpression expr
+           && ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes
+           && ParsetreeViewer.operatorPrecedence operator
+              >= ParsetreeViewer.operatorPrecedence "|." ->
+      Nothing
     | expr when ParsetreeViewer.isBinaryExpression expr -> Parenthesized
     | {
      pexp_desc =
@@ -202,7 +212,9 @@ let lazyOrAssertOrAwaitExprRhs expr =
        | Pexp_try _ | Pexp_while _ | Pexp_for _ | Pexp_ifthenelse _ );
     } ->
       Parenthesized
-    | _ when ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
+    | _
+      when (not inAwait)
+           && ParsetreeViewer.hasAwaitAttribute expr.pexp_attributes ->
       Parenthesized
     | _ -> Nothing)
 

--- a/src/res_parens.mli
+++ b/src/res_parens.mli
@@ -10,6 +10,7 @@ val subBinaryExprOperand : string -> string -> bool
 val rhsBinaryExprOperand : string -> Parsetree.expression -> bool
 val flattenOperandRhs : string -> Parsetree.expression -> bool
 
+val binaryOperatorInsideAwaitNeedsParens : string -> bool
 val lazyOrAssertOrAwaitExprRhs : ?inAwait:bool -> Parsetree.expression -> kind
 
 val fieldExpr : Parsetree.expression -> kind

--- a/src/res_parens.mli
+++ b/src/res_parens.mli
@@ -10,7 +10,7 @@ val subBinaryExprOperand : string -> string -> bool
 val rhsBinaryExprOperand : string -> Parsetree.expression -> bool
 val flattenOperandRhs : string -> Parsetree.expression -> bool
 
-val lazyOrAssertOrAwaitExprRhs : Parsetree.expression -> kind
+val lazyOrAssertOrAwaitExprRhs : ?inAwait:bool -> Parsetree.expression -> kind
 
 val fieldExpr : Parsetree.expression -> kind
 

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3612,15 +3612,18 @@ and printBinaryExpression ~customLayout (expr : Parsetree.expression) cmtTbl =
             in
             let doc =
               if isAwait then
+                let parens =
+                  Res_parens.binaryOperatorInsideAwaitNeedsParens operator
+                in
                 Doc.concat
                   [
                     Doc.lparen;
                     Doc.text "await ";
-                    Doc.lparen;
+                    (if parens then Doc.lparen else Doc.nil);
                     leftPrinted;
                     printBinaryOperator ~inlineRhs:false operator;
                     rightPrinted;
-                    Doc.rparen;
+                    (if parens then Doc.rparen else Doc.nil);
                     Doc.rparen;
                   ]
               else

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -3330,13 +3330,13 @@ and printExpression ~customLayout (e : Parsetree.expression) cmtTbl =
     if ParsetreeViewer.hasAwaitAttribute e.pexp_attributes then
       let rhs =
         match
-          Parens.lazyOrAssertOrAwaitExprRhs
+          Parens.lazyOrAssertOrAwaitExprRhs ~inAwait:true
             {
               e with
               pexp_attributes =
                 List.filter
                   (function
-                    | {Location.txt = "res.await" | "ns.braces"}, _ -> false
+                    | {Location.txt = "ns.braces"}, _ -> false
                     | _ -> true)
                   e.pexp_attributes;
             }
@@ -3614,11 +3614,13 @@ and printBinaryExpression ~customLayout (expr : Parsetree.expression) cmtTbl =
               if isAwait then
                 Doc.concat
                   [
+                    Doc.lparen;
                     Doc.text "await ";
                     Doc.lparen;
                     leftPrinted;
                     printBinaryOperator ~inlineRhs:false operator;
                     rightPrinted;
+                    Doc.rparen;
                     Doc.rparen;
                   ]
               else

--- a/tests/parsing/grammar/expressions/async.res
+++ b/tests/parsing/grammar/expressions/async.res
@@ -30,3 +30,8 @@ let f = isPositive ? (async (a, b) : int => a + b) : async (c, d) : int => c - d
 
 let foo = async(~a=34)
 let bar = async(~a)=>a+1
+
+let ex1 = await 3 + await 4
+let ex2 = await 3 ** await 4
+let ex3 = await foo->bar(~arg)
+let ex4 = await foo.bar.baz

--- a/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -28,3 +28,7 @@ let f =
   [@ns.ternary ])
 let foo = async ~a:((34)[@ns.namedArgLoc ])
 let bar = ((fun ~a:((a)[@ns.namedArgLoc ]) -> a + 1)[@res.async ])
+let ex1 = ((3)[@res.await ]) + ((4)[@res.await ])
+let ex2 = ((3)[@res.await ]) ** ((4)[@res.await ])
+let ex3 = ((foo |. (bar ~arg:((arg)[@ns.namedArgLoc ])))[@res.await ])
+let ex4 = (((foo.bar).baz)[@res.await ])

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -99,6 +99,7 @@ let f13 = @a @b (~x) => 3
 
 let aw = (await (server->start))->foo
 let aw = (@foo (server->start))->foo
+let aw = (await (3**4))->foo
 
 let foo = async(~a=34)
 let bar = async(~a)=>a+1

--- a/tests/printer/expr/asyncAwait.res
+++ b/tests/printer/expr/asyncAwait.res
@@ -102,3 +102,13 @@ let aw = (@foo (server->start))->foo
 
 let foo = async(~a=34)
 let bar = async(~a)=>a+1
+
+let a1 = await 3 + await 4
+let a2 = await 3 ** await 4
+let a3 = await foo->bar(~arg)
+let a4 = await foo.bar.baz
+
+let b1  = await (3+4)
+let b2 = await (3**4)
+let b3 = await (foo->bar(~arg))
+let b4 = await (foo.bar.baz)

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -121,6 +121,7 @@ let f13 = (@a @b ~x) => 3
 
 let aw = (await server->start)->foo
 let aw = @foo (server->start)->foo
+let aw = (await (3 ** 4))->foo
 
 let foo = async(~a=34)
 let bar = async (~a) => a + 1

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -30,14 +30,14 @@ user.data = await fetch()
 
 <Navbar promise={await gc()}> {await weirdReactSuspenseApi} </Navbar>
 
-let inBinaryExpression = (await x)->Js.Promise.resolve + 1
-let inBinaryExpression = (await x)->Js.Promise.resolve + (await y)->Js.Promise.resolve
+let inBinaryExpression = await x->Js.Promise.resolve + 1
+let inBinaryExpression = await x->Js.Promise.resolve + await y->Js.Promise.resolve
 
 let withCallback = async (. ()) => {
-  async (. x) => await (x->Js.promise.resolve) + 1
+  async (. x) => await x->Js.promise.resolve + 1
 }
 
-let () = (await fetch(url))->(await resolve)
+let () = await (await fetch(url))->(await resolve)
 
 let _ = await (1 + 1)
 let _ = (await 1) + 1
@@ -119,8 +119,18 @@ let f11 = (. ~x) => (. ~y) => 3
 let f12 = @a x => 3
 let f13 = (@a @b ~x) => 3
 
-let aw = await (server->start)->foo
+let aw = (await (server->start))->foo
 let aw = @foo (server->start)->foo
 
 let foo = async(~a=34)
 let bar = async (~a) => a + 1
+
+let a1 = (await 3) + (await 4)
+let a2 = (await 3) ** (await 4)
+let a3 = await foo->bar(~arg)
+let a4 = await foo.bar.baz
+
+let b1 = await (3 + 4)
+let b2 = await (3 ** 4)
+let b3 = await foo->bar(~arg)
+let b4 = await foo.bar.baz

--- a/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/tests/printer/expr/expected/asyncAwait.res.txt
@@ -119,7 +119,7 @@ let f11 = (. ~x) => (. ~y) => 3
 let f12 = @a x => 3
 let f13 = (@a @b ~x) => 3
 
-let aw = (await (server->start))->foo
+let aw = (await server->start)->foo
 let aw = @foo (server->start)->foo
 
 let foo = async(~a=34)


### PR DESCRIPTION
Making pipe behave just like application seems pretty unlikely. First `->` has deep binary operator behavior, including associating to the left on `a->b->c`, and mixes in specific ways with other operators. Instead application lives on a different level entirely with no issues of how to treat specially the right-hand-side which is enclosed in parens (and lives in a radically different place in the call stack of the parser).

The await operator is essentially a unary operator. After all it takes one argument. It is also treated as such in JS. Some expected behaviours are that `await 2 + await 3` just like `-2 + -3` is expected to mean `(await 2) + (await 3)`. Or: `await getName() ++ await getSurname()`.

The issue raised by people who have tried `await` is in combination with pipe: the desired outcome is that `await a->b` is parsed as `await (a->b)`. However notice that `- a->b` is parsed as `(-a)->b`, so that's a difference.

So on one side, one would like to have `await` behave like other unary operators. On the other side one wouldn't.

As a compromise, this PR treats `await` as an almost-unary operator. In the sense that it binds more tightly than any "real" binary operator such as `+` and `**`, but not `->` and `.`.

This introduces some lack of uniformity, and requires special-casing parts of parsing and printing.