### PR TITLE
Fix formatting of props spread for multiline JSX expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Fix issue with overlapping labelled argument with default value https://github.com/rescript-lang/syntax/pull/734
 - Fix issue with using alias and default value together https://github.com/rescript-lang/syntax/pull/734
 - Fix formatting of `switch` expressions that contain braced `cases` inside https://github.com/rescript-lang/syntax/pull/735
+- Fix formatting of props spread for multiline JSX expression https://github.com/rescript-lang/syntax/pull/736
 
 #### :eyeglasses: Spec Compliance
 

--- a/src/res_printer.ml
+++ b/src/res_printer.ml
@@ -4337,7 +4337,7 @@ and printJsxProp ~customLayout arg cmtTbl =
     | Optional _lbl -> Doc.concat [Doc.question; printIdentLike ident])
   | Asttypes.Labelled "_spreadProps", expr ->
     let doc = printExpressionWithComments ~customLayout expr cmtTbl in
-    Doc.concat [Doc.lbrace; Doc.dotdotdot; Doc.softLine; doc; Doc.rbrace]
+    Doc.concat [Doc.lbrace; Doc.dotdotdot; doc; Doc.rbrace]
   | lbl, expr ->
     let argLoc, expr =
       match expr.pexp_attributes with

--- a/tests/printer/expr/expected/jsx.res.txt
+++ b/tests/printer/expr/expected/jsx.res.txt
@@ -410,3 +410,10 @@ let v =
   </A>
 
 let x = <A x="y" {...str} />
+
+// https://github.com/rescript-lang/rescript-compiler/issues/6002
+let x = props =>
+  <A
+    {...props}
+    className="inline-block px-6 py-2.5 bg-blue-600 text-white font-medium text-xs leading-tight"
+  />

--- a/tests/printer/expr/jsx.res
+++ b/tests/printer/expr/jsx.res
@@ -403,3 +403,10 @@ let v =
   </A>
 
 let x = <A x="y" {...str} />
+
+// https://github.com/rescript-lang/rescript-compiler/issues/6002
+let x = props =>
+  <A
+    {...props}
+    className="inline-block px-6 py-2.5 bg-blue-600 text-white font-medium text-xs leading-tight"
+  />


### PR DESCRIPTION
Backporting https://github.com/rescript-lang/rescript-compiler/pull/6006