### PR TITLE
Specialize the printing of the rhs of a record field assignment for o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 - Change the internal representation of props for the lowercase components to record. https://github.com/rescript-lang/syntax/pull/665
 - Change the payload of Pconst_char for type safety. https://github.com/rescript-lang/rescript-compiler/pull/5759
+- Specialize the printing of the rhs of a record field assignment for optional values `{x: ? e}` https://github.com/rescript-lang/syntax/issues/714
 
 ## ReScript 10.0
 

--- a/src/res_parens.ml
+++ b/src/res_parens.ml
@@ -15,6 +15,16 @@ let expr expr =
     | {pexp_desc = Pexp_constraint _} -> Parenthesized
     | _ -> Nothing)
 
+let exprRecordRowRhs e =
+  let kind = expr e in
+  match kind with
+  | Nothing when Res_parsetree_viewer.hasOptionalAttribute e.pexp_attributes
+    -> (
+    match e.pexp_desc with
+    | Pexp_ifthenelse _ -> Parenthesized
+    | _ -> kind)
+  | _ -> kind
+
 let callExpr expr =
   let optBraces, _ = ParsetreeViewer.processBracesAttr expr in
   match optBraces with

--- a/src/res_parens.ml
+++ b/src/res_parens.ml
@@ -21,7 +21,7 @@ let exprRecordRowRhs e =
   | Nothing when Res_parsetree_viewer.hasOptionalAttribute e.pexp_attributes
     -> (
     match e.pexp_desc with
-    | Pexp_ifthenelse _ -> Parenthesized
+    | Pexp_ifthenelse _ | Pexp_fun _ -> Parenthesized
     | _ -> kind)
   | _ -> kind
 

--- a/src/res_parens.mli
+++ b/src/res_parens.mli
@@ -35,3 +35,5 @@ val includeModExpr : Parsetree.module_expr -> bool
 val arrowReturnTypExpr : Parsetree.core_type -> bool
 
 val patternRecordRowRhs : Parsetree.pattern -> bool
+
+val exprRecordRowRhs : Parsetree.expression -> kind

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -5188,7 +5188,7 @@ and printExpressionRecordRow ~customLayout (lbl, expr) cmtTbl punningAllowed =
             Doc.text ": ";
             printOptionalLabel expr.pexp_attributes;
             (let doc = printExpressionWithComments ~customLayout expr cmtTbl in
-             match Parens.expr expr with
+             match Parens.exprRecordRowRhs expr with
              | Parens.Parenthesized -> addParens doc
              | Braced braces -> printBraces doc expr braces
              | Nothing -> doc);

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -96,3 +96,8 @@ let _ = switch z {
 type tt = {x: int, y?: string}
 
 type ttt = {x: int, y?: string}
+
+let optParen = {x: 3, y: ?(someBool ? Some("") : None)}
+let optParen = {x: 3, y: ?(3 + 4)}
+let optParen = {x: 3, y: ?foo(bar)}
+let optParen = {x: 3, y: ?foo->bar}

--- a/tests/printer/expr/expected/record.res.txt
+++ b/tests/printer/expr/expected/record.res.txt
@@ -101,3 +101,4 @@ let optParen = {x: 3, y: ?(someBool ? Some("") : None)}
 let optParen = {x: 3, y: ?(3 + 4)}
 let optParen = {x: 3, y: ?foo(bar)}
 let optParen = {x: 3, y: ?foo->bar}
+let optParen = {x: 3, y: ?(() => 3)}

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -91,3 +91,4 @@ let optParen = { x:3, y: ? (someBool ? Some("") : None) }
 let optParen = { x:3, y: ? (3+4) }
 let optParen = { x:3, y: ? (foo(bar)) }
 let optParen = { x:3, y: ? (foo->bar) }
+let optParen = { x:3, y: ? (()=>3) }

--- a/tests/printer/expr/record.res
+++ b/tests/printer/expr/record.res
@@ -86,3 +86,8 @@ let _ = switch z {
 type tt = {x:int, @ns.optional y: string}
 
 type ttt = {x:int, y?: string}
+
+let optParen = { x:3, y: ? (someBool ? Some("") : None) }
+let optParen = { x:3, y: ? (3+4) }
+let optParen = { x:3, y: ? (foo(bar)) }
+let optParen = { x:3, y: ? (foo->bar) }


### PR DESCRIPTION
…ptional values

Fixes https://github.com/rescript-lang/syntax/issues/714

Put parens around if-then-else.