### PR TITLE
Fix formatting of `switch` expressions that contain braced cases inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Fix support for recursive components in JSX V4 https://github.com/rescript-lang/syntax/pull/733
 - Fix issue with overlapping labelled argument with default value https://github.com/rescript-lang/syntax/pull/734
 - Fix issue with using alias and default value together https://github.com/rescript-lang/syntax/pull/734
+- Fix formatting of `switch` expressions that contain braced `cases` inside https://github.com/rescript-lang/syntax/pull/735
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_comments_table.ml
+++ b/src/res_comments_table.ml
@@ -345,7 +345,13 @@ let getLoc node =
   let open Parsetree in
   match node with
   | Case case ->
-    {case.pc_lhs.ppat_loc with loc_end = case.pc_rhs.pexp_loc.loc_end}
+    {
+      case.pc_lhs.ppat_loc with
+      loc_end =
+        (match ParsetreeViewer.processBracesAttr case.pc_rhs with
+        | None, _ -> case.pc_rhs.pexp_loc.loc_end
+        | Some ({loc}, _), _ -> loc.Location.loc_end);
+    }
   | CoreType ct -> ct.ptyp_loc
   | ExprArgument expr -> (
     match expr.Parsetree.pexp_attributes with

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4743,7 +4743,10 @@ and printCases ~customLayout (cases : Parsetree.case list) cmtTbl =
                ~getLoc:(fun n ->
                  {
                    n.Parsetree.pc_lhs.ppat_loc with
-                   loc_end = n.pc_rhs.pexp_loc.loc_end;
+                   loc_end =
+                     (match ParsetreeViewer.processBracesAttr n.pc_rhs with
+                     | None, _ -> n.pc_rhs.pexp_loc.loc_end
+                     | Some ({loc}, _), _ -> loc.Location.loc_end);
                  })
                ~print:(printCase ~customLayout) ~nodes:cases cmtTbl;
            ];

--- a/tests/printer/expr/expected/switch.res.txt
+++ b/tests/printer/expr/expected/switch.res.txt
@@ -55,3 +55,11 @@ switch route {
     <div> {React.string("Second B div")} </div>
   </>
 }
+
+switch x {
+| A => {
+    let _ = 1
+    let _ = 2
+  } // no blank line below
+| B => ()
+}

--- a/tests/printer/expr/switch.res
+++ b/tests/printer/expr/switch.res
@@ -49,3 +49,11 @@ switch route {
     <div> {React.string("Second B div")} </div>
   </>
 }
+
+switch x {
+| A => {
+    let _ = 1
+    let _ = 2
+  } // no blank line below
+| B => ()
+}


### PR DESCRIPTION
Backporting https://github.com/rescript-lang/rescript-compiler/pull/6015