### PR TITLE
Fix jsx mode being ignored when set via @@jsxConfig

### DIFF
--- a/cli/reactjs_jsx_ppx.ml
+++ b/cli/reactjs_jsx_ppx.ml
@@ -28,7 +28,8 @@ let getJsxConfigByKey ~key ~type_ recordFields =
           Some value
         | ( String,
             {txt = Lident k},
-            {pexp_desc = Pexp_constant (Pconst_string (value, None))} )
+            (* accept both normal strings and "js" strings *)
+            {pexp_desc = Pexp_constant (Pconst_string (value, _))} )
           when k = key ->
           Some value
         | _ -> None)


### PR DESCRIPTION
When setting the JSX mode in-source via

```rescript
@@jsxConfig({version: 4, mode: "automatic"})
````

it is currently ignored. This is because the AST is

```
Pexp_constant PConst_string ("automatic",Some "js")
```

but the code was matching for

```ocaml
{pexp_desc = Pexp_constant (Pconst_string (value, None))}
```