### PR TITLE
JSX4: Fix missing attributes from props type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Fix dropping attributes from props in make function in JSX V4 https://github.com/rescript-lang/syntax/pull/723
 - Fix an issue where error messages related to duplicate props were displayed without a loc and were unclear https://github.com/rescript-lang/syntax/pull/728
 - Fix issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/syntax/pull/730
+- Fix issue where uncurried functions were incorrectly converting the type of a prop given as a default value to curried https://github.com/rescript-lang/syntax/pull/731
 
 #### :eyeglasses: Spec Compliance
 

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -719,19 +719,10 @@ let argToType ~newtypes ~(typeConstraints : core_type option) types
   in
   match (type_, name, default) with
   | Some type_, name, _ when isOptional name ->
-    ( true,
-      getLabel name,
-      attrs,
-      loc,
-      {type_ with ptyp_attributes = optionalAttr :: type_.ptyp_attributes} )
-    :: types
+    (true, getLabel name, attrs, loc, type_) :: types
   | Some type_, name, _ -> (false, getLabel name, attrs, loc, type_) :: types
   | None, name, _ when isOptional name ->
-    ( true,
-      getLabel name,
-      attrs,
-      loc,
-      Typ.var ~loc ~attrs:optionalAttrs (safeTypeFromValue name) )
+    (true, getLabel name, attrs, loc, Typ.var ~loc (safeTypeFromValue name))
     :: types
   | None, name, _ when isLabelled name ->
     (false, getLabel name, attrs, loc, Typ.var ~loc (safeTypeFromValue name))

--- a/cli/reactjs_jsx_v4.ml
+++ b/cli/reactjs_jsx_v4.ml
@@ -723,7 +723,7 @@ let argToType ~newtypes ~(typeConstraints : core_type option) types
       getLabel name,
       attrs,
       loc,
-      {type_ with ptyp_attributes = optionalAttrs} )
+      {type_ with ptyp_attributes = optionalAttr :: type_.ptyp_attributes} )
     :: types
   | Some type_, name, _ -> (false, getLabel name, attrs, loc, type_) :: types
   | None, name, _ when isOptional name ->

--- a/tests/ppx/react/expected/uncurriedProps.res.txt
+++ b/tests/ppx/react/expected/uncurriedProps.res.txt
@@ -2,7 +2,7 @@
 type props<'a> = {a?: 'a}
 
 @react.component
-let make = ({?a, _}: props<(unit => unit)>) => {
+let make = ({?a, _}: props<(. unit) => unit>) => {
   let a = switch a {
   | Some(a) => a
   | None => (. ()) => ()
@@ -30,7 +30,7 @@ module Foo = {
   type props<'callback> = {callback?: 'callback}
 
   @react.component
-  let make = ({?callback, _}: props<(string, bool, bool) => unit>) => {
+  let make = ({?callback, _}: props<(. string, bool, bool) => unit>) => {
     let callback = switch callback {
     | Some(callback) => callback
     | None => (. _, _, _) => ()

--- a/tests/ppx/react/expected/uncurriedProps.res.txt
+++ b/tests/ppx/react/expected/uncurriedProps.res.txt
@@ -1,0 +1,59 @@
+@@jsxConfig({version: 4})
+type props<'a> = {a?: 'a}
+
+@react.component
+let make = ({?a, _}: props<(unit => unit)>) => {
+  let a = switch a {
+  | Some(a) => a
+  | None => (. ()) => ()
+  }
+
+  React.null
+}
+let make = {
+  let \"UncurriedProps" = (props: props<_>) => make(props)
+
+  \"UncurriedProps"
+}
+
+let func = (~callback: (. string, bool, bool) => unit=(. _, _, _) => (), ()) => {
+  let _ = callback
+}
+
+func(~callback=(. str, a, b) => {
+  let _ = str
+  let _ = a
+  let _ = b
+}, ())
+
+module Foo = {
+  type props<'callback> = {callback?: 'callback}
+
+  @react.component
+  let make = ({?callback, _}: props<(string, bool, bool) => unit>) => {
+    let callback = switch callback {
+    | Some(callback) => callback
+    | None => (. _, _, _) => ()
+    }
+
+    {
+      React.null
+    }
+  }
+  let make = {
+    let \"UncurriedProps$Foo" = (props: props<_>) => make(props)
+
+    \"UncurriedProps$Foo"
+  }
+}
+
+module Bar = {
+  type props = {}
+
+  @react.component let make = (_: props) => React.jsx(Foo.make, {callback: (. _, _, _) => ()})
+  let make = {
+    let \"UncurriedProps$Bar" = props => make(props)
+
+    \"UncurriedProps$Bar"
+  }
+}

--- a/tests/ppx/react/uncurriedProps.res
+++ b/tests/ppx/react/uncurriedProps.res
@@ -1,0 +1,26 @@
+@@jsxConfig({ version: 4 })
+
+@react.component
+let make = (~a: (. unit) => unit=(. ) => ()) => React.null
+
+let func = (~callback: (. string, bool, bool) => unit=(. _, _, _) => (), ()) => {
+  let _ = callback
+}
+
+func(~callback=(. str, a, b) => {
+  let _ = str
+  let _ = a
+  let _ = b
+}, ())
+
+module Foo = {
+  @react.component
+  let make = (~callback: (. string, bool, bool) => unit=(. _, _, _) => ()) => {
+    React.null
+  }
+}
+
+module Bar = {
+  @react.component
+  let make = () => <Foo callback={(. _, _, _) => ()} />
+}


### PR DESCRIPTION
This PR fixes the issue https://github.com/rescript-lang/rescript-compiler/issues/5969
This change keeps the attributes of the argument in the make function and removes the unnecessary optional attr from the core_type as the type parameter. So it prevents that uncurried functions were incorrectly converting the type of a prop given as a default value.
The current master in the compiler transforms the uncurried type annotation correctly without this change, but this change can fix the issue in v10.1.2